### PR TITLE
Fix dashboard key flow and analytics events

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import { OnboardingView } from "./components/OnboardingView";
 import { DashboardKeyModal } from "./components/DashboardKeyModal";
 import { BrandLogo } from "./components/BrandLogo";
 import { Icon, Spinner } from "./components/Icon";
-import { brandName } from "./constants";
+import { brandName, dashboardUrl } from "./constants";
 import { getPreviewMode, getPreviewTab } from "./preview";
 import type { AppTab, Conversation } from "./types";
 import { resolveTheme, type Theme } from "./theme";
@@ -128,7 +128,7 @@ export function App() {
           limit_bytes: 5_000_000_000,
           percent_used: 24,
           state: "active",
-          dashboard_url: "https://app.nextbrowser.com/dashboard",
+          dashboard_url: dashboardUrl,
         },
         showOnboarding: false,
         ...(tabParam && PREVIEW_TABS.has(tabParam) ? { tab: tabParam as AppTab } : {}),

--- a/src/components/DashboardKeyModal.tsx
+++ b/src/components/DashboardKeyModal.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { useStore } from "../store";
 import { Icon, Spinner } from "./Icon";
+import { trackEvent } from "../lib/analytics";
+import { dashboardUrl } from "../constants";
 
 export function DashboardKeyModal() {
   const open = useStore((s) => s.dashboardKeyPromptOpen);
@@ -45,9 +47,10 @@ export function DashboardKeyModal() {
         <div className="row" style={{ marginTop: 12, gap: 8 }}>
           <a
             className="link small"
-            href="https://app.nextbrowser.com/dashboard"
+            href={dashboardUrl}
             target="_blank"
             rel="noreferrer"
+            onClick={() => trackEvent("dashboard_opened", { source: "dashboard_key_modal" })}
           >
             Open dashboard
           </a>

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useStore } from "../store";
-import { brandName } from "../constants";
+import { brandName, dashboardUrl } from "../constants";
 import { BrandLogo } from "./BrandLogo";
 import { Spinner } from "./Icon";
 
@@ -9,6 +9,7 @@ export function Login() {
   const error = useStore((s) => s.loginError);
   const loading = useStore((s) => s.isLoggingIn);
   const [key, setKey] = useState("");
+  const canSubmit = !!key.trim() && !loading;
 
   return (
     <div className="login">
@@ -24,22 +25,24 @@ export function Login() {
           placeholder="nextbrowser API key"
           value={key}
           onChange={(e) => setKey(e.target.value)}
-          onKeyDown={(e) => e.key === "Enter" && login(key)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && canSubmit) void login(key);
+          }}
         />
         {error && <div className="error small login-error">{error}</div>}
       </div>
 
       <button
         className="btn-bordered-prominent login-submit"
-        disabled={loading}
-        onClick={() => login(key)}
+        disabled={!canSubmit}
+        onClick={() => void login(key)}
       >
         {loading ? <Spinner size={16} /> : "Sign in"}
       </button>
 
       <a
         className="login-link"
-        href="https://app.nextbrowser.com/dashboard"
+        href={dashboardUrl}
         target="_blank"
         rel="noreferrer"
       >

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import { BrandHeader } from "./BrandLogo";
 import { ScheduledRunsPanel } from "./ScheduledRunsPanel";
 import { Icon, Spinner } from "./Icon";
 import { countryFlag, countryLabel, ROTATION_COUNTRIES } from "../lib/countryFlag";
+import { trackEvent } from "../lib/analytics";
 import { humanBytes, proxyFraction } from "../types";
 
 export function Sidebar() {
@@ -86,7 +87,26 @@ export function Sidebar() {
                 </div>
               )}
               {s.proxy.dashboard_url && (
-                <a className="link small" href={s.proxy.dashboard_url} target="_blank" rel="noreferrer">
+                <a
+                  className="link small"
+                  href={s.proxy.dashboard_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  onClick={() => {
+                    const params = {
+                      proxy_state: s.proxy?.state ?? "unknown",
+                      limited: s.proxy?.limited ?? false,
+                      percent_used_bucket:
+                        s.proxy?.percent_used == null
+                          ? "unknown"
+                          : Math.min(100, Math.floor(s.proxy.percent_used / 10) * 10),
+                    };
+                    trackEvent("proxy_top_up_requested", params);
+                    trackEvent("proxy_top_up_clicked", {
+                      ...params,
+                    });
+                  }}
+                >
                   Top up in dashboard →
                 </a>
               )}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
 export const brandName = "NextBrowser";
 
 export const brandAccent = "#8c80ff"; // Swift .tint Color(red: 0.55, green: 0.5, blue: 1.0)
+
+export const dashboardUrl = "https://app.clawbrowser.ai/dashboard";

--- a/src/store.ts
+++ b/src/store.ts
@@ -977,10 +977,16 @@ export const useStore = create<State>((set, get) => ({
 
   login: async (key) => {
     const startedAt = performance.now();
+    const apiKey = key.trim();
     trackEvent("dashboard_key_save_started");
+    if (!apiKey) {
+      set({ loginError: "Enter your dashboard API key before signing in.", isLoggingIn: false });
+      trackTiming("dashboard_key_save_failed", startedAt, { reason: "empty_key" });
+      return;
+    }
     set({ loginError: undefined, isLoggingIn: true });
     try {
-      await clawctlRun(["config", "set", "--api-key", key.trim()]);
+      await clawctlRun(["config", "set", "--api-key", apiKey]);
       await refreshAnalyticsIdentity().catch(() => {
         trackEvent("analytics_identity_unavailable", { phase: "login" });
       });
@@ -1172,9 +1178,11 @@ export const useStore = create<State>((set, get) => ({
 
   startDefaultSession: async () => {
     const startedAt = performance.now();
+    trackEvent("session_create_requested", { scope: "default" });
     trackEvent("session_start_requested", { scope: "default" });
     await clawctlRun(["start", "--format", "json"]);
     await get().loadDefaultSession();
+    trackTiming("session_create_completed", startedAt, { scope: "default", session_status: get().defaultSession?.status ?? "unknown" });
     trackTiming("session_start_completed", startedAt, { scope: "default", session_status: get().defaultSession?.status ?? "unknown" });
   },
 
@@ -1188,28 +1196,34 @@ export const useStore = create<State>((set, get) => ({
 
   rotateDefaultSession: async () => {
     const startedAt = performance.now();
+    trackEvent("proxy_ip_change_requested", { scope: "default_session" });
     trackEvent("session_rotate_requested", { scope: "default" });
     await clawctlRun(["rotate", "--format", "json"]);
     await get().loadDefaultSession();
     await get().loadProxy().catch(() => {});
+    trackTiming("proxy_ip_change_completed", startedAt, { scope: "default_session" });
     trackTiming("session_rotate_completed", startedAt, { scope: "default" });
   },
 
   rotateDefaultSessionCountry: async (country) => {
     const startedAt = performance.now();
+    trackEvent("proxy_country_change_requested", { scope: "default_session", country });
     trackEvent("session_rotate_requested", { scope: "default", country });
     await clawctlRun(["rotate", "--country", country, "--verify", "--format", "json"]);
     await get().loadDefaultSession();
     await get().loadProxy().catch(() => {});
+    trackTiming("proxy_country_change_completed", startedAt, { scope: "default_session", country });
     trackTiming("session_rotate_completed", startedAt, { scope: "default", country });
   },
 
   startProfile: async (n) => {
     const startedAt = performance.now();
+    trackEvent("profile_session_create_requested", { scope: "profile" });
     trackEvent("profile_start_requested");
     set((s) => ({ statuses: { ...s.statuses, [n]: "starting" } }));
     await clawctlRun(["start", "--profile", n, "--format", "json"]);
     await get().loadProfiles();
+    trackTiming("profile_session_create_completed", startedAt, { status: get().statuses[n] ?? "unknown" });
     trackTiming("profile_start_completed", startedAt, { status: get().statuses[n] ?? "unknown" });
   },
 
@@ -1224,16 +1238,19 @@ export const useStore = create<State>((set, get) => ({
 
   rotateProfile: async (n) => {
     const startedAt = performance.now();
+    trackEvent("proxy_ip_change_requested", { scope: "profile" });
     trackEvent("profile_rotate_requested");
     set((s) => ({ statuses: { ...s.statuses, [n]: "rotating" } }));
     await clawctlRun(["rotate", "--profile", n, "--format", "json"]);
     await get().loadProfiles();
     await get().loadProxy().catch(() => {});
+    trackTiming("proxy_ip_change_completed", startedAt, { scope: "profile", status: get().statuses[n] ?? "unknown" });
     trackTiming("profile_rotate_completed", startedAt, { status: get().statuses[n] ?? "unknown" });
   },
 
   rotateProfileCountry: async (n, country) => {
     const startedAt = performance.now();
+    trackEvent("proxy_country_change_requested", { scope: "profile", country });
     trackEvent("profile_rotate_requested", { country });
     set((s) => ({ statuses: { ...s.statuses, [n]: "rotating" } }));
     await clawctlRun([
@@ -1248,11 +1265,13 @@ export const useStore = create<State>((set, get) => ({
     ]);
     await get().loadProfiles();
     await get().loadProxy().catch(() => {});
+    trackTiming("proxy_country_change_completed", startedAt, { scope: "profile", country, status: get().statuses[n] ?? "unknown" });
     trackTiming("profile_rotate_completed", startedAt, { country, status: get().statuses[n] ?? "unknown" });
   },
 
   deleteProfile: async (n) => {
     const startedAt = performance.now();
+    trackEvent("profile_session_delete_requested", { was_running: get().statuses[n] === "running" });
     trackEvent("profile_delete_requested", { was_running: get().statuses[n] === "running" });
     if (get().statuses[n] === "running") {
       await clawctlRun(["stop", "--profile", n, "--format", "json"]);
@@ -1265,6 +1284,7 @@ export const useStore = create<State>((set, get) => ({
       return { statuses };
     });
     await get().loadProfiles();
+    trackTiming("profile_session_delete_completed", startedAt);
     trackTiming("profile_delete_completed", startedAt);
   },
 
@@ -1746,6 +1766,13 @@ export const useStore = create<State>((set, get) => ({
       attachment_count: attachments.length,
       prompt_length_bucket: Math.min(5000, Math.ceil(prompt.length / 250) * 250),
     });
+    trackEvent("chat_request_submitted", {
+      agent: agentId,
+      has_chip: !!chip,
+      chip_kind: chip?.kind ?? "none",
+      attachment_count: attachments.length,
+      prompt_length_bucket: Math.min(5000, Math.ceil(prompt.length / 250) * 250),
+    });
     set((s) => {
       const conversations = s.conversations.map((c) =>
         c.id === cid
@@ -1938,6 +1965,10 @@ export const useStore = create<State>((set, get) => ({
 
   useSkillInChat: async (entry) => {
     if (!get().agentReady()) return;
+    trackEvent("skill_usage_requested", {
+      category: entry.category,
+      selector_kind: entry.selector.kind,
+    });
     trackEvent("skill_used_in_chat", {
       category: entry.category,
       selector_kind: entry.selector.kind,
@@ -1974,6 +2005,11 @@ export const useStore = create<State>((set, get) => ({
 
   runScript: async (entry, host = "") => {
     const onHost = host.trim();
+    trackEvent("script_usage_requested", {
+      script_type: entry.js ? "local_eval" : "agent_skill",
+      has_host: !!onHost,
+      category: entry.category,
+    });
     trackEvent("script_run_started", {
       script_type: entry.js ? "local_eval" : "agent_skill",
       has_host: !!onHost,


### PR DESCRIPTION
## Summary
- prevent empty dashboard API key sign-in attempts
- switch dashboard links to https://app.clawbrowser.ai/dashboard while keeping NextBrowser branding
- add GA events for proxy top-up, profile/session lifecycle, proxy IP/country changes, chat requests, skill/script usage

## Tests
- npm run build
- npm test