### PR TITLE
Fix spacing between Terminal chat and Proxy usage

### DIFF
--- a/src/store.conversations.test.ts
+++ b/src/store.conversations.test.ts
@@ -82,3 +82,46 @@ describe("conversation deletion", () => {
     });
   });
 });
+
+describe("conversation persistence", () => {
+  it("writes snapshots sequentially so older queued state cannot overwrite newer state", async () => {
+    let releaseFirstWrite: (() => void) | undefined;
+    const firstWrite = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+    bridge.invoke.mockImplementation((command: string) => {
+      if (command === "app_data_write" && bridge.invoke.mock.calls.filter(([name]) => name === "app_data_write").length === 1) {
+        return firstWrite;
+      }
+      return Promise.resolve(null);
+    });
+
+    const { useStore } = await import("./store");
+    const chat = conversation("chat", "codex", 1);
+    useStore.setState({
+      agentId: "codex",
+      conversations: [chat],
+      activeConvId: { codex: chat.id },
+    });
+
+    useStore.getState().renameConversation(chat.id, "queued snapshot");
+    await vi.waitFor(() => {
+      expect(bridge.invoke.mock.calls.filter(([command]) => command === "app_data_write")).toHaveLength(1);
+    });
+
+    useStore.getState().renameConversation(chat.id, "streaming snapshot");
+    await Promise.resolve();
+    expect(bridge.invoke.mock.calls.filter(([command]) => command === "app_data_write")).toHaveLength(1);
+
+    releaseFirstWrite?.();
+    await vi.waitFor(() => {
+      expect(bridge.invoke.mock.calls.filter(([command]) => command === "app_data_write")).toHaveLength(2);
+    });
+
+    const writes = bridge.invoke.mock.calls.filter(([command]) => command === "app_data_write");
+    const first = JSON.parse(String(writes[0]?.[1]?.content)) as Conversation[];
+    const second = JSON.parse(String(writes[1]?.[1]?.content)) as Conversation[];
+    expect(first[0]?.title).toBe("queued snapshot");
+    expect(second[0]?.title).toBe("streaming snapshot");
+  });
+});

--- a/src/store.ts
+++ b/src/store.ts
@@ -555,8 +555,24 @@ async function waitForLocalNextctlIdle(getState: () => State): Promise<void> {
   }
 }
 
-function persistConvs(conversations: Conversation[]) {
-  void saveJson("conversations.json", serializeConversations(conversations));
+let conversationWriteTail: Promise<void> = Promise.resolve();
+
+function persistConvs(conversations: Conversation[]): Promise<void> {
+  const snapshot = serializeConversations(conversations);
+  conversationWriteTail = conversationWriteTail
+    .catch(() => {
+      // A failed write must not prevent newer state from being persisted.
+    })
+    .then(() => saveJson("conversations.json", snapshot));
+  // Most state updates intentionally do not block on disk IO. Attach a handler
+  // so those writes cannot create unhandled rejections; callers that need a
+  // durability boundary can still await the original promise.
+  void conversationWriteTail.catch(() => {});
+  return conversationWriteTail;
+}
+
+function flushConversations(): Promise<void> {
+  return conversationWriteTail;
 }
 
 function persistSchedules(runs: ScheduledRun[]) {
@@ -1315,6 +1331,27 @@ export const useStore = create<State>((set, get) => {
     }));
     replyExecutionTargets.set(item.replyId, item.executionTarget);
     get().setMessageStatus(item.conversationId, item.replyId, "streaming");
+    try {
+      // Persist the dispatched state before spawning the agent. Otherwise an
+      // app restart can restore the older queued snapshot and send the same
+      // user prompt a second time.
+      await flushConversations();
+    } catch {
+      replyExecutionTargets.delete(item.replyId);
+      get().setMessageStatus(
+        item.conversationId,
+        item.replyId,
+        "failed",
+        "The request was not sent because its state could not be saved.",
+      );
+      set((s) => ({
+        runtime: {
+          ...s.runtime,
+          [agentId]: { ...s.runtime[agentId], runningReplyId: undefined },
+        },
+      }));
+      return;
+    }
     trackEvent("agent_turn_started", {
       agent: agentId,
       has_profile: !!get().selectedProfile,

--- a/src/styles.css
+++ b/src/styles.css
@@ -2767,6 +2767,7 @@ code { background: var(--surface-4); padding: 1px 5px; border-radius: 4px; }
   align-items: center;
   gap: 10px;
   padding: 11px 12px;
+  margin-bottom: 8px;
   border: 1px solid var(--line);
   border-radius: var(--radius-md);
   background: var(--surface-1);


### PR DESCRIPTION
Adds the same 8px vertical spacing below Terminal chat that already separates Agent from Terminal chat.

Verification: npm run build.