### PR TITLE
Automate nextctl updates and stabilize session refresh

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -248,7 +248,6 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
               {s.isRefreshing ? <Spinner size={12} /> : <Icon name="arrow.clockwise" size={12} />}
             </button>
             <span className="spacer" />
-            {s.anyAgentRunning() && <Spinner size={12} />}
           </div>
 
           <div className="session-quick-actions">

--- a/src/store.ts
+++ b/src/store.ts
@@ -150,8 +150,8 @@ const STALL_MS = 120_000;
 const WATCHDOG_MS = 5_000;
 const PROXY_REFRESH_MS = 120_000;
 const SCHEDULE_TICK_MS = 30_000;
-const NEXTCTL_DAILY_UPDATE_MS = 24 * 60 * 60 * 1000;
-const NEXTCTL_DAILY_UPDATE_POLL_MS = 60 * 60 * 1000;
+const NEXTCTL_DAILY_UPDATE_MS = 20 * 60 * 1000;
+const NEXTCTL_DAILY_UPDATE_POLL_MS = 60 * 1000;
 const NEXTCTL_UPDATE_STATE_FILE = "nextctl-update.json";
 
 function nextBrowserInstallPrompt(agentAdapter: string): string {

--- a/src/store.ts
+++ b/src/store.ts
@@ -435,6 +435,7 @@ interface State {
 let proxyTimer: ReturnType<typeof setInterval> | null = null;
 let scheduleTimer: ReturnType<typeof setInterval> | null = null;
 let sessionPollTimer: ReturnType<typeof setInterval> | null = null;
+let sessionPollInFlight = false;
 let nextctlDailyUpdateTimer: ReturnType<typeof setInterval> | null = null;
 let vpsSetupReservations = 0;
 let localNextctlOperations = 0;
@@ -1423,16 +1424,24 @@ export const useStore = create<State>((set, get) => {
 
   startSessionPoll: () => {
     if (sessionPollTimer) return;
-    sessionPollTimer = setInterval(() => {
+    sessionPollTimer = setInterval(async () => {
       if (!runningTarget(get(), "local")) {
         if (sessionPollTimer) clearInterval(sessionPollTimer);
         sessionPollTimer = null;
+        sessionPollInFlight = false;
         return;
       }
-      if (pendingTarget(get(), "vps")) return;
-      get().loadProfiles().catch(() => {});
-      get().loadDefaultSession().catch(() => {});
-    }, 2000);
+      if (pendingTarget(get(), "vps") || sessionPollInFlight) return;
+      sessionPollInFlight = true;
+      try {
+        await Promise.all([
+          get().loadProfiles().catch(() => {}),
+          get().loadDefaultSession().catch(() => {}),
+        ]);
+      } finally {
+        sessionPollInFlight = false;
+      }
+    }, 5000);
   },
 
   login: async (key) => {
@@ -1646,7 +1655,11 @@ export const useStore = create<State>((set, get) => {
   loadProfiles: async () => {
     try {
       const list = await nextctlJson<{ profiles: Profile[] }>(["profiles", "ls"]);
-      set({ profiles: list.profiles, profileSessions: {} });
+      const statuses: Record<string, string> = {};
+      const profileSessions: Record<string, SessionStatus> = {};
+      const profileIdentities: Record<string, ProxyIdentity> = {};
+      const defaultIdentity = get().profileIdentities.__default;
+      if (defaultIdentity) profileIdentities.__default = defaultIdentity;
       trackEvent("profiles_loaded", {
         profile_count: list.profiles.length,
         country_count: new Set(list.profiles.map((p) => p.country).filter(Boolean)).size,
@@ -1654,22 +1667,20 @@ export const useStore = create<State>((set, get) => {
       for (const p of list.profiles) {
         try {
           const st = await nextctlJson<SessionStatus>(["status", "--profile", p.name]);
-          set((s) => ({
-            statuses: { ...s.statuses, [p.name]: st.status },
-            profileSessions: { ...s.profileSessions, [p.name]: st },
-          }));
+          statuses[p.name] = st.status;
+          profileSessions[p.name] = st;
           if (st.status === "running") {
             const identity = await verifyProxyIdentity(p.name);
-            if (identity) set((s) => ({ profileIdentities: { ...s.profileIdentities, [p.name]: identity } }));
+            if (identity) profileIdentities[p.name] = identity;
+          } else if (get().profileIdentities[p.name]) {
+            profileIdentities[p.name] = get().profileIdentities[p.name];
           }
         } catch {
-          set((s) => {
-            const profileSessions = { ...s.profileSessions };
-            delete profileSessions[p.name];
-            return { statuses: { ...s.statuses, [p.name]: "unknown" }, profileSessions };
-          });
+          statuses[p.name] = "unknown";
+          if (get().profileIdentities[p.name]) profileIdentities[p.name] = get().profileIdentities[p.name];
         }
       }
+      set({ profiles: list.profiles, statuses, profileSessions, profileIdentities });
     } catch {
       /* non-fatal */
     }
@@ -1685,7 +1696,6 @@ export const useStore = create<State>((set, get) => {
       }
       trackEvent("default_profile_loaded", { status: st.status, backend: st.backend ?? "unknown" });
     } catch {
-      set({ defaultSession: undefined });
       trackEvent("default_profile_unavailable");
     }
   },


### PR DESCRIPTION
## Summary
- check nextctl updates automatically every 20 minutes
- poll update eligibility once per minute while preserving VPS/update guards
- refresh named profile state atomically so the technical `default` session no longer flickers
- prevent overlapping session polling requests and reduce active polling from 2s to 5s
- preserve the last known default session across transient status failures
- remove the unrelated perpetual agent activity spinner from the Profiles header

## Replaces
This includes all changes from #152 plus the session refresh fix. #152 can be closed after this PR is used.

## Test plan
- `npm test`
- `npm run build`