### PR TITLE
Fix macOS release: don't pass empty CSC_LINK (unsigned builds)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,18 +11,6 @@ permissions:
 jobs:
   macos:
     runs-on: macos-14
-    env:
-      # Code signing + notarization activate automatically once these repo
-      # secrets are populated. Until then the mac build stays unsigned.
-      #   MAC_CSC_LINK                 base64 of the Developer ID .p12
-      #   MAC_CSC_KEY_PASSWORD         password for that .p12
-      #   APPLE_ID / APPLE_TEAM_ID     Apple account + team for notarization
-      #   APPLE_APP_SPECIFIC_PASSWORD  app-specific password for notarization
-      CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
-      CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
-      APPLE_ID: ${{ secrets.APPLE_ID }}
-      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -33,11 +21,32 @@ jobs:
       - name: Sync version from tag
         if: github.ref_type == 'tag'
         run: node scripts/sync-version.mjs ${{ github.ref_name }}
-      - name: Toggle signing on secret availability
+      - name: Configure macOS signing
+        # Only export CSC_*/APPLE_* when a certificate secret is actually set.
+        # An empty CSC_LINK still counts as "defined" and makes electron-builder
+        # try to read a cert from an empty path, which fails the build — so we
+        # must leave it unset for unsigned builds rather than pass empty strings.
+        #   MAC_CSC_LINK                 base64 of the Developer ID .p12
+        #   MAC_CSC_KEY_PASSWORD         password for that .p12
+        #   APPLE_ID / APPLE_TEAM_ID     Apple account + team for notarization
+        #   APPLE_APP_SPECIFIC_PASSWORD  app-specific password for notarization
+        env:
+          MAC_CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
+          MAC_CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          if [ -n "${CSC_LINK}" ]; then
-            echo "Signing certificate present — signing enabled."
-            echo "CSC_IDENTITY_AUTO_DISCOVERY=true" >> "$GITHUB_ENV"
+          if [ -n "$MAC_CSC_LINK" ]; then
+            echo "Signing certificate present — signing + notarization enabled."
+            {
+              echo "CSC_LINK=$MAC_CSC_LINK"
+              echo "CSC_KEY_PASSWORD=$MAC_CSC_KEY_PASSWORD"
+              echo "APPLE_ID=$APPLE_ID"
+              echo "APPLE_APP_SPECIFIC_PASSWORD=$APPLE_APP_SPECIFIC_PASSWORD"
+              echo "APPLE_TEAM_ID=$APPLE_TEAM_ID"
+              echo "CSC_IDENTITY_AUTO_DISCOVERY=true"
+            } >> "$GITHUB_ENV"
           else
             echo "No signing certificate — building unsigned."
             echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Problem

The v0.1.11 release shipped **without macOS artifacts** (`latest-mac.yml`, dmg, zip) — the mac job failed at `npm run dist:mac`:

```
• empty password will be used for code signing  reason=CSC_KEY_PASSWORD is not defined
⨯ /Users/runner/work/nextbrowser-app/nextbrowser-app not a file
```

The mac job set `CSC_LINK` / `CSC_KEY_PASSWORD` / `APPLE_*` at **job scope** directly from secrets. When the signing secrets are unset they resolve to **empty strings**, but the env vars are still *defined*. electron-builder then treats `CSC_LINK=""` as "a certificate path was provided" and tries to read a cert from an empty path → resolves to the workspace dir → `not a file` → build fails.

As a result electron-updater on macOS picks v0.1.11 as the latest release and 404s on its missing `latest-mac.yml`.

## Fix

Move the signing env into the `Configure macOS signing` step and only export `CSC_*` / `APPLE_*` to `GITHUB_ENV` **when `MAC_CSC_LINK` is non-empty**. Unsigned builds now never see a `CSC_LINK` var at all, so electron-builder builds unsigned cleanly. Signing + notarization still activate automatically once the secrets are added — no other change needed.

## Follow-up (release ops)
- Re-release with the fix (e.g. tag `v0.1.12`) so a macOS build with `latest-mac.yml` + zip is published and mac auto-update/detection works again.