### PR TITLE
Check nextctl updates every 20 minutes

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -150,8 +150,8 @@ const STALL_MS = 120_000;
 const WATCHDOG_MS = 5_000;
 const PROXY_REFRESH_MS = 120_000;
 const SCHEDULE_TICK_MS = 30_000;
-const NEXTCTL_DAILY_UPDATE_MS = 24 * 60 * 60 * 1000;
-const NEXTCTL_DAILY_UPDATE_POLL_MS = 60 * 60 * 1000;
+const NEXTCTL_DAILY_UPDATE_MS = 20 * 60 * 1000;
+const NEXTCTL_DAILY_UPDATE_POLL_MS = 60 * 1000;
 const NEXTCTL_UPDATE_STATE_FILE = "nextctl-update.json";
 
 function nextBrowserInstallPrompt(agentAdapter: string): string {


### PR DESCRIPTION
## Summary
- run the existing automatic nextctl update check every 20 minutes instead of daily
- poll eligibility once per minute so the check starts without an hour-long delay
- preserve the existing guards for active VPS work and in-progress updates

## Test plan
- `npm run build`
- `npm test`