### PR TITLE
Update Discord invite in README translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a change. Use the structu
 
 ## Community and support
 
-- Join the [Nextbrowser Discord](https://discord.gg/jfYjwJQdQ) for community chat, setup help, and product updates.
+- Join the [Nextbrowser Discord](https://discord.gg/qnKUKMvGB9) for community chat, setup help, and product updates.
 - Ask general questions and share ideas in [GitHub Discussions](https://github.com/nextbrowser-oss/nextbrowser-app/discussions).
 - Use [GitHub Issues](https://github.com/nextbrowser-oss/nextbrowser-app/issues) for actionable, scoped work.
 - Follow [SECURITY.md](SECURITY.md) for private vulnerability reporting; do not publish security details in an issue.

--- a/docs/i18n/ar/README.md
+++ b/docs/i18n/ar/README.md
@@ -128,7 +128,7 @@ Nextbrowser هو سطح التحكم المكتبي. تحدد الملفات ا�
 
 ## المجتمع والدعم
 
-- انضم إلى [Discord الخاص بـ Nextbrowser](https://discord.gg/jfYjwJQdQ) للتواصل مع المجتمع والحصول على مساعدة في الإعداد ومتابعة تحديثات المنتج.
+- انضم إلى [Discord الخاص بـ Nextbrowser](https://discord.gg/qnKUKMvGB9) للتواصل مع المجتمع والحصول على مساعدة في الإعداد ومتابعة تحديثات المنتج.
 - اطرح الأسئلة العامة وشارك الأفكار في [GitHub Discussions](https://github.com/nextbrowser-oss/nextbrowser-app/discussions).
 - استخدم [GitHub Issues](https://github.com/nextbrowser-oss/nextbrowser-app/issues) للعمل القابل للتنفيذ والمحدد النطاق.
 - اتبع [SECURITY.md](../../../SECURITY.md) للإبلاغ الخاص عن الثغرات؛ لا تنشر تفاصيل الأمان في issue.

--- a/docs/i18n/de/README.md
+++ b/docs/i18n/de/README.md
@@ -127,7 +127,7 @@ Lies [CONTRIBUTING.md](../../../CONTRIBUTING.md), bevor du eine Änderung einrei
 
 ## Community und Support
 
-- Tritt dem [Nextbrowser Discord](https://discord.gg/jfYjwJQdQ) bei, um dich mit der Community auszutauschen, Hilfe bei der Einrichtung zu erhalten und Produktneuigkeiten zu verfolgen.
+- Tritt dem [Nextbrowser Discord](https://discord.gg/qnKUKMvGB9) bei, um dich mit der Community auszutauschen, Hilfe bei der Einrichtung zu erhalten und Produktneuigkeiten zu verfolgen.
 - Stelle allgemeine Fragen und teile Ideen in [GitHub Discussions](https://github.com/nextbrowser-oss/nextbrowser-app/discussions).
 - Nutze [GitHub Issues](https://github.com/nextbrowser-oss/nextbrowser-app/issues) für umsetzbare, klar abgegrenzte Arbeit.
 - Befolge [SECURITY.md](../../../SECURITY.md), um Schwachstellen vertraulich zu melden; veröffentliche keine Sicherheitsdetails in einem Issue.

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -127,7 +127,7 @@ Lee [CONTRIBUTING.md](../../../CONTRIBUTING.md) antes de abrir un cambio. Utiliz
 
 ## Comunidad y soporte
 
-- Únete al [Discord de Nextbrowser](https://discord.gg/jfYjwJQdQ) para conversar con la comunidad, obtener ayuda con la configuración y recibir novedades del producto.
+- Únete al [Discord de Nextbrowser](https://discord.gg/qnKUKMvGB9) para conversar con la comunidad, obtener ayuda con la configuración y recibir novedades del producto.
 - Haz preguntas generales y comparte ideas en [GitHub Discussions](https://github.com/nextbrowser-oss/nextbrowser-app/discussions).
 - Utiliza [GitHub Issues](https://github.com/nextbrowser-oss/nextbrowser-app/issues) para trabajo accionable y bien delimitado.
 - Sigue [SECURITY.md](../../../SECURITY.md) para informar vulnerabilidades de forma privada; no publiques detalles de seguridad en un issue.

--- a/docs/i18n/fa/README.md
+++ b/docs/i18n/fa/README.md
@@ -128,7 +128,7 @@ Nextbrowser سطح کنترل دسکتاپ است. پروفایل‌ها هوی�
 
 ## جامعه و پشتیبانی
 
-- برای گفت‌وگو با جامعه، دریافت راهنمایی راه‌اندازی و دنبال‌کردن به‌روزرسانی‌های محصول به [Discord نکست‌براوزر](https://discord.gg/jfYjwJQdQ) بپیوندید.
+- برای گفت‌وگو با جامعه، دریافت راهنمایی راه‌اندازی و دنبال‌کردن به‌روزرسانی‌های محصول به [Discord نکست‌براوزر](https://discord.gg/qnKUKMvGB9) بپیوندید.
 - پرسش‌های عمومی را مطرح و ایده‌ها را در [GitHub Discussions](https://github.com/nextbrowser-oss/nextbrowser-app/discussions) به اشتراک بگذارید.
 - برای کارهای اقدام‌پذیر و دارای محدوده مشخص از [GitHub Issues](https://github.com/nextbrowser-oss/nextbrowser-app/issues) استفاده کنید.
 - برای گزارش خصوصی آسیب‌پذیری از [SECURITY.md](../../../SECURITY.md) پیروی کنید؛ جزئیات امنیتی را در issue منتشر نکنید.

--- a/docs/i18n/fr/README.md
+++ b/docs/i18n/fr/README.md
@@ -127,7 +127,7 @@ Lisez [CONTRIBUTING.md](../../../CONTRIBUTING.md) avant de proposer une modifica
 
 ## Communauté et assistance
 
-- Rejoignez le [Discord Nextbrowser](https://discord.gg/jfYjwJQdQ) pour échanger avec la communauté, obtenir de l’aide à la configuration et suivre les actualités du produit.
+- Rejoignez le [Discord Nextbrowser](https://discord.gg/qnKUKMvGB9) pour échanger avec la communauté, obtenir de l’aide à la configuration et suivre les actualités du produit.
 - Posez vos questions générales et partagez vos idées dans [GitHub Discussions](https://github.com/nextbrowser-oss/nextbrowser-app/discussions).
 - Utilisez les [GitHub Issues](https://github.com/nextbrowser-oss/nextbrowser-app/issues) pour un travail exploitable et bien délimité.
 - Suivez [SECURITY.md](../../../SECURITY.md) pour signaler une vulnérabilité en privé ; ne publiez pas de détails de sécurité dans un issue.

--- a/docs/i18n/hi/README.md
+++ b/docs/i18n/hi/README.md
@@ -127,7 +127,7 @@ Change खोलने से पहले [CONTRIBUTING.md](../../../CONTRIBUTI
 
 ## समुदाय और सहायता
 
-- समुदाय से बातचीत, सेटअप सहायता और उत्पाद अपडेट के लिए [Nextbrowser Discord](https://discord.gg/jfYjwJQdQ) से जुड़ें।
+- समुदाय से बातचीत, सेटअप सहायता और उत्पाद अपडेट के लिए [Nextbrowser Discord](https://discord.gg/qnKUKMvGB9) से जुड़ें।
 - सामान्य प्रश्न पूछने और विचार साझा करने के लिए [GitHub Discussions](https://github.com/nextbrowser-oss/nextbrowser-app/discussions) का उपयोग करें।
 - Actionable और स्पष्ट दायरे वाले कार्य के लिए [GitHub Issues](https://github.com/nextbrowser-oss/nextbrowser-app/issues) का उपयोग करें।
 - Vulnerability की private reporting के लिए [SECURITY.md](../../../SECURITY.md) का पालन करें; issue में security details प्रकाशित न करें।

--- a/docs/i18n/id/README.md
+++ b/docs/i18n/id/README.md
@@ -128,7 +128,7 @@ Baca [CONTRIBUTING.md](../../../CONTRIBUTING.md) sebelum membuka perubahan. Guna
 
 ## Komunitas dan dukungan
 
-- Bergabunglah dengan [Discord Nextbrowser](https://discord.gg/jfYjwJQdQ) untuk berdiskusi dengan komunitas, mendapatkan bantuan penyiapan, dan mengikuti pembaruan produk.
+- Bergabunglah dengan [Discord Nextbrowser](https://discord.gg/qnKUKMvGB9) untuk berdiskusi dengan komunitas, mendapatkan bantuan penyiapan, dan mengikuti pembaruan produk.
 - Ajukan pertanyaan umum dan bagikan ide di [GitHub Discussions](https://github.com/nextbrowser-oss/nextbrowser-app/discussions).
 - Gunakan [GitHub Issues](https://github.com/nextbrowser-oss/nextbrowser-app/issues) untuk pekerjaan yang dapat ditindaklanjuti dan memiliki cakupan jelas.
 - Ikuti [SECURITY.md](../../../SECURITY.md) untuk pelaporan kerentanan secara privat; jangan publikasikan detail keamanan dalam issue.

--- a/docs/i18n/it/README.md
+++ b/docs/i18n/it/README.md
@@ -127,7 +127,7 @@ Leggi [CONTRIBUTING.md](../../../CONTRIBUTING.md) prima di proporre una modifica
 
 ## Community e supporto
 
-- Unisciti al [Discord di Nextbrowser](https://discord.gg/jfYjwJQdQ) per parlare con la community, ricevere assistenza per la configurazione e seguire gli aggiornamenti del prodotto.
+- Unisciti al [Discord di Nextbrowser](https://discord.gg/qnKUKMvGB9) per parlare con la community, ricevere assistenza per la configurazione e seguire gli aggiornamenti del prodotto.
 - Fai domande generali e condividi idee in [GitHub Discussions](https://github.com/nextbrowser-oss/nextbrowser-app/discussions).
 - Usa [GitHub Issues](https://github.com/nextbrowser-oss/nextbrowser-app/issues) per attività concrete e ben delimitate.
 - Segui [SECURITY.md](../../../SECURITY.md) per segnalare privatamente le vulnerabilità; non pubblicare dettagli di sicurezza in un issue.

--- a/docs/i18n/ja/README.md
+++ b/docs/i18n/ja/README.md
@@ -127,7 +127,7 @@ Nextbrowser はデスクトップの操作画面です。プロファイルが�
 
 ## コミュニティとサポート
 
-- [Nextbrowser Discord](https://discord.gg/jfYjwJQdQ) に参加して、コミュニティ交流、セットアップのサポート、製品の最新情報を確認してください。
+- [Nextbrowser Discord](https://discord.gg/qnKUKMvGB9) に参加して、コミュニティ交流、セットアップのサポート、製品の最新情報を確認してください。
 - 一般的な質問やアイデアの共有には [GitHub Discussions](https://github.com/nextbrowser-oss/nextbrowser-app/discussions) を利用してください。
 - 実行可能で範囲が明確な作業には [GitHub Issues](https://github.com/nextbrowser-oss/nextbrowser-app/issues) を使用してください。
 - 脆弱性の非公開報告については [SECURITY.md](../../../SECURITY.md) に従い、issue にセキュリティの詳細を投稿しないでください。

--- a/docs/i18n/ko/README.md
+++ b/docs/i18n/ko/README.md
@@ -127,7 +127,7 @@ Nextbrowser는 데스크톱 제어 화면입니다. 프로필은 브라우저 ID
 
 ## 커뮤니티 및 지원
 
-- [Nextbrowser Discord](https://discord.gg/jfYjwJQdQ)에 참여해 커뮤니티 대화, 설정 도움말, 제품 업데이트를 확인하세요.
+- [Nextbrowser Discord](https://discord.gg/qnKUKMvGB9)에 참여해 커뮤니티 대화, 설정 도움말, 제품 업데이트를 확인하세요.
 - 일반적인 질문과 아이디어 공유에는 [GitHub Discussions](https://github.com/nextbrowser-oss/nextbrowser-app/discussions)를 이용하세요.
 - 실행 가능하고 범위가 명확한 작업에는 [GitHub Issues](https://github.com/nextbrowser-oss/nextbrowser-app/issues)를 사용하세요.
 - 취약점은 [SECURITY.md](../../../SECURITY.md)에 따라 비공개로 신고하고, issue에 보안 세부 정보를 게시하지 마세요.

--- a/docs/i18n/nl/README.md
+++ b/docs/i18n/nl/README.md
@@ -127,7 +127,7 @@ Lees [CONTRIBUTING.md](../../../CONTRIBUTING.md) voordat je een wijziging indien
 
 ## Community en ondersteuning
 
-- Word lid van de [Nextbrowser Discord](https://discord.gg/jfYjwJQdQ) voor gesprekken met de community, hulp bij de installatie en productupdates.
+- Word lid van de [Nextbrowser Discord](https://discord.gg/qnKUKMvGB9) voor gesprekken met de community, hulp bij de installatie en productupdates.
 - Stel algemene vragen en deel ideeën in [GitHub Discussions](https://github.com/nextbrowser-oss/nextbrowser-app/discussions).
 - Gebruik [GitHub Issues](https://github.com/nextbrowser-oss/nextbrowser-app/issues) voor uitvoerbaar, afgebakend werk.
 - Volg [SECURITY.md](../../../SECURITY.md) om kwetsbaarheden privé te melden; publiceer geen beveiligingsdetails in een issue.

--- a/docs/i18n/pl/README.md
+++ b/docs/i18n/pl/README.md
@@ -127,7 +127,7 @@ Przed zaproponowaniem zmiany przeczytaj [CONTRIBUTING.md](../../../CONTRIBUTING.
 
 ## Społeczność i pomoc
 
-- Dołącz do [Discorda Nextbrowser](https://discord.gg/jfYjwJQdQ), aby rozmawiać ze społecznością, uzyskać pomoc w konfiguracji i śledzić aktualizacje produktu.
+- Dołącz do [Discorda Nextbrowser](https://discord.gg/qnKUKMvGB9), aby rozmawiać ze społecznością, uzyskać pomoc w konfiguracji i śledzić aktualizacje produktu.
 - Zadawaj pytania ogólne i udostępniaj pomysły w [GitHub Discussions](https://github.com/nextbrowser-oss/nextbrowser-app/discussions).
 - Używaj [GitHub Issues](https://github.com/nextbrowser-oss/nextbrowser-app/issues) do zadań wykonalnych i precyzyjnie określonych.
 - Postępuj zgodnie z [SECURITY.md](../../../SECURITY.md), aby prywatnie zgłaszać luki; nie publikuj szczegółów bezpieczeństwa w issue.

--- a/docs/i18n/pt-BR/README.md
+++ b/docs/i18n/pt-BR/README.md
@@ -127,7 +127,7 @@ Leia [CONTRIBUTING.md](../../../CONTRIBUTING.md) antes de abrir uma alteração.
 
 ## Comunidade e suporte
 
-- Entre no [Discord do Nextbrowser](https://discord.gg/jfYjwJQdQ) para conversar com a comunidade, obter ajuda de configuração e acompanhar novidades do produto.
+- Entre no [Discord do Nextbrowser](https://discord.gg/qnKUKMvGB9) para conversar com a comunidade, obter ajuda de configuração e acompanhar novidades do produto.
 - Faça perguntas gerais e compartilhe ideias no [GitHub Discussions](https://github.com/nextbrowser-oss/nextbrowser-app/discussions).
 - Use [GitHub Issues](https://github.com/nextbrowser-oss/nextbrowser-app/issues) para trabalho acionável e com escopo definido.
 - Siga o [SECURITY.md](../../../SECURITY.md) para relatar vulnerabilidades de forma privada; não publique detalhes de segurança em um issue.

--- a/docs/i18n/ru/README.md
+++ b/docs/i18n/ru/README.md
@@ -128,7 +128,7 @@ Nextbrowser — это рабочая поверхность для управл
 
 ## Сообщество и поддержка
 
-- Присоединяйтесь к [Discord Nextbrowser](https://discord.gg/jfYjwJQdQ) для общения с сообществом, помощи с настройкой и новостей продукта.
+- Присоединяйтесь к [Discord Nextbrowser](https://discord.gg/qnKUKMvGB9) для общения с сообществом, помощи с настройкой и новостей продукта.
 - Задавайте общие вопросы и делитесь идеями в [GitHub Discussions](https://github.com/nextbrowser-oss/nextbrowser-app/discussions).
 - Используйте [GitHub Issues](https://github.com/nextbrowser-oss/nextbrowser-app/issues) для конкретной работы с чёткими границами.
 - Следуйте [SECURITY.md](../../../SECURITY.md) для приватного сообщения об уязвимостях; не публикуйте сведения о безопасности в issue.

--- a/docs/i18n/th/README.md
+++ b/docs/i18n/th/README.md
@@ -127,7 +127,7 @@ Nextbrowser คือพื้นผิวควบคุมบนเดสก�
 
 ## ชุมชนและการสนับสนุน
 
-- เข้าร่วม [Discord ของ Nextbrowser](https://discord.gg/jfYjwJQdQ) เพื่อพูดคุยกับชุมชน รับความช่วยเหลือในการตั้งค่า และติดตามอัปเดตผลิตภัณฑ์
+- เข้าร่วม [Discord ของ Nextbrowser](https://discord.gg/qnKUKMvGB9) เพื่อพูดคุยกับชุมชน รับความช่วยเหลือในการตั้งค่า และติดตามอัปเดตผลิตภัณฑ์
 - ถามคำถามทั่วไปและแบ่งปันแนวคิดใน [GitHub Discussions](https://github.com/nextbrowser-oss/nextbrowser-app/discussions)
 - ใช้ [GitHub Issues](https://github.com/nextbrowser-oss/nextbrowser-app/issues) สำหรับงานที่ดำเนินการได้และมีขอบเขตชัดเจน
 - ปฏิบัติตาม [SECURITY.md](../../../SECURITY.md) เพื่อรายงานช่องโหว่เป็นการส่วนตัว อย่าเผยแพร่รายละเอียดด้าน security ใน issue

--- a/docs/i18n/tr/README.md
+++ b/docs/i18n/tr/README.md
@@ -128,7 +128,7 @@ Bir değişiklik açmadan önce [CONTRIBUTING.md](../../../CONTRIBUTING.md) dosy
 
 ## Topluluk ve destek
 
-- Topluluk sohbeti, kurulum yardımı ve ürün güncellemeleri için [Nextbrowser Discord](https://discord.gg/jfYjwJQdQ) sunucusuna katılın.
+- Topluluk sohbeti, kurulum yardımı ve ürün güncellemeleri için [Nextbrowser Discord](https://discord.gg/qnKUKMvGB9) sunucusuna katılın.
 - Genel soruları sorun ve fikirlerinizi [GitHub Discussions](https://github.com/nextbrowser-oss/nextbrowser-app/discussions) üzerinde paylaşın.
 - Eyleme dönük, kapsamı belirli işler için [GitHub Issues](https://github.com/nextbrowser-oss/nextbrowser-app/issues) kullanın.
 - Güvenlik açıklarını gizli bildirmek için [SECURITY.md](../../../SECURITY.md) dosyasını izleyin; güvenlik ayrıntılarını bir issue içinde yayımlamayın.

--- a/docs/i18n/uk/README.md
+++ b/docs/i18n/uk/README.md
@@ -128,7 +128,7 @@ Nextbrowser — це десктопна поверхня керування. П�
 
 ## Спільнота та підтримка
 
-- Приєднуйтеся до [Discord Nextbrowser](https://discord.gg/jfYjwJQdQ) для спілкування зі спільнотою, допомоги з налаштуванням і новин продукту.
+- Приєднуйтеся до [Discord Nextbrowser](https://discord.gg/qnKUKMvGB9) для спілкування зі спільнотою, допомоги з налаштуванням і новин продукту.
 - Ставте загальні запитання та діліться ідеями в [GitHub Discussions](https://github.com/nextbrowser-oss/nextbrowser-app/discussions).
 - Використовуйте [GitHub Issues](https://github.com/nextbrowser-oss/nextbrowser-app/issues) для конкретної роботи з чіткими межами.
 - Дотримуйтеся [SECURITY.md](../../../SECURITY.md) для приватного повідомлення про вразливості; не публікуйте відомості про безпеку в issue.

--- a/docs/i18n/vi/README.md
+++ b/docs/i18n/vi/README.md
@@ -127,7 +127,7 @@ Công việc roadmap được theo dõi qua [GitHub Issues](https://github.com/n
 
 ## Cộng đồng và hỗ trợ
 
-- Tham gia [Discord Nextbrowser](https://discord.gg/jfYjwJQdQ) để trò chuyện cùng cộng đồng, nhận trợ giúp thiết lập và theo dõi cập nhật sản phẩm.
+- Tham gia [Discord Nextbrowser](https://discord.gg/qnKUKMvGB9) để trò chuyện cùng cộng đồng, nhận trợ giúp thiết lập và theo dõi cập nhật sản phẩm.
 - Đặt câu hỏi chung và chia sẻ ý tưởng trong [GitHub Discussions](https://github.com/nextbrowser-oss/nextbrowser-app/discussions).
 - Dùng [GitHub Issues](https://github.com/nextbrowser-oss/nextbrowser-app/issues) cho công việc có thể thực hiện và có phạm vi rõ ràng.
 - Làm theo [SECURITY.md](../../../SECURITY.md) để báo cáo lỗ hổng một cách riêng tư; không đăng chi tiết bảo mật trong issue.

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -127,7 +127,7 @@ Nextbrowser 是桌面控制界面。Profile 定义浏览器身份，session 提�
 
 ## 社区与支持
 
-- 加入 [Nextbrowser Discord](https://discord.gg/jfYjwJQdQ)，参与社区交流、获取配置帮助和产品更新。
+- 加入 [Nextbrowser Discord](https://discord.gg/qnKUKMvGB9)，参与社区交流、获取配置帮助和产品更新。
 - 在 [GitHub Discussions](https://github.com/nextbrowser-oss/nextbrowser-app/discussions) 中提出一般问题并分享想法。
 - 使用 [GitHub Issues](https://github.com/nextbrowser-oss/nextbrowser-app/issues) 跟踪可执行且范围明确的工作。
 - 按照 [SECURITY.md](../../../SECURITY.md) 私下报告漏洞；不要在 issue 中发布安全细节。


### PR DESCRIPTION
### Summary
- update the Discord invite in the main README
- keep all translated README files aligned

Docs-only change.