### PR TITLE
Harden and polish terminal chat

### DIFF
--- a/electron/agent-workspace.cjs
+++ b/electron/agent-workspace.cjs
@@ -1,0 +1,9 @@
+const path = require("node:path");
+
+function agentWorkspaceDir(homeDir) {
+  const resolvedHome = String(homeDir || "").trim();
+  if (!resolvedHome) throw new Error("A home directory is required for the agent workspace.");
+  return path.join(resolvedHome, ".nextbrowser", "workspace");
+}
+
+module.exports = { agentWorkspaceDir };

--- a/electron/agent-workspace.test.cjs
+++ b/electron/agent-workspace.test.cjs
@@ -1,0 +1,19 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const { agentWorkspaceDir } = require("./agent-workspace.cjs");
+
+test("agent workspace stays outside macOS Library and protected user folders", () => {
+  const workspace = agentWorkspaceDir("/Users/alice");
+
+  assert.equal(workspace, path.join("/Users/alice", ".nextbrowser", "workspace"));
+  assert.equal(workspace.includes(`${path.sep}Library${path.sep}`), false);
+  for (const protectedFolder of ["Documents", "Downloads", "Desktop", "Music", "Pictures"]) {
+    assert.equal(workspace.includes(`${path.sep}${protectedFolder}${path.sep}`), false);
+  }
+});
+
+test("agent workspace requires an explicit home directory", () => {
+  assert.throws(() => agentWorkspaceDir(""), /home directory/i);
+});

--- a/electron/github-stars.cjs
+++ b/electron/github-stars.cjs
@@ -1,0 +1,18 @@
+const REPOSITORY_API_URL = "https://api.github.com/repos/nextbrowser-oss/nextbrowser-app";
+
+async function fetchGitHubStars(fetchImpl = globalThis.fetch, options = {}) {
+  const response = await fetchImpl(REPOSITORY_API_URL, {
+    headers: {
+      accept: "application/vnd.github+json",
+      "user-agent": "NextBrowser",
+    },
+    signal: options.signal,
+  });
+  if (!response.ok) return null;
+
+  const body = await response.json();
+  const count = body?.stargazers_count;
+  return Number.isInteger(count) && count >= 0 ? count : null;
+}
+
+module.exports = { REPOSITORY_API_URL, fetchGitHubStars };

--- a/electron/github-stars.test.cjs
+++ b/electron/github-stars.test.cjs
@@ -1,0 +1,29 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { REPOSITORY_API_URL, fetchGitHubStars } = require("./github-stars.cjs");
+
+test("returns the repository star count", async () => {
+  const count = await fetchGitHubStars(async (url, options) => {
+    assert.equal(url, REPOSITORY_API_URL);
+    assert.equal(options.headers["user-agent"], "NextBrowser");
+    return {
+      ok: true,
+      json: async () => ({ stargazers_count: 8 }),
+    };
+  });
+
+  assert.equal(count, 8);
+});
+
+test("returns null when GitHub responds with an error", async () => {
+  const count = await fetchGitHubStars(async () => ({ ok: false }));
+  assert.equal(count, null);
+});
+
+test("returns null for an invalid star count", async () => {
+  const count = await fetchGitHubStars(async () => ({
+    ok: true,
+    json: async () => ({ stargazers_count: "8" }),
+  }));
+  assert.equal(count, null);
+});

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -6,6 +6,9 @@ const fsSync = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const { randomUUID } = require("node:crypto");
+const { agentWorkspaceDir } = require("./agent-workspace.cjs");
+const { fetchGitHubStars } = require("./github-stars.cjs");
+const { ensureWorkspaceInstructions } = require("./workspace-instructions.cjs");
 const pty = require("node-pty");
 const {
   cancelAllCommands,
@@ -29,7 +32,14 @@ let nextctlInstallPromise = null;
 
 const TERMINAL_AGENTS = {
   claude: { binary: "claude", envVar: "CLAUDE_BIN" },
-  codex: { binary: "codex", envVar: "CODEX_BIN" },
+  // Terminal chat runs inside NextBrowser's dedicated workspace. Let Codex use
+  // browser MCP tools without prompting on every call, while retaining a
+  // workspace-write filesystem sandbox.
+  codex: {
+    binary: "codex",
+    envVar: "CODEX_BIN",
+    args: ["--ask-for-approval", "never", "--sandbox", "workspace-write"],
+  },
   hermes: { binary: "hermes", envVar: "HERMES_BIN" },
   kilo: { binary: "kilo", envVar: "KILO_BIN" },
   openclaw: { binary: "openclaw", envVar: "OPENCLAW_BIN" },
@@ -420,6 +430,13 @@ async function apiFetchJSON(baseURL, route, options = {}) {
 
 async function invokeCommand(command, args = {}) {
   switch (command) {
+    case "github_stars": {
+      try {
+        return await fetchGitHubStars(fetch, { signal: AbortSignal.timeout(5000) });
+      } catch {
+        return null;
+      }
+    }
     case "app_update_status": return appUpdateStatus;
     case "app_check_for_update": {
       await checkForAppUpdate();
@@ -600,7 +617,16 @@ async function invokeCommand(command, args = {}) {
       }
       return null;
     }
-    case "working_directory": { const dir = path.join(dataDir(), "workspace"); await fs.mkdir(dir, { recursive: true }); return dir; }
+    case "working_directory": {
+      // Keep coding-agent discovery outside ~/Library/Application Support.
+      // Agents walk parent directories for config/instruction files; inside
+      // Library that can make macOS attribute unrelated TCC access requests
+      // (Music, other apps' data, protected folders) to NextBrowser.
+      const dir = agentWorkspaceDir(home());
+      await fs.mkdir(dir, { recursive: true });
+      await ensureWorkspaceInstructions(dir);
+      return dir;
+    }
     case "agent_run": {
       const bin = resolveBinary(args.binary, args.envVar); if (!bin) throw new Error(`${args.binary} executable not found.`);
       const spec = commandSpec(bin, args.args || []); const child = spawn(spec.file, spec.args, { cwd: args.workingDir || undefined, env: childEnv(), windowsHide: true, stdio: [args.stdinText != null ? "pipe" : "ignore", "pipe", "pipe"] });
@@ -618,7 +644,7 @@ async function invokeCommand(command, args = {}) {
       const bin = resolveBinary(agent.binary, agent.envVar);
       if (!bin) throw new Error(`${agent.binary} CLI not found.`);
       const id = randomUUID();
-      const spec = commandSpec(bin, []);
+      const spec = commandSpec(bin, agent.args || []);
       const terminal = pty.spawn(spec.file, spec.args, {
         name: "xterm-256color",
         cols: Math.max(2, Math.min(500, Number(args.cols) || 80)),

--- a/electron/workspace-instructions.cjs
+++ b/electron/workspace-instructions.cjs
@@ -1,0 +1,48 @@
+const fs = require("node:fs/promises");
+const path = require("node:path");
+
+const START = "<!-- NEXTBROWSER MANAGED INSTRUCTIONS START -->";
+const END = "<!-- NEXTBROWSER MANAGED INSTRUCTIONS END -->";
+const MANAGED_INSTRUCTIONS = `${START}
+# NextBrowser browser workspace
+
+- For browser tasks, use the installed Clawbrowser CLI immediately. Prefer \`nbc\` when available and fall back to \`nextctl\`; check with \`command -v nbc || command -v nextctl\`.
+- Do not use another browser integration when the user asks for Clawbrowser or when the task is being run inside NextBrowser.
+- Use an explicit named profile for commands that act on a browser.
+- Authentication is managed by the NextBrowser app. Never search for, read, print, copy, or ask the user to paste API keys, tokens, environment variables, or Clawbrowser configuration files.
+- If a Clawbrowser command reports an authentication error, retry that command once. If it still fails, ask the user to reconnect their account in NextBrowser; do not troubleshoot by inspecting secrets.
+- Keep filesystem work inside this workspace unless the user explicitly supplies another exact path.
+${END}`;
+
+function mergeManagedInstructions(existing = "") {
+  const start = existing.indexOf(START);
+  const end = existing.indexOf(END);
+  if (start >= 0 && end >= start) {
+    return `${existing.slice(0, start)}${MANAGED_INSTRUCTIONS}${existing.slice(end + END.length)}`;
+  }
+  return existing.trim()
+    ? `${MANAGED_INSTRUCTIONS}\n\n${existing}`
+    : `${MANAGED_INSTRUCTIONS}\n`;
+}
+
+async function ensureWorkspaceInstructions(workspaceDir) {
+  for (const name of ["AGENTS.md", "CLAUDE.md"]) {
+    const file = path.join(workspaceDir, name);
+    let existing = "";
+    try {
+      existing = await fs.readFile(file, "utf8");
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+    const next = mergeManagedInstructions(existing);
+    if (next !== existing) await fs.writeFile(file, next, "utf8");
+  }
+}
+
+module.exports = {
+  END,
+  MANAGED_INSTRUCTIONS,
+  START,
+  ensureWorkspaceInstructions,
+  mergeManagedInstructions,
+};

--- a/electron/workspace-instructions.test.cjs
+++ b/electron/workspace-instructions.test.cjs
@@ -1,0 +1,22 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { mergeManagedInstructions, START, END } = require("./workspace-instructions.cjs");
+
+test("adds browser and secret-handling guidance", () => {
+  const result = mergeManagedInstructions("");
+  assert.match(result, /Prefer `nbc`/);
+  assert.match(result, /Never search for, read, print, copy/);
+});
+
+test("preserves user-authored instructions", () => {
+  const result = mergeManagedInstructions("# My rules\n\nKeep this.");
+  assert.match(result, /# My rules/);
+  assert.match(result, /Keep this\./);
+});
+
+test("updates the managed block without duplicating it", () => {
+  const result = mergeManagedInstructions(`${START}\nold\n${END}\n\nCustom`);
+  assert.equal(result.split(START).length - 1, 1);
+  assert.match(result, /Custom/);
+  assert.doesNotMatch(result, /\nold\n/);
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "dev": "concurrently -k \"vite --port 1421\" \"wait-on tcp:1421 && cross-env VITE_DEV_SERVER_URL=http://localhost:1421 electron .\"",
     "build": "tsc && vite build",
-    "test": "vitest run --exclude electron/command-runner.test.cjs --exclude electron/ssh-config.test.cjs --exclude electron/proxy-traffic.test.cjs && node --test electron/command-runner.test.cjs electron/ssh-config.test.cjs electron/proxy-traffic.test.cjs && node scripts/verify-pty.cjs",
+    "postinstall": "electron-builder install-app-deps",
+    "test": "vitest run --exclude electron/agent-workspace.test.cjs --exclude electron/workspace-instructions.test.cjs --exclude electron/github-stars.test.cjs --exclude electron/command-runner.test.cjs --exclude electron/ssh-config.test.cjs --exclude electron/proxy-traffic.test.cjs && node --test electron/agent-workspace.test.cjs electron/workspace-instructions.test.cjs electron/github-stars.test.cjs electron/command-runner.test.cjs electron/ssh-config.test.cjs electron/proxy-traffic.test.cjs && node scripts/verify-pty.cjs",
     "start": "electron .",
     "pack": "npm run build && electron-builder --dir",
     "dist": "npm run build && electron-builder --publish never",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import { DashboardKeyModal } from "./components/DashboardKeyModal";
 import { BrandLogo } from "./components/BrandLogo";
 import { Icon, Spinner } from "./components/Icon";
 import { AgentPicker } from "./components/AgentPicker";
-import { brandName, dashboardUrl, discordUrl, latestReleaseUrl, repoApiUrl, repoUrl } from "./constants";
+import { brandName, dashboardUrl, discordUrl, latestReleaseUrl, repoUrl } from "./constants";
 import { getPreviewMode, getPreviewTab } from "./preview";
 import { humanBytes, proxyFraction, type AppTab, type Conversation } from "./types";
 import { resolveTheme, type Theme } from "./theme";
@@ -116,7 +116,7 @@ function DiscordMark({ size = 17 }: { size?: number }) {
 }
 
 function formatStars(count?: number | null): string {
-  if (count == null) return "5";
+  if (count == null) return "—";
   if (count < 1000) return `${count}`;
   const rounded = count < 10_000 ? Math.round(count / 100) / 10 : Math.round(count / 1000);
   return `${rounded}k`;
@@ -157,14 +157,15 @@ function SocialButtons() {
   const [stars, setStars] = useState<number | null>(null);
 
   useEffect(() => {
-    const controller = new AbortController();
-    fetch(repoApiUrl, { signal: controller.signal })
-      .then((response) => (response.ok ? response.json() : null))
-      .then((data: { stargazers_count?: number } | null) => {
-        if (typeof data?.stargazers_count === "number") setStars(data.stargazers_count);
+    let cancelled = false;
+    invoke<number | null>("github_stars")
+      .then((count) => {
+        if (!cancelled && typeof count === "number") setStars(count);
       })
       .catch(() => undefined);
-    return () => controller.abort();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   return (

--- a/src/components/AgentTerminal.tsx
+++ b/src/components/AgentTerminal.tsx
@@ -12,6 +12,60 @@ interface AgentTerminalProps {
   onClose: () => void;
 }
 
+const DARK_TERMINAL_THEME = {
+  background: "#181818",
+  foreground: "#d9d9dc",
+  cursor: "#a5a6ff",
+  cursorAccent: "#181818",
+  selectionBackground: "#55578080",
+  black: "#242426",
+  red: "#ef6b73",
+  green: "#61c98b",
+  yellow: "#d7b76a",
+  blue: "#7697e8",
+  magenta: "#b48cdb",
+  cyan: "#64b8c5",
+  white: "#d9d9dc",
+  brightBlack: "#85858d",
+  brightRed: "#ff848b",
+  brightGreen: "#78dda0",
+  brightYellow: "#e9cb80",
+  brightBlue: "#91aff5",
+  brightMagenta: "#c8a2ec",
+  brightCyan: "#7bcbd6",
+  brightWhite: "#f4f4f5",
+};
+
+const LIGHT_TERMINAL_THEME = {
+  background: "#f7f7f8",
+  foreground: "#29292d",
+  cursor: "#5555d9",
+  cursorAccent: "#f7f7f8",
+  selectionBackground: "#b9baf080",
+  black: "#29292d",
+  red: "#b52c39",
+  green: "#247a48",
+  yellow: "#86630b",
+  blue: "#355fb3",
+  magenta: "#7745a2",
+  cyan: "#17717d",
+  white: "#e8e8ea",
+  brightBlack: "#707078",
+  brightRed: "#cf3e49",
+  brightGreen: "#318e56",
+  brightYellow: "#987316",
+  brightBlue: "#4972c7",
+  brightMagenta: "#8b59b5",
+  brightCyan: "#25838f",
+  brightWhite: "#ffffff",
+};
+
+function activeTerminalTheme() {
+  return document.documentElement.dataset.theme === "light"
+    ? LIGHT_TERMINAL_THEME
+    : DARK_TERMINAL_THEME;
+}
+
 export function AgentTerminal({ agentId, agentName, workingDir, onClose }: AgentTerminalProps) {
   const hostRef = useRef<HTMLDivElement>(null);
   const terminalIdRef = useRef<string>();
@@ -25,7 +79,6 @@ export function AgentTerminal({ agentId, agentName, workingDir, onClose }: Agent
     let removeData: (() => void) | undefined;
     let removeExit: (() => void) | undefined;
 
-    const dark = document.documentElement.dataset.theme !== "light";
     const terminal = new Terminal({
       cursorBlink: true,
       convertEol: true,
@@ -33,9 +86,7 @@ export function AgentTerminal({ agentId, agentName, workingDir, onClose }: Agent
       fontSize: 12,
       lineHeight: 1.25,
       scrollback: 10_000,
-      theme: dark
-        ? { background: "#171717", foreground: "#e7e7e7", cursor: "#8b8cff", selectionBackground: "#46466a" }
-        : { background: "#fbfbfb", foreground: "#252525", cursor: "#5555d9", selectionBackground: "#cfcff5" },
+      theme: activeTerminalTheme(),
     });
     const fit = new FitAddon();
     terminal.loadAddon(fit);
@@ -58,6 +109,13 @@ export function AgentTerminal({ agentId, agentName, workingDir, onClose }: Agent
     };
     const observer = new ResizeObserver(resize);
     observer.observe(host);
+    const themeObserver = new MutationObserver(() => {
+      terminal.options.theme = activeTerminalTheme();
+    });
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
     const input = terminal.onData((data) => {
       const id = terminalIdRef.current;
       if (id) void invoke("terminal_input", { id, data });
@@ -100,6 +158,7 @@ export function AgentTerminal({ agentId, agentName, workingDir, onClose }: Agent
     return () => {
       disposed = true;
       observer.disconnect();
+      themeObserver.disconnect();
       input.dispose();
       removeData?.();
       removeExit?.();

--- a/src/lib/composePrompt.test.ts
+++ b/src/lib/composePrompt.test.ts
@@ -120,8 +120,11 @@ describe("composePrompt VPS mode", () => {
       { nextctlAvailable: true },
     );
 
-    expect(prompt).toContain("which is already installed");
+    expect(prompt).toContain("installed Clawbrowser CLI");
     expect(prompt).toContain("Active NextBrowser profile: work");
+    expect(prompt).toContain("Browser tasks are browser-only");
+    expect(prompt).toContain("do not scan the user's home directory");
+    expect(prompt).toContain("do not use OS automation for Music");
     expect(prompt).not.toContain("Strict VPS remote-only mode");
   });
 
@@ -139,7 +142,7 @@ describe("composePrompt VPS mode", () => {
       { nextctlAvailable: true },
     );
 
-    expect(prompt).toContain("which is already installed");
+    expect(prompt).toContain("installed Clawbrowser CLI");
     expect(prompt).not.toContain("Strict VPS remote-only mode");
   });
 
@@ -154,7 +157,7 @@ describe("composePrompt VPS mode", () => {
       { nextctlAvailable: true },
     );
 
-    expect(prompt).toContain("which is already installed");
+    expect(prompt).toContain("installed Clawbrowser CLI");
     expect(prompt).not.toContain("Strict VPS remote-only mode");
   });
 
@@ -177,7 +180,7 @@ describe("composePrompt VPS mode", () => {
       { nextctlAvailable: true, executionTarget: "local" },
     );
 
-    expect(prompt).toContain("which is already installed");
+    expect(prompt).toContain("installed Clawbrowser CLI");
     expect(prompt).toContain("Active NextBrowser profile: work");
     expect(prompt).not.toContain("Strict VPS remote-only mode");
     expect(prompt).not.toContain(VPS_PROMPT_MARKER);

--- a/src/lib/composePrompt.ts
+++ b/src/lib/composePrompt.ts
@@ -3,11 +3,19 @@ import type { ExecutionTarget } from "./executionTarget";
 import { hasVPSPromptMarker } from "./vpsPrompt";
 
 const LOCAL_NEXTCTL_PROMPT =
-  "[You control the NextBrowser browser through the `nextctl` command-line tool, " +
-  "which is already installed. Use it (e.g. `nextctl open <url>`, " +
-  "`nextctl click`, `nextctl input`, `nextctl status`, `nextctl start`, " +
-  "`nextctl rotate`) to open pages, act on them, and manage sessions/proxies. " +
-  "Run `nextctl --help` if unsure of a subcommand.]";
+  "[You control the NextBrowser browser through the installed Clawbrowser CLI. " +
+  "Prefer `nbc` when available and fall back to `nextctl`; check with " +
+  "`command -v nbc || command -v nextctl`. Use that CLI to open pages, act on them, " +
+  "and manage sessions/proxies. Run its `--help` if unsure of a subcommand. " +
+  "Authentication is managed by NextBrowser: never search for, read, print, copy, " +
+  "or ask the user to paste API keys or Clawbrowser configuration. On an authentication " +
+  "error, retry once, then ask the user to reconnect their account in NextBrowser. " +
+  "Browser tasks are browser-only: " +
+  "do not scan the user's home directory, Library, Documents, Downloads, Desktop, mounted volumes, " +
+  "media libraries, or other applications' data; do not use OS automation for Music or other apps. " +
+  "Limit filesystem access to the current NextBrowser workspace and the specific agent/nextctl " +
+  "configuration files needed to run the requested browser task. If a task genuinely needs a local " +
+  "file outside the workspace, ask the user for that exact file instead of exploring folders.]";
 
 const MISSING_LOCAL_NEXTCTL_PROMPT =
   "[NextBrowser is installed, but the local `nextctl`/Clawbrowser components are missing or not on PATH. " +

--- a/src/styles.css
+++ b/src/styles.css
@@ -2056,19 +2056,19 @@ button, input, textarea, select { color: var(--text); }
   flex-direction: column;
   margin: 10px 12px 12px;
   overflow: hidden;
-  border: 1px solid var(--line);
+  border: 1px solid var(--line-strong);
   border-radius: var(--radius-lg);
-  background: #171717;
+  background: #181818;
   box-shadow: 0 8px 24px color-mix(in srgb, var(--shadow) 55%, transparent);
 }
 .agent-terminal-header {
   display: flex;
   align-items: center;
   gap: 7px;
-  min-height: 38px;
-  padding: 5px 8px 5px 11px;
-  border-bottom: 1px solid var(--line);
-  background: var(--surface-2);
+  min-height: 42px;
+  padding: 6px 10px 6px 12px;
+  border-bottom: 1px solid var(--line-strong);
+  background: var(--surface-3);
   color: var(--text);
   font-size: 12px;
 }
@@ -2084,11 +2084,11 @@ button, input, textarea, select { color: var(--text); }
   flex: 1;
   min-width: 0;
   min-height: 0;
-  padding: 8px 7px;
+  padding: 12px 10px 10px;
 }
 .agent-terminal-host .xterm { height: 100%; }
 .agent-terminal-host .xterm-viewport { scrollbar-color: var(--surface-8) transparent; }
-[data-theme="light"] .agent-terminal-panel { background: #fbfbfb; }
+[data-theme="light"] .agent-terminal-panel { background: #f7f7f8; }
 .msg { max-width: 80%; min-width: 0; overflow-wrap: anywhere; }
 .msg-system { text-align: center; color: var(--muted); font-size: 12px; }
 .msg-user-wrap { display: flex; justify-content: flex-end; }


### PR DESCRIPTION
## Summary

- run local agents in a dedicated `~/.nextbrowser/workspace` instead of macOS Application Support
- add managed Codex/Claude workspace guidance so browser tasks use Clawbrowser without inspecting API keys or protected folders
- start interactive Codex with no repeated approvals while retaining the `workspace-write` sandbox
- sync the embedded terminal palette with live theme changes and improve terminal contrast/separation
- fetch the live GitHub star count through Electron IPC instead of a CSP-blocked renderer request and remove the stale hardcoded fallback
- rebuild native Electron dependencies after install for reliable `node-pty` startup

## Validation

- `npm test` (160 Vitest tests, 28 Electron/Node tests, PTY smoke test)
- `npm run build`
- local Electron launch on macOS
- live GitHub star lookup returns the current count
- `nbc skill check --domain 999.md --json` succeeds without exposing credentials