### PR TITLE
fix: preserve and reconnect live streams

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -869,7 +869,9 @@ export function App() {
         <div className={"tab-content" + (tab === "skills" ? " tab-content-bleed" : "")}>
           {tab === "chat" && <ChatView />}
           {tab === "skills" && <SkillsView onOpenAgentSettings={() => openSettings("agent")} />}
-          {tab === "live" && <LiveView />}
+          <div className={"persistent-tab-panel" + (tab === "live" ? "" : " is-hidden")}>
+            <LiveView active={tab === "live"} />
+          </div>
           {tab === "usage" && <UsageView />}
           {tab === "guide" && <GuideView onOpenAgentSettings={() => openSettings("agent")} />}
           {tab === "scheduled" && (

--- a/src/components/LiveView.tsx
+++ b/src/components/LiveView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type WheelEvent as ReactWheelEvent } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type PointerEvent as ReactPointerEvent, type WheelEvent as ReactWheelEvent } from "react";
 import { RemoteControlClient, type RemoteLiveTab, type RemoteMediaStats, type RemoteStreamInfo } from "../remoteControl";
 import { useStore } from "../store";
 import { internalError } from "../lib/userFacingError";
@@ -6,6 +6,7 @@ import { Icon, Spinner } from "./Icon";
 import { UserFacingError } from "./UserFacingError";
 
 type LiveState = "idle" | "connecting" | "live" | "error";
+const LIVE_VIEW_BACKGROUND_TTL_MS = 10 * 60 * 1000;
 
 function modifierBits(event: MouseEvent | WheelEvent | KeyboardEvent) {
   return (event.altKey ? 1 : 0) | (event.ctrlKey ? 2 : 0) | (event.metaKey ? 4 : 0) | (event.shiftKey ? 8 : 0);
@@ -31,12 +32,13 @@ function mergeTabs(current: RemoteLiveTab[], incoming: RemoteLiveTab[]) {
   return [...next.values()];
 }
 
-export function LiveView() {
+export function LiveView({ active }: { active: boolean }) {
   const s = useStore();
   const [sessionKey, setSessionKey] = useState<string>("");
   const [streamInfo, setStreamInfo] = useState<RemoteStreamInfo | null>(null);
   const [state, setState] = useState<LiveState>("idle");
   const [error, setError] = useState("");
+  const [inputWarning, setInputWarning] = useState("");
   const [remoteTabs, setRemoteTabs] = useState<RemoteLiveTab[]>([]);
   const [pendingRemoteTab, setPendingRemoteTab] = useState("");
   const [mediaStats, setMediaStats] = useState<RemoteMediaStats>({});
@@ -44,6 +46,9 @@ export function LiveView() {
   const remoteClientRef = useRef<RemoteControlClient | null>(null);
   const remoteEmbedRef = useRef<HTMLDivElement | null>(null);
   const remoteVideoRef = useRef<HTMLVideoElement | null>(null);
+  const inactiveTimerRef = useRef<number | null>(null);
+  const inputWarningTimerRef = useRef<number | null>(null);
+  const pointerDragRef = useRef<{ pointerId: number; button: string; buttons: number; x: number; y: number } | null>(null);
   const runningProfiles = s.profiles.filter((profile) => s.statuses[profile.name] === "running");
   const defaultRunning = s.defaultSession?.status === "running";
   const profileOptions = [
@@ -59,6 +64,10 @@ export function LiveView() {
   const nativeViewer = !!streamInfo?.viewer_ws_url;
 
   const stop = () => {
+    if (inactiveTimerRef.current !== null) {
+      window.clearTimeout(inactiveTimerRef.current);
+      inactiveTimerRef.current = null;
+    }
     remoteClientRef.current?.close();
     remoteClientRef.current = null;
     if (remoteVideoRef.current) remoteVideoRef.current.srcObject = null;
@@ -68,6 +77,7 @@ export function LiveView() {
     setRemoteTabs([]);
     setPendingRemoteTab("");
     setMediaStats({});
+    setInputWarning("");
   };
 
   const connectRemoteViewer = async (info: RemoteStreamInfo) => {
@@ -103,6 +113,14 @@ export function LiveView() {
         setRemoteTabs((tabs) => tabs.map((tab) => ({ ...tab, active: tab.target_id === targetID })));
       },
       onMediaStats: setMediaStats,
+      onInputError: () => {
+        setInputWarning("Input was not applied. Try again.");
+        if (inputWarningTimerRef.current !== null) window.clearTimeout(inputWarningTimerRef.current);
+        inputWarningTimerRef.current = window.setTimeout(() => {
+          inputWarningTimerRef.current = null;
+          setInputWarning("");
+        }, 3000);
+      },
     });
     remoteClientRef.current = client;
     await client.start();
@@ -173,16 +191,53 @@ export function LiveView() {
   };
 
   useEffect(() => {
+    if (!active) return;
     const current =
       s.selectedProfile ||
       (s.defaultSession?.status === "running" ? "__default" : "") ||
       s.profiles.find((profile) => s.statuses[profile.name] === "running")?.name ||
       "";
     setSessionKey(current);
-    if (current && (current === "__default" || s.statuses[current] === "running")) void start(current);
-    return () => remoteClientRef.current?.close();
-    // LiveView is mounted afresh on tab selection, matching Swift onAppear.
+    if (
+      !remoteClientRef.current &&
+      state !== "connecting" &&
+      !streamInfo &&
+      current &&
+      (current === "__default" || s.statuses[current] === "running")
+    ) {
+      void start(current);
+    }
+    // The component stays mounted while another app tab is active.
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active]);
+
+  useEffect(() => {
+    if (active) {
+      if (inactiveTimerRef.current !== null) {
+        window.clearTimeout(inactiveTimerRef.current);
+        inactiveTimerRef.current = null;
+      }
+      return;
+    }
+    if (!remoteClientRef.current && !streamInfo) return;
+    inactiveTimerRef.current = window.setTimeout(() => {
+      inactiveTimerRef.current = null;
+      stop();
+    }, LIVE_VIEW_BACKGROUND_TTL_MS);
+    return () => {
+      if (inactiveTimerRef.current !== null) {
+        window.clearTimeout(inactiveTimerRef.current);
+        inactiveTimerRef.current = null;
+      }
+    };
+    // Only transitions between app tabs should reset the grace period.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active]);
+
+  useEffect(() => () => {
+    if (inactiveTimerRef.current !== null) window.clearTimeout(inactiveTimerRef.current);
+    if (inputWarningTimerRef.current !== null) window.clearTimeout(inputWarningTimerRef.current);
+    remoteClientRef.current?.close();
   }, []);
 
   useEffect(() => {
@@ -192,23 +247,59 @@ export function LiveView() {
     void video.play().catch(() => undefined);
   }, [remoteMediaStream, state]);
 
-  const handleMouseDown = (event: ReactMouseEvent<HTMLDivElement>) => {
-    remoteEmbedRef.current?.focus();
+  const releasePointer = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const drag = pointerDragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
     const point = pointForEvent(event.nativeEvent);
     remoteClientRef.current?.sendInput({
       type: "mouse",
-      payload: { event: "mousePressed", x: point.x, y: point.y, button: buttonName(event.button), buttons: 1, clickCount: event.detail || 1, modifiers: modifierBits(event.nativeEvent) },
+      payload: { event: "mouseReleased", x: point.x, y: point.y, button: drag.button, buttons: 0, clickCount: event.detail || 1, modifiers: modifierBits(event.nativeEvent) },
+    });
+    pointerDragRef.current = null;
+  };
+
+  const handlePointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.button < 0) return;
+    remoteEmbedRef.current?.focus();
+    const point = pointForEvent(event.nativeEvent);
+    const button = buttonName(event.button);
+    const buttons = event.buttons || 1;
+    remoteClientRef.current?.sendInput({
+      type: "mouse",
+      payload: { event: "mousePressed", x: point.x, y: point.y, button, buttons, clickCount: event.detail || 1, modifiers: modifierBits(event.nativeEvent) },
+    });
+    pointerDragRef.current = { pointerId: event.pointerId, button, buttons, x: point.x, y: point.y };
+    event.currentTarget.setPointerCapture(event.pointerId);
+    event.preventDefault();
+  };
+
+  const handlePointerMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const drag = pointerDragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    const point = pointForEvent(event.nativeEvent);
+    drag.x = point.x;
+    drag.y = point.y;
+    if (event.buttons === 0) {
+      releasePointer(event);
+      return;
+    }
+    remoteClientRef.current?.sendInput({
+      type: "mouse",
+      payload: { event: "mouseMoved", x: point.x, y: point.y, button: drag.button, buttons: event.buttons || drag.buttons, modifiers: modifierBits(event.nativeEvent) },
     });
     event.preventDefault();
   };
 
-  const handleMouseUp = (event: ReactMouseEvent<HTMLDivElement>) => {
-    const point = pointForEvent(event.nativeEvent);
-    remoteClientRef.current?.sendInput({
-      type: "mouse",
-      payload: { event: "mouseReleased", x: point.x, y: point.y, button: buttonName(event.button), buttons: 0, clickCount: event.detail || 1, modifiers: modifierBits(event.nativeEvent) },
-    });
+  const handlePointerUp = (event: ReactPointerEvent<HTMLDivElement>) => {
+    releasePointer(event);
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
     event.preventDefault();
+  };
+
+  const handlePointerCancel = (event: ReactPointerEvent<HTMLDivElement>) => {
+    releasePointer(event);
   };
 
   const handleWheel = (event: ReactWheelEvent<HTMLDivElement>) => {
@@ -374,8 +465,10 @@ export function LiveView() {
             ref={remoteEmbedRef}
             className="remote-live-embed"
             tabIndex={0}
-            onMouseDown={handleMouseDown}
-            onMouseUp={handleMouseUp}
+            onPointerCancel={handlePointerCancel}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerUp}
             onWheel={handleWheel}
             onKeyDown={handleKeyDown}
             onKeyUp={handleKeyUp}
@@ -392,9 +485,9 @@ export function LiveView() {
       </div>
       {state === "live" && (
         <div className="live-hint muted small">
-          {nativeViewer
+          {inputWarning || (nativeViewer
             ? "Remote Control is running natively in NextBrowser. Click, scroll, type, or use the tab bar above."
-            : "Remote Control is embedded in NextBrowser through the backend dashboard viewer."}
+            : "Remote Control is embedded in NextBrowser through the backend dashboard viewer.")}
         </div>
       )}
     </div>

--- a/src/remoteControl.test.ts
+++ b/src/remoteControl.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const bridge = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  listen: vi.fn(),
+}));
+
+vi.mock("./electronBridge", () => bridge);
+
+import { RemoteControlClient } from "./remoteControl";
+
+class FakeDataChannel {
+  readyState: RTCDataChannelState = "connecting";
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  sent: string[] = [];
+
+  send(value: string) {
+    this.sent.push(value);
+  }
+
+  close() {
+    this.readyState = "closed";
+  }
+
+  open() {
+    this.readyState = "open";
+    this.onopen?.();
+  }
+}
+
+class FakePeerConnection {
+  static instances: FakePeerConnection[] = [];
+  connectionState: RTCPeerConnectionState = "new";
+  remoteDescription: RTCSessionDescription | null = null;
+  onconnectionstatechange: (() => void) | null = null;
+  onicecandidate: ((event: { candidate: null }) => void) | null = null;
+  ontrack: ((event: { streams: MediaStream[] }) => void) | null = null;
+  channels: FakeDataChannel[] = [];
+
+  constructor() {
+    FakePeerConnection.instances.push(this);
+  }
+
+  addTransceiver() {
+    return {};
+  }
+
+  createDataChannel() {
+    const channel = new FakeDataChannel();
+    this.channels.push(channel);
+    return channel;
+  }
+
+  async createOffer() {
+    return { type: "offer" as RTCSdpType, sdp: "offer-sdp" };
+  }
+
+  async setLocalDescription() {}
+  async setRemoteDescription() {}
+  async addIceCandidate() {}
+
+  close() {
+    this.connectionState = "closed";
+    this.onconnectionstatechange?.();
+  }
+
+  setConnectionState(state: RTCPeerConnectionState) {
+    this.connectionState = state;
+    this.onconnectionstatechange?.();
+  }
+}
+
+describe("RemoteControlClient", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    FakePeerConnection.instances = [];
+    vi.stubGlobal("RTCPeerConnection", FakePeerConnection);
+    bridge.listen.mockResolvedValue(() => undefined);
+    bridge.invoke.mockImplementation(async (command: string) => {
+      if (command === "remote_signal_open") return "signal-1";
+      return undefined;
+    });
+  });
+
+  it("creates a fresh offer and revision after a disconnected peer times out", async () => {
+    const states: string[] = [];
+    const client = new RemoteControlClient(
+      { id: "session-1", viewer_ws_url: "wss://example.test/viewer" },
+      { onState: (state) => states.push(state) },
+    );
+
+    await client.start();
+    expect(FakePeerConnection.instances).toHaveLength(1);
+    FakePeerConnection.instances[0].setConnectionState("disconnected");
+
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(FakePeerConnection.instances).toHaveLength(2);
+
+    const offers = bridge.invoke.mock.calls
+      .filter(([command]) => command === "remote_signal_send")
+      .map(([, args]) => JSON.parse(args.data))
+      .filter((message) => message.type === "rtc_offer");
+    expect(offers.map((message) => message.revision)).toEqual([1, 2]);
+    expect(states).toContain("connecting");
+    client.close();
+  });
+
+  it("reports rejected input results from the agent", async () => {
+    const onInputError = vi.fn();
+    const client = new RemoteControlClient(
+      { id: "session-1", viewer_ws_url: "wss://example.test/viewer" },
+      { onInputError },
+    );
+
+    await client.start();
+    const input = FakePeerConnection.instances[0].channels[1];
+    input.onmessage?.({ data: JSON.stringify({ type: "input_result", seq: 7, ok: false }) });
+
+    expect(onInputError).toHaveBeenCalledOnce();
+    client.close();
+  });
+});

--- a/src/remoteControl.ts
+++ b/src/remoteControl.ts
@@ -46,6 +46,7 @@ type CallbackSet = {
   onTabs?: (tabs: RemoteLiveTab[]) => void;
   onTabSelected?: (targetID: string) => void;
   onMediaStats?: (stats: RemoteMediaStats) => void;
+  onInputError?: () => void;
 };
 
 type InputEnvelope = {
@@ -62,13 +63,13 @@ export class RemoteControlClient {
   private pc: RTCPeerConnection | null = null;
   private control: RTCDataChannel | null = null;
   private input: RTCDataChannel | null = null;
-  private revision = 1;
+  private revision = 0;
   private seq = 0;
   private closed = false;
   private helloSent = false;
   private pendingControl: string[] = [];
-  private pendingInput: string[] = [];
   private pendingCandidates: RTCIceCandidateInit[] = [];
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(info: RemoteStreamInfo, cb: CallbackSet) {
     this.info = info;
@@ -78,6 +79,24 @@ export class RemoteControlClient {
   async start() {
     if (!this.info.viewer_ws_url) throw new Error("Remote stream did not include viewer_ws_url.");
     this.closed = false;
+    this.cb.onState?.("connecting");
+    await this.openSignalSocket();
+    await this.startPeerConnection();
+  }
+
+  private async startPeerConnection() {
+    if (this.closed) return;
+    this.clearReconnectTimer();
+    this.control?.close();
+    this.input?.close();
+    this.pc?.close();
+    this.control = null;
+    this.input = null;
+    this.pc = null;
+    this.helloSent = false;
+    this.pendingCandidates = [];
+    this.revision += 1;
+    const revision = this.revision;
     this.cb.onState?.("connecting");
     const pc = new RTCPeerConnection({
       iceServers: (this.info.ice_servers || [])
@@ -97,22 +116,29 @@ export class RemoteControlClient {
       this.flushControl();
     };
     this.control.onmessage = (event) => this.handleControlMessage(String(event.data));
-    this.input.onopen = () => this.flushInput();
-    this.input.onmessage = () => undefined;
+    this.input.onopen = () => undefined;
+    this.input.onmessage = (event) => {
+      try {
+        const message = JSON.parse(String(event.data));
+        if (message.type === "input_result" && message.ok === false) this.cb.onInputError?.();
+      } catch {
+        // Ignore non-protocol input messages.
+      }
+    };
     pc.ontrack = (event) => {
       const [stream] = event.streams;
       if (stream) this.cb.onStream?.(stream);
     };
     pc.onicecandidate = (event) => {
       if (!event.candidate) {
-        this.sendSignal({ type: "ice_complete", session_id: this.info.id, revision: this.revision, payload: null });
+        this.sendSignal({ type: "ice_complete", session_id: this.info.id, revision, payload: null });
         return;
       }
       const candidate = event.candidate.toJSON();
       this.sendSignal({
         type: "ice_candidate",
         session_id: this.info.id,
-        revision: this.revision,
+        revision,
         payload: {
           candidate: candidate.candidate,
           sdpMid: candidate.sdpMid,
@@ -121,25 +147,33 @@ export class RemoteControlClient {
       });
     };
     pc.onconnectionstatechange = () => {
-      if (pc.connectionState === "connected") this.cb.onState?.("connected");
-      if (pc.connectionState === "failed" || pc.connectionState === "closed") {
-        if (!this.closed) this.cb.onState?.("error");
+      if (this.pc !== pc || this.closed) return;
+      if (pc.connectionState === "connected") {
+        this.clearReconnectTimer();
+        this.cb.onState?.("connected");
+      }
+      if (pc.connectionState === "disconnected") {
+        this.scheduleReconnect(1500);
+      }
+      if (pc.connectionState === "failed") {
+        this.scheduleReconnect(250);
       }
     };
 
-    await this.openSignalSocket();
     const offer = await pc.createOffer();
+    if (this.closed || this.pc !== pc) return;
     await pc.setLocalDescription(offer);
     this.sendSignal({
       type: "rtc_offer",
       session_id: this.info.id,
-      revision: this.revision,
+      revision,
       payload: { type: offer.type, sdp: offer.sdp },
     });
   }
 
   close() {
     this.closed = true;
+    this.clearReconnectTimer();
     this.sendControl({ type: "close" });
     if (this.signalID) void invoke("remote_signal_close", { id: this.signalID }).catch(() => undefined);
     this.unlistenSignal?.();
@@ -154,6 +188,27 @@ export class RemoteControlClient {
     this.input = null;
     this.pc = null;
     this.cb.onState?.("idle");
+  }
+
+  private scheduleReconnect(delay: number) {
+    if (this.closed || this.reconnectTimer) return;
+    this.cb.onState?.("connecting");
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (this.closed || this.pc?.connectionState === "connected") return;
+      void (async () => {
+        if (!this.signalID) await this.openSignalSocket();
+        await this.startPeerConnection();
+      })().catch(() => {
+        if (!this.closed) this.cb.onState?.("error");
+      });
+    }, delay);
+  }
+
+  private clearReconnectTimer() {
+    if (!this.reconnectTimer) return;
+    clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = null;
   }
 
   selectTab(targetID: string) {
@@ -175,16 +230,24 @@ export class RemoteControlClient {
   }
 
   private async openSignalSocket() {
-    this.unlistenSignal = await listen<{ id: string; type: string; data?: string; message?: string }>("remote_signal_event", ({ payload }) => {
-      if (payload.id !== this.signalID) return;
-      if (payload.type === "message" && payload.data) void this.handleSignalMessage(payload.data);
-      if (payload.type === "error") {
-        this.cb.onError?.(internalError("We couldn't connect Live View."));
-      }
-      if (payload.type === "close" && !this.closed) {
-        this.cb.onError?.(internalError("The Live View connection closed unexpectedly."));
-      }
-    });
+    if (!this.unlistenSignal) {
+      this.unlistenSignal = await listen<{ id: string; type: string; data?: string; message?: string }>("remote_signal_event", ({ payload }) => {
+        if (payload.id !== this.signalID) return;
+        if (payload.type === "message" && payload.data) void this.handleSignalMessage(payload.data);
+        if (payload.type === "error" && !this.closed) {
+          const failedSignalID = this.signalID;
+          this.signalID = "";
+          if (failedSignalID) void invoke("remote_signal_close", { id: failedSignalID }).catch(() => undefined);
+          this.pc?.close();
+          this.scheduleReconnect(250);
+        }
+        if (payload.type === "close" && !this.closed) {
+          this.signalID = "";
+          this.pc?.close();
+          this.scheduleReconnect(250);
+        }
+      });
+    }
     this.signalID = await invoke<string>("remote_signal_open", { url: this.info.viewer_ws_url || "" });
   }
 
@@ -195,6 +258,7 @@ export class RemoteControlClient {
     } catch {
       return;
     }
+    if (message.revision !== undefined && message.revision !== this.revision) return;
     if (message.type === "rtc_answer" && message.payload?.sdp && this.pc) {
       await this.pc.setRemoteDescription({ type: "answer", sdp: message.payload.sdp });
       const candidates = this.pendingCandidates.splice(0);
@@ -272,18 +336,12 @@ export class RemoteControlClient {
 
   private sendInputText(raw: string) {
     if (this.input?.readyState === "open") this.input.send(raw);
-    else this.pendingInput.push(raw);
+    else this.cb.onInputError?.();
   }
 
   private flushControl() {
     while (this.control?.readyState === "open" && this.pendingControl.length) {
       this.control.send(this.pendingControl.shift() || "");
-    }
-  }
-
-  private flushInput() {
-    while (this.input?.readyState === "open" && this.pendingInput.length) {
-      this.input.send(this.pendingInput.shift() || "");
     }
   }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1902,6 +1902,8 @@ button, input, textarea, select { color: var(--text); }
 }
 .tab-content { flex: 1; min-height: 0; display: flex; flex-direction: column; }
 .tab-content-bleed { overflow: hidden; }
+.persistent-tab-panel { flex: 1; min-height: 0; display: flex; flex-direction: column; }
+.persistent-tab-panel.is-hidden { display: none; }
 
 /* Chat */
 .chat { flex: 1; display: flex; flex-direction: column; min-width: 0; min-height: 0; overflow-x: hidden; }


### PR DESCRIPTION
## Summary
- keep the native Live viewer mounted when navigating to another app tab
- retain the stream for a 10-minute grace period, then stop it automatically
- resume instantly when returning during the grace period
- recreate signaling and WebRTC peers after disconnects with a fresh revision
- support drag movement, pointer cancellation/release, and input failure feedback
- ignore stale signaling revisions and avoid replaying stale queued input

## Base
Created from current `origin/main` at `bd4e553` (v0.1.25).

## Verification
- `npm test` (159 tests)
- `npm run build`
- added reconnect/revision and input-result tests