### PR TITLE
feat: download platform installers directly

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -551,6 +551,7 @@ async function invokeCommand(command, args = {}) {
       await shell.openExternal(String(args.url || ""));
       return null;
     }
+    case "app_platform": return { platform: process.platform, arch: process.arch };
     case "agent_authorize": {
       const bin = resolveBinary(args.binary, args.envVar); if (!bin) throw new Error(`${args.binary} executable not found.`);
       const r = await run(bin, ["--version"]); if (r.code !== 0) throw new Error(`${args.binary} is not ready: ${(r.stdout + r.stderr).trim()}`);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import {
 import { internalError } from "./lib/userFacingError";
 import { invoke, listen } from "./electronBridge";
 import { agentById } from "./agents";
+import { releaseDownloadUrl } from "./lib/releaseDownload";
 import { UserFacingError } from "./components/UserFacingError";
 import { AgentInstallLink } from "./components/AgentInstallLink";
 
@@ -292,7 +293,7 @@ function SettingsModal({
               {manualUpdate ? (
                 updateAvailable(appUpdate) ? (
                   <button className="mini primary-mini" onClick={onOpenRelease}>
-                    Open release page
+                    Download update
                   </button>
                 ) : null
               ) : (
@@ -452,7 +453,7 @@ function AppUpdatePrompt({
         </div>
         <p className="muted">
           {manual
-            ? "Open the releases page to download and install the new version."
+            ? "Download and install the new version."
             : downloaded
               ? "The update is downloaded. Restart to finish installing."
               : downloading
@@ -463,7 +464,7 @@ function AppUpdatePrompt({
           <button className="secondary" onClick={onLater}>Later</button>
           <span className="spacer" />
           {manual ? (
-            <button className="primary" onClick={onOpenRelease}>Open release page</button>
+            <button className="primary" onClick={onOpenRelease}>Download update</button>
           ) : (
             <button
               className="primary"
@@ -550,9 +551,18 @@ export function App() {
       setAppUpdate({ status: "error", message: internalError("We couldn't install the update.") });
     });
   };
-  const openLatestRelease = () => {
+  const openLatestRelease = async () => {
     trackEvent("app_update_open_release", { version: appUpdate.version ?? undefined });
-    window.open(latestReleaseUrl, "_blank", "noopener,noreferrer");
+    let url = latestReleaseUrl;
+    try {
+      const info = await invoke<{ platform: string; arch: string }>("app_platform");
+      url = releaseDownloadUrl(appUpdate.version, info.platform, info.arch);
+    } catch {
+      // Browser previews and unsupported builds fall back to the releases page.
+    }
+    await invoke("open_external", { url }).catch(() => {
+      window.open(url, "_blank", "noopener,noreferrer");
+    });
   };
   const openSettings = (focus: "agent" | null = null) => {
     setSettingsFocus(focus);

--- a/src/lib/releaseDownload.test.ts
+++ b/src/lib/releaseDownload.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { latestReleaseUrl } from "../constants";
+import { releaseDownloadUrl } from "./releaseDownload";
+
+describe("releaseDownloadUrl", () => {
+  it("links directly to the Apple Silicon installer", () => {
+    expect(releaseDownloadUrl("0.1.20", "darwin", "arm64")).toBe(
+      "https://github.com/nextbrowser-oss/nextbrowser-app/releases/download/v0.1.20/NextBrowser-0.1.20-arm64.dmg",
+    );
+  });
+
+  it("links directly to the Windows installer", () => {
+    expect(releaseDownloadUrl("v0.1.20", "win32", "x64")).toBe(
+      "https://github.com/nextbrowser-oss/nextbrowser-app/releases/download/v0.1.20/NextBrowser-0.1.20-x64.exe",
+    );
+  });
+
+  it("falls back to the releases page for an unavailable build", () => {
+    expect(releaseDownloadUrl("0.1.20", "darwin", "x64")).toBe(latestReleaseUrl);
+    expect(releaseDownloadUrl(undefined, "win32", "x64")).toBe(latestReleaseUrl);
+  });
+});

--- a/src/lib/releaseDownload.ts
+++ b/src/lib/releaseDownload.ts
@@ -1,0 +1,23 @@
+import { latestReleaseUrl, repoUrl } from "../constants";
+
+export function releaseDownloadUrl(
+  version: string | undefined,
+  platform: string,
+  arch: string,
+): string {
+  const cleanVersion = version?.trim().replace(/^v/i, "");
+  if (!cleanVersion || !/^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/.test(cleanVersion)) {
+    return latestReleaseUrl;
+  }
+
+  let asset: string | undefined;
+  if (platform === "darwin" && arch === "arm64") {
+    asset = `NextBrowser-${cleanVersion}-arm64.dmg`;
+  } else if (platform === "win32" && arch === "x64") {
+    asset = `NextBrowser-${cleanVersion}-x64.exe`;
+  }
+
+  return asset
+    ? `${repoUrl}/releases/download/v${cleanVersion}/${asset}`
+    : latestReleaseUrl;
+}


### PR DESCRIPTION
## Summary
- make the update action open the platform installer asset directly instead of the GitHub Releases page
- download the Apple Silicon `.dmg` directly on macOS
- download the x64 `.exe` directly on Windows
- keep the Releases page as a safe fallback for unsupported platforms, architectures, or invalid versions
- update the UI copy from “Open release page” to “Download update”

## Validation
- `npm test` — 114 tests passed
- `npm run build` — passed