### PR TITLE
Treat dotted browser hosts as websites

### DIFF
--- a/electron/agent-workspace.test.cjs
+++ b/electron/agent-workspace.test.cjs
@@ -32,3 +32,10 @@ test("terminal Codex keeps workspace isolation while allowing Clawbrowser networ
   assert.match(main, /\.local", "state", "clawbrowser"/);
   assert.doesNotMatch(main, /dangerously-bypass-approvals-and-sandbox/);
 });
+
+test("terminal chat is isolated by conversation", () => {
+  const terminal = fs.readFileSync(path.join(__dirname, "..", "src", "components", "AgentTerminal.tsx"), "utf8");
+  const chat = fs.readFileSync(path.join(__dirname, "..", "src", "components", "ChatView.tsx"), "utf8");
+  assert.match(terminal, /\[agentId, conversationId, workingDir\]/);
+  assert.match(chat, /conversationId=\{conv\?\.id\}/);
+});

--- a/electron/agent-workspace.test.cjs
+++ b/electron/agent-workspace.test.cjs
@@ -24,5 +24,9 @@ test("terminal Codex keeps workspace isolation while allowing Clawbrowser networ
   assert.match(main, /"--sandbox", "workspace-write"/);
   assert.match(main, /sandbox_workspace_write\.network_access=true/);
   assert.match(main, /default_tools_approval_mode="approve"/);
+  assert.match(main, /tools\.\$\{tool\}\.approval_mode="approve"/);
+  assert.match(main, /"--add-dir", dir/);
+  assert.match(main, /\.cache", "clawbrowser"/);
+  assert.match(main, /\.local", "share", "clawbrowser"/);
   assert.doesNotMatch(main, /dangerously-bypass-approvals-and-sandbox/);
 });

--- a/electron/agent-workspace.test.cjs
+++ b/electron/agent-workspace.test.cjs
@@ -25,6 +25,7 @@ test("terminal Codex keeps workspace isolation while allowing Clawbrowser networ
   assert.match(main, /"--sandbox", "workspace-write"/);
   assert.match(main, /sandbox_workspace_write\.network_access=true/);
   assert.match(main, /default_tools_approval_mode = "approve"/);
+  assert.match(main, /\[plugins\."browser@openai-bundled"\][\s\S]*enabled = false/);
   assert.match(main, /ensureCodexTerminalProfile\(\)/);
   assert.match(main, /"--add-dir", dir/);
   assert.match(main, /\.cache", "clawbrowser"/);

--- a/electron/agent-workspace.test.cjs
+++ b/electron/agent-workspace.test.cjs
@@ -23,8 +23,8 @@ test("terminal Codex keeps workspace isolation while allowing Clawbrowser networ
   const main = fs.readFileSync(path.join(__dirname, "main.cjs"), "utf8");
   assert.match(main, /"--sandbox", "workspace-write"/);
   assert.match(main, /sandbox_workspace_write\.network_access=true/);
-  assert.match(main, /default_tools_approval_mode="approve"/);
-  assert.match(main, /tools\.\$\{tool\}\.approval_mode="approve"/);
+  assert.match(main, /default_tools_approval_mode="auto"/);
+  assert.match(main, /tools\.\$\{tool\}\.approval_mode="auto"/);
   assert.match(main, /"--add-dir", dir/);
   assert.match(main, /\.cache", "clawbrowser"/);
   assert.match(main, /\.local", "share", "clawbrowser"/);

--- a/electron/agent-workspace.test.cjs
+++ b/electron/agent-workspace.test.cjs
@@ -21,11 +21,11 @@ test("agent workspace requires an explicit home directory", () => {
 
 test("terminal Codex keeps workspace isolation while allowing Clawbrowser network calls", () => {
   const main = fs.readFileSync(path.join(__dirname, "main.cjs"), "utf8");
+  assert.match(main, /"--profile", CODEX_TERMINAL_PROFILE/);
   assert.match(main, /"--sandbox", "workspace-write"/);
   assert.match(main, /sandbox_workspace_write\.network_access=true/);
-  assert.match(main, /approvals_reviewer="auto_review"/);
-  assert.match(main, /default_tools_approval_mode="auto"/);
-  assert.match(main, /tools\.\$\{tool\}\.approval_mode="auto"/);
+  assert.match(main, /default_tools_approval_mode = "approve"/);
+  assert.match(main, /ensureCodexTerminalProfile\(\)/);
   assert.match(main, /"--add-dir", dir/);
   assert.match(main, /\.cache", "clawbrowser"/);
   assert.match(main, /\.local", "share", "clawbrowser"/);

--- a/electron/agent-workspace.test.cjs
+++ b/electron/agent-workspace.test.cjs
@@ -23,5 +23,6 @@ test("terminal Codex keeps workspace isolation while allowing Clawbrowser networ
   const main = fs.readFileSync(path.join(__dirname, "main.cjs"), "utf8");
   assert.match(main, /"--sandbox", "workspace-write"/);
   assert.match(main, /sandbox_workspace_write\.network_access=true/);
+  assert.match(main, /default_tools_approval_mode="approve"/);
   assert.doesNotMatch(main, /dangerously-bypass-approvals-and-sandbox/);
 });

--- a/electron/agent-workspace.test.cjs
+++ b/electron/agent-workspace.test.cjs
@@ -1,4 +1,5 @@
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
 const path = require("node:path");
 const test = require("node:test");
 
@@ -16,4 +17,11 @@ test("agent workspace stays outside macOS Library and protected user folders", (
 
 test("agent workspace requires an explicit home directory", () => {
   assert.throws(() => agentWorkspaceDir(""), /home directory/i);
+});
+
+test("terminal Codex keeps workspace isolation while allowing Clawbrowser network calls", () => {
+  const main = fs.readFileSync(path.join(__dirname, "main.cjs"), "utf8");
+  assert.match(main, /"--sandbox", "workspace-write"/);
+  assert.match(main, /sandbox_workspace_write\.network_access=true/);
+  assert.doesNotMatch(main, /dangerously-bypass-approvals-and-sandbox/);
 });

--- a/electron/agent-workspace.test.cjs
+++ b/electron/agent-workspace.test.cjs
@@ -23,10 +23,12 @@ test("terminal Codex keeps workspace isolation while allowing Clawbrowser networ
   const main = fs.readFileSync(path.join(__dirname, "main.cjs"), "utf8");
   assert.match(main, /"--sandbox", "workspace-write"/);
   assert.match(main, /sandbox_workspace_write\.network_access=true/);
+  assert.match(main, /approvals_reviewer="auto_review"/);
   assert.match(main, /default_tools_approval_mode="auto"/);
   assert.match(main, /tools\.\$\{tool\}\.approval_mode="auto"/);
   assert.match(main, /"--add-dir", dir/);
   assert.match(main, /\.cache", "clawbrowser"/);
   assert.match(main, /\.local", "share", "clawbrowser"/);
+  assert.match(main, /\.local", "state", "clawbrowser"/);
   assert.doesNotMatch(main, /dangerously-bypass-approvals-and-sandbox/);
 });

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -47,9 +47,9 @@ function codexClawbrowserArgs() {
     "--ask-for-approval", "never",
     "--sandbox", "workspace-write",
     "-c", "sandbox_workspace_write.network_access=true",
-    "-c", `${pluginRoot}.default_tools_approval_mode="approve"`,
+    "-c", `${pluginRoot}.default_tools_approval_mode="auto"`,
     ...CLAWBROWSER_MCP_TOOLS.flatMap((tool) => [
-      "-c", `${pluginRoot}.tools.${tool}.approval_mode="approve"`,
+      "-c", `${pluginRoot}.tools.${tool}.approval_mode="auto"`,
     ]),
   ];
 }

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -31,7 +31,10 @@ let nextctlInstallStatus = { status: "idle" };
 let nextctlInstallPromise = null;
 
 const CODEX_TERMINAL_PROFILE = "nextbrowser";
-const CODEX_TERMINAL_PROFILE_CONTENT = `[plugins."clawbrowser@clawctl-local".mcp_servers.clawbrowser]
+const CODEX_TERMINAL_PROFILE_CONTENT = `[plugins."browser@openai-bundled"]
+enabled = false
+
+[plugins."clawbrowser@clawctl-local".mcp_servers.clawbrowser]
 default_tools_approval_mode = "approve"
 `;
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -30,29 +30,28 @@ let appUpdateTimer = null;
 let nextctlInstallStatus = { status: "idle" };
 let nextctlInstallPromise = null;
 
-const CLAWBROWSER_MCP_TOOLS = [
-  "doctor", "browser_performance", "site_recipe_save", "site_recipe_list",
-  "site_recipe_run", "start", "rotate", "status", "proxy_traffic_status",
-  "endpoint", "stop", "verify", "open", "open_url", "tabs_list",
-  "list_tabs", "tabs_activate", "tabs_close", "close_tabs",
-  "profiles_create", "profiles_list", "profiles_inspect", "profiles_rm",
-  "extensions_install", "state", "extract", "paginate_extract",
-  "tabs_extract", "click", "input", "press", "select", "scroll", "wait",
-  "screenshot", "dismiss", "captcha_solve",
-];
+const CODEX_TERMINAL_PROFILE = "nextbrowser";
+const CODEX_TERMINAL_PROFILE_CONTENT = `[plugins."clawbrowser@clawctl-local".mcp_servers.clawbrowser]
+default_tools_approval_mode = "approve"
+`;
 
 function codexClawbrowserArgs() {
-  const pluginRoot = 'plugins."clawbrowser@clawctl-local".mcp_servers.clawbrowser';
   return [
+    "--profile", CODEX_TERMINAL_PROFILE,
     "--ask-for-approval", "never",
     "--sandbox", "workspace-write",
     "-c", "sandbox_workspace_write.network_access=true",
-    "-c", 'approvals_reviewer="auto_review"',
-    "-c", `${pluginRoot}.default_tools_approval_mode="auto"`,
-    ...CLAWBROWSER_MCP_TOOLS.flatMap((tool) => [
-      "-c", `${pluginRoot}.tools.${tool}.approval_mode="auto"`,
-    ]),
   ];
+}
+
+async function ensureCodexTerminalProfile() {
+  const codexDir = String(process.env.CODEX_HOME || path.join(home(), ".codex"));
+  await fs.mkdir(codexDir, { recursive: true });
+  await fs.writeFile(
+    path.join(codexDir, `${CODEX_TERMINAL_PROFILE}.config.toml`),
+    CODEX_TERMINAL_PROFILE_CONTENT,
+    { encoding: "utf8", mode: 0o600 },
+  );
 }
 
 function clawbrowserWritableDirs() {
@@ -683,6 +682,7 @@ async function invokeCommand(command, args = {}) {
       if (!bin) throw new Error(`${agent.binary} CLI not found.`);
       const id = randomUUID();
       const writableDirs = args.agentId === "codex" ? clawbrowserWritableDirs() : [];
+      if (args.agentId === "codex") await ensureCodexTerminalProfile();
       await Promise.all(writableDirs.map((dir) => fs.mkdir(dir, { recursive: true })));
       const terminalArgs = [
         ...(agent.args || []),

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -30,6 +30,42 @@ let appUpdateTimer = null;
 let nextctlInstallStatus = { status: "idle" };
 let nextctlInstallPromise = null;
 
+const CLAWBROWSER_MCP_TOOLS = [
+  "doctor", "browser_performance", "site_recipe_save", "site_recipe_list",
+  "site_recipe_run", "start", "rotate", "status", "proxy_traffic_status",
+  "endpoint", "stop", "verify", "open", "open_url", "tabs_list",
+  "list_tabs", "tabs_activate", "tabs_close", "close_tabs",
+  "profiles_create", "profiles_list", "profiles_inspect", "profiles_rm",
+  "extensions_install", "state", "extract", "paginate_extract",
+  "tabs_extract", "click", "input", "press", "select", "scroll", "wait",
+  "screenshot", "dismiss", "captcha_solve",
+];
+
+function codexClawbrowserArgs() {
+  const pluginRoot = 'plugins."clawbrowser@clawctl-local".mcp_servers.clawbrowser';
+  return [
+    "--ask-for-approval", "never",
+    "--sandbox", "workspace-write",
+    "-c", "sandbox_workspace_write.network_access=true",
+    "-c", `${pluginRoot}.default_tools_approval_mode="approve"`,
+    ...CLAWBROWSER_MCP_TOOLS.flatMap((tool) => [
+      "-c", `${pluginRoot}.tools.${tool}.approval_mode="approve"`,
+    ]),
+  ];
+}
+
+function clawbrowserWritableDirs() {
+  if (process.platform === "win32") {
+    const localAppData = String(process.env.LOCALAPPDATA || path.join(home(), "AppData", "Local"));
+    return [path.join(localAppData, "Clawbrowser")];
+  }
+  return [
+    path.join(home(), ".cache", "clawbrowser"),
+    path.join(home(), ".config", "clawbrowser"),
+    path.join(home(), ".local", "share", "clawbrowser"),
+  ];
+}
+
 const TERMINAL_AGENTS = {
   claude: { binary: "claude", envVar: "CLAUDE_BIN" },
   // Terminal chat runs inside NextBrowser's dedicated workspace. Let Codex use
@@ -38,12 +74,7 @@ const TERMINAL_AGENTS = {
   codex: {
     binary: "codex",
     envVar: "CODEX_BIN",
-    args: [
-      "--ask-for-approval", "never",
-      "--sandbox", "workspace-write",
-      "-c", "sandbox_workspace_write.network_access=true",
-      "-c", 'plugins."clawbrowser@clawctl-local".mcp_servers.clawbrowser.default_tools_approval_mode="approve"',
-    ],
+    args: codexClawbrowserArgs(),
   },
   hermes: { binary: "hermes", envVar: "HERMES_BIN" },
   kilo: { binary: "kilo", envVar: "KILO_BIN" },
@@ -649,7 +680,13 @@ async function invokeCommand(command, args = {}) {
       const bin = resolveBinary(agent.binary, agent.envVar);
       if (!bin) throw new Error(`${agent.binary} CLI not found.`);
       const id = randomUUID();
-      const spec = commandSpec(bin, agent.args || []);
+      const writableDirs = args.agentId === "codex" ? clawbrowserWritableDirs() : [];
+      await Promise.all(writableDirs.map((dir) => fs.mkdir(dir, { recursive: true })));
+      const terminalArgs = [
+        ...(agent.args || []),
+        ...writableDirs.flatMap((dir) => ["--add-dir", dir]),
+      ];
+      const spec = commandSpec(bin, terminalArgs);
       const terminal = pty.spawn(spec.file, spec.args, {
         name: "xterm-256color",
         cols: Math.max(2, Math.min(500, Number(args.cols) || 80)),

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -42,6 +42,7 @@ const TERMINAL_AGENTS = {
       "--ask-for-approval", "never",
       "--sandbox", "workspace-write",
       "-c", "sandbox_workspace_write.network_access=true",
+      "-c", 'plugins."clawbrowser@clawctl-local".mcp_servers.clawbrowser.default_tools_approval_mode="approve"',
     ],
   },
   hermes: { binary: "hermes", envVar: "HERMES_BIN" },

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -38,7 +38,11 @@ const TERMINAL_AGENTS = {
   codex: {
     binary: "codex",
     envVar: "CODEX_BIN",
-    args: ["--ask-for-approval", "never", "--sandbox", "workspace-write"],
+    args: [
+      "--ask-for-approval", "never",
+      "--sandbox", "workspace-write",
+      "-c", "sandbox_workspace_write.network_access=true",
+    ],
   },
   hermes: { binary: "hermes", envVar: "HERMES_BIN" },
   kilo: { binary: "kilo", envVar: "KILO_BIN" },

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -47,6 +47,7 @@ function codexClawbrowserArgs() {
     "--ask-for-approval", "never",
     "--sandbox", "workspace-write",
     "-c", "sandbox_workspace_write.network_access=true",
+    "-c", 'approvals_reviewer="auto_review"',
     "-c", `${pluginRoot}.default_tools_approval_mode="auto"`,
     ...CLAWBROWSER_MCP_TOOLS.flatMap((tool) => [
       "-c", `${pluginRoot}.tools.${tool}.approval_mode="auto"`,
@@ -63,6 +64,7 @@ function clawbrowserWritableDirs() {
     path.join(home(), ".cache", "clawbrowser"),
     path.join(home(), ".config", "clawbrowser"),
     path.join(home(), ".local", "share", "clawbrowser"),
+    path.join(home(), ".local", "state", "clawbrowser"),
   ];
 }
 

--- a/electron/workspace-instructions.cjs
+++ b/electron/workspace-instructions.cjs
@@ -9,6 +9,7 @@ const MANAGED_INSTRUCTIONS = `${START}
 - For browser tasks, use the installed Clawbrowser CLI immediately. Prefer \`nbc\` when available and fall back to \`nextctl\`; check with \`command -v nbc || command -v nextctl\`.
 - Do not use another browser integration when the user asks for Clawbrowser or when the task is being run inside NextBrowser.
 - Use an explicit named profile for commands that act on a browser.
+- In a browser request, treat a dotted hostname such as \`999.md\` as a website, never as a local filename. Open bare hostnames as \`https://<host>\` unless the user explicitly says they mean a file or path.
 - Authentication is managed by the NextBrowser app. Never search for, read, print, copy, or ask the user to paste API keys, tokens, environment variables, or Clawbrowser configuration files.
 - If a Clawbrowser command reports an authentication error, retry that command once. If it still fails, ask the user to reconnect their account in NextBrowser; do not troubleshoot by inspecting secrets.
 - Keep filesystem work inside this workspace unless the user explicitly supplies another exact path.

--- a/electron/workspace-instructions.cjs
+++ b/electron/workspace-instructions.cjs
@@ -6,7 +6,11 @@ const END = "<!-- NEXTBROWSER MANAGED INSTRUCTIONS END -->";
 const MANAGED_INSTRUCTIONS = `${START}
 # NextBrowser browser workspace
 
-- For browser tasks, use the installed Clawbrowser CLI immediately. Prefer \`nbc\` when available and fall back to \`nextctl\`; check with \`command -v nbc || command -v nextctl\`.
+- For browser tasks, use the connected Clawbrowser MCP tools immediately when they are available. They keep one CDP connection warm. Use the CLI only when MCP is unavailable; then prefer \`nbc\` and fall back to \`nextctl\`.
+- Do not probe for the CLI, run a duplicate CLI \`start\`, or switch between CLI and MCP after a successful MCP call.
+- Start or reuse the requested profile exactly once. Pass the target URL to \`start\`; do not separately open the same URL unless navigation actually failed.
+- For catalogs, listings, and search results, use one \`paginate_extract\` call after the page is ready. Do not manually repeat \`scroll\` → \`wait\` → \`state\`; \`paginate_extract\` scrolls, waits, extracts, deduplicates, filters, and sorts in one operation.
+- Combine actions with \`wait_for\` and \`return_state: true\` when another decision is needed. Do not wait for \`load\` after a plain scroll because scrolling does not navigate.
 - Do not use another browser integration when the user asks for Clawbrowser or when the task is being run inside NextBrowser.
 - Inside NextBrowser, generic requests such as "open the browser", "use the browser", "открой браузер", or "используй браузер" mean Clawbrowser. Use another browser only when the user explicitly names it.
 - Use an explicit named profile for commands that act on a browser.

--- a/electron/workspace-instructions.cjs
+++ b/electron/workspace-instructions.cjs
@@ -8,6 +8,7 @@ const MANAGED_INSTRUCTIONS = `${START}
 
 - For browser tasks, use the installed Clawbrowser CLI immediately. Prefer \`nbc\` when available and fall back to \`nextctl\`; check with \`command -v nbc || command -v nextctl\`.
 - Do not use another browser integration when the user asks for Clawbrowser or when the task is being run inside NextBrowser.
+- Inside NextBrowser, generic requests such as "open the browser", "use the browser", "открой браузер", or "используй браузер" mean Clawbrowser. Use another browser only when the user explicitly names it.
 - Use an explicit named profile for commands that act on a browser.
 - In a browser request, treat a dotted hostname such as \`999.md\` as a website, never as a local filename. Open bare hostnames as \`https://<host>\` unless the user explicitly says they mean a file or path.
 - Authentication is managed by the NextBrowser app. Never search for, read, print, copy, or ask the user to paste API keys, tokens, environment variables, or Clawbrowser configuration files.

--- a/electron/workspace-instructions.cjs
+++ b/electron/workspace-instructions.cjs
@@ -8,7 +8,9 @@ const MANAGED_INSTRUCTIONS = `${START}
 
 - For browser tasks, use the connected Clawbrowser MCP tools immediately when they are available. They keep one CDP connection warm. Use the CLI only when MCP is unavailable; then prefer \`nbc\` and fall back to \`nextctl\`.
 - Do not probe for the CLI, run a duplicate CLI \`start\`, or switch between CLI and MCP after a successful MCP call.
+- Clawbrowser is the only browser integration enabled in Terminal Chat. Read only its browser skill; do not search for or read instructions for another browser integration.
 - Start or reuse the requested profile exactly once. Pass the target URL to \`start\`; do not separately open the same URL unless navigation actually failed.
+- Include \`wait_for: {"settle": true}\` and \`return_state: true\` in the same MCP \`start\` call when the next step needs page controls; do not issue separate \`wait\` and \`state\` calls.
 - For catalogs, listings, and search results, use one \`paginate_extract\` call after the page is ready. Do not manually repeat \`scroll\` → \`wait\` → \`state\`; \`paginate_extract\` scrolls, waits, extracts, deduplicates, filters, and sorts in one operation.
 - Combine actions with \`wait_for\` and \`return_state: true\` when another decision is needed. Do not wait for \`load\` after a plain scroll because scrolling does not navigate.
 - Do not use another browser integration when the user asks for Clawbrowser or when the task is being run inside NextBrowser.

--- a/electron/workspace-instructions.test.cjs
+++ b/electron/workspace-instructions.test.cjs
@@ -6,6 +6,7 @@ test("adds browser and secret-handling guidance", () => {
   const result = mergeManagedInstructions("");
   assert.match(result, /Prefer `nbc`/);
   assert.match(result, /Never search for, read, print, copy/);
+  assert.match(result, /`999\.md` as a website/);
 });
 
 test("preserves user-authored instructions", () => {

--- a/electron/workspace-instructions.test.cjs
+++ b/electron/workspace-instructions.test.cjs
@@ -4,7 +4,9 @@ const { mergeManagedInstructions, START, END } = require("./workspace-instructio
 
 test("adds browser and secret-handling guidance", () => {
   const result = mergeManagedInstructions("");
-  assert.match(result, /Prefer `nbc`/);
+  assert.match(result, /use the connected Clawbrowser MCP tools immediately/);
+  assert.match(result, /use one `paginate_extract` call/);
+  assert.match(result, /Do not wait for `load` after a plain scroll/);
   assert.match(result, /Never search for, read, print, copy/);
   assert.match(result, /`999\.md` as a website/);
   assert.match(result, /"открой браузер".*mean Clawbrowser/);

--- a/electron/workspace-instructions.test.cjs
+++ b/electron/workspace-instructions.test.cjs
@@ -5,7 +5,9 @@ const { mergeManagedInstructions, START, END } = require("./workspace-instructio
 test("adds browser and secret-handling guidance", () => {
   const result = mergeManagedInstructions("");
   assert.match(result, /use the connected Clawbrowser MCP tools immediately/);
+  assert.match(result, /Read only its browser skill/);
   assert.match(result, /use one `paginate_extract` call/);
+  assert.match(result, /same MCP `start` call/);
   assert.match(result, /Do not wait for `load` after a plain scroll/);
   assert.match(result, /Never search for, read, print, copy/);
   assert.match(result, /`999\.md` as a website/);

--- a/electron/workspace-instructions.test.cjs
+++ b/electron/workspace-instructions.test.cjs
@@ -7,6 +7,7 @@ test("adds browser and secret-handling guidance", () => {
   assert.match(result, /Prefer `nbc`/);
   assert.match(result, /Never search for, read, print, copy/);
   assert.match(result, /`999\.md` as a website/);
+  assert.match(result, /"открой браузер".*mean Clawbrowser/);
 });
 
 test("preserves user-authored instructions", () => {

--- a/src/components/AgentTerminal.tsx
+++ b/src/components/AgentTerminal.tsx
@@ -8,6 +8,7 @@ import { Icon, Spinner } from "./Icon";
 interface AgentTerminalProps {
   agentId: string;
   agentName: string;
+  conversationId?: string;
   workingDir?: string;
   onClose: () => void;
 }
@@ -66,7 +67,7 @@ function activeTerminalTheme() {
     : DARK_TERMINAL_THEME;
 }
 
-export function AgentTerminal({ agentId, agentName, workingDir, onClose }: AgentTerminalProps) {
+export function AgentTerminal({ agentId, agentName, conversationId, workingDir, onClose }: AgentTerminalProps) {
   const hostRef = useRef<HTMLDivElement>(null);
   const terminalIdRef = useRef<string>();
   const [status, setStatus] = useState<"starting" | "running" | "exited" | "failed">("starting");
@@ -167,7 +168,10 @@ export function AgentTerminal({ agentId, agentName, workingDir, onClose }: Agent
       if (id) void invoke("terminal_kill", { id });
       terminal.dispose();
     };
-  }, [agentId, workingDir]);
+  // A terminal is the interactive state of one chat, not a global agent
+  // process. Restart it when the selected conversation changes so pending
+  // input, scrollback, or an unfinished prompt cannot leak into another chat.
+  }, [agentId, conversationId, workingDir]);
 
   return (
     <section className="agent-terminal-panel" aria-label={`${agentName} terminal`}>

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -297,6 +297,7 @@ export function ChatView() {
           <AgentTerminal
             agentId={agentId}
             agentName={agentName}
+            conversationId={conv?.id}
             workingDir={s.workingDir}
             onClose={() => s.setTerminalChat(false)}
           />

--- a/src/lib/composePrompt.ts
+++ b/src/lib/composePrompt.ts
@@ -7,6 +7,9 @@ const LOCAL_NEXTCTL_PROMPT =
   "Prefer `nbc` when available and fall back to `nextctl`; check with " +
   "`command -v nbc || command -v nextctl`. Use that CLI to open pages, act on them, " +
   "and manage sessions/proxies. Run its `--help` if unsure of a subcommand. " +
+  "Inside NextBrowser, generic requests such as `open the browser`, `use the browser`, " +
+  "`открой браузер`, or `используй браузер` mean Clawbrowser; use another browser only " +
+  "when the user explicitly names it. " +
   "In browser requests, a dotted hostname such as `999.md` is a website, not a local file; " +
   "open a bare hostname as `https://<host>` unless the user explicitly asks for a file or path. " +
   "Authentication is managed by NextBrowser: never search for, read, print, copy, " +

--- a/src/lib/composePrompt.ts
+++ b/src/lib/composePrompt.ts
@@ -7,6 +7,8 @@ const LOCAL_NEXTCTL_PROMPT =
   "Prefer `nbc` when available and fall back to `nextctl`; check with " +
   "`command -v nbc || command -v nextctl`. Use that CLI to open pages, act on them, " +
   "and manage sessions/proxies. Run its `--help` if unsure of a subcommand. " +
+  "In browser requests, a dotted hostname such as `999.md` is a website, not a local file; " +
+  "open a bare hostname as `https://<host>` unless the user explicitly asks for a file or path. " +
   "Authentication is managed by NextBrowser: never search for, read, print, copy, " +
   "or ask the user to paste API keys or Clawbrowser configuration. On an authentication " +
   "error, retry once, then ask the user to reconnect their account in NextBrowser. " +

--- a/src/store.ts
+++ b/src/store.ts
@@ -1117,6 +1117,10 @@ export const useStore = create<State>((set, get) => {
   },
 
   tickNextctlDailyUpdate: async () => {
+    // A development build may intentionally point at a locally compiled nbc.
+    // Never replace that test binary with the latest published release while
+    // the app is running under Vite/Electron development mode.
+    if (import.meta.env.DEV) return;
     if (!get().nextctlAvailable) return;
     if (get().nextctlUpdating) return;
     if (pendingTarget(get(), "vps")) return;


### PR DESCRIPTION
## Summary
- tell terminal agents that dotted hostnames such as `999.md` are websites in browser requests
- reinforce the rule in both the per-message prompt and managed workspace instructions
- prevent unnecessary filesystem searches before Clawbrowser navigation

## Verification
- workspace instruction tests
- compose prompt tests
- production renderer build

Not merged; ready for local testing.