### PR TITLE
Fix macOS "damaged" error: ad-hoc sign unsigned builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         # must leave it unset for unsigned builds rather than pass empty strings.
         #   MAC_CSC_LINK                 base64 of the Developer ID .p12
         #   MAC_CSC_KEY_PASSWORD         password for that .p12
+        #   MAC_IDENTITY                 "Developer ID Application: NAME (TEAMID)"
         #   APPLE_ID / APPLE_TEAM_ID     Apple account + team for notarization
         #   APPLE_APP_SPECIFIC_PASSWORD  app-specific password for notarization
         env:
@@ -48,11 +49,25 @@ jobs:
               echo "CSC_IDENTITY_AUTO_DISCOVERY=true"
             } >> "$GITHUB_ENV"
           else
-            echo "No signing certificate — building unsigned."
+            echo "No signing certificate — building ad-hoc signed (unsigned distribution)."
             echo "CSC_IDENTITY_AUTO_DISCOVERY=false" >> "$GITHUB_ENV"
           fi
       - run: npm test
-      - run: npm run dist:mac
+      - name: Build macOS app
+        env:
+          MAC_IDENTITY: ${{ secrets.MAC_IDENTITY }}
+        run: |
+          if [ -n "$CSC_LINK" ]; then
+            # Signed release: override the package.json ad-hoc identity ("-")
+            # with the real Developer ID so the cert is actually used.
+            npm run dist:mac -- -c.mac.identity="$MAC_IDENTITY"
+          else
+            # Unsigned release: package.json identity "-" makes electron-builder
+            # re-sign the bundle ad-hoc, which yields a valid signature (the
+            # normal "unidentified developer" gate) instead of a broken one that
+            # macOS reports as "damaged".
+            npm run dist:mac
+          fi
       - name: Publish macOS build
         if: github.ref_type == 'tag'
         uses: softprops/action-gh-release@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextbrowser",
-  "version": "0.1.11",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nextbrowser",
-      "version": "0.1.11",
+      "version": "0.1.13",
       "license": "UNLICENSED",
       "dependencies": {
         "electron-updater": "^6.8.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextbrowser",
-  "version": "0.1.11",
+  "version": "0.1.13",
   "description": "NextBrowser desktop agent console for macOS and Windows",
   "author": "NextBrowser",
   "license": "UNLICENSED",
@@ -67,8 +67,7 @@
       ],
       "category": "public.app-category.developer-tools",
       "icon": "build/icon.icns",
-      "hardenedRuntime": true,
-      "gatekeeperAssess": false,
+      "identity": "-",
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist"
     },


### PR DESCRIPTION
## Problem

v0.1.12 opens on macOS with **«NextBrowser» is damaged and can't be opened. Move it to Trash** instead of the normal "unidentified developer / allow in Settings" gate.

Root cause is a regression from the earlier signing-readiness change: dropping `mac.identity` + setting `CSC_IDENTITY_AUTO_DISCOVERY=false` made electron-builder **skip signing entirely**. The app bundle then keeps Electron's original linker ad-hoc signature while being renamed to `NextBrowser` and repackaged, so the signature no longer matches the bundle. On Apple Silicon an invalid signature is reported as *damaged* (a fully-unsigned/broken app), whereas a valid ad-hoc signature only triggers the milder unidentified-developer gate.

Verified locally on the shipped config:
```
codesign -dv:  Identifier=Electron   flags=0x20002(adhoc,linker-signed)
spctl:         code has no resources but signature indicates they must be present   ← broken
```

## Fix

Restore `mac.identity: "-"` so electron-builder **re-signs the whole bundle ad-hoc**. Verified:
```
codesign -dv:      Identifier=com.nextbrowser.desktop   flags=0x10002(adhoc,runtime)
codesign --verify --deep --strict:  valid on disk; satisfies its Designated Requirement (exit 0)
```
Confirmed valid ad-hoc even with `CSC_IDENTITY_AUTO_DISCOVERY=false` (the CI unsigned path).

Signed releases override the ad-hoc identity with the real Developer ID via a new `MAC_IDENTITY` secret (`-c.mac.identity="$MAC_IDENTITY"`), so signing + notarization remain a drop-in once the cert secrets are added — no further code changes. Removed the redundant `hardenedRuntime`/`gatekeeperAssess` from package.json (electron-builder defaults `hardenedRuntime` on for distribution, covered by the existing disable-library-validation entitlement).

Also bumps version to 0.1.13.

## Follow-up
- Merge and tag **v0.1.13** to ship a mac build that opens with the normal gate (right-click → Open / allow in Settings) instead of "damaged".