### PR TITLE
Experimental Browser Use CDP engine[DRAFT]

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -27,7 +27,12 @@ jobs:
         with:
           node-version: "22"
           cache: npm
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
       - run: npm ci
+      - run: python -m pip install -r browser-engine/requirements.txt
+      - run: python scripts/build-browser-engine.py
       - run: npm test
       - name: Configure macOS signing
         env:
@@ -88,7 +93,12 @@ jobs:
         with:
           node-version: "22"
           cache: npm
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
       - run: npm ci
+      - run: python -m pip install -r browser-engine/requirements.txt
+      - run: python scripts/build-browser-engine.py
       - run: npm test
       - name: Build Windows installer
         run: npm run dist:win

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,12 @@ jobs:
         with:
           node-version: "22"
           cache: npm
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
       - run: npm ci
+      - run: python -m pip install -r browser-engine/requirements.txt
+      - run: python scripts/build-browser-engine.py
       - run: npm test
       - run: npm run build
       - name: Package application without installer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,12 @@ jobs:
         with:
           node-version: "22"
           cache: npm
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
       - run: npm ci
+      - run: python -m pip install -r browser-engine/requirements.txt
+      - run: python scripts/build-browser-engine.py
       - name: Sync version from tag
         if: github.ref_type == 'tag'
         run: node scripts/sync-version.mjs ${{ github.ref_name }}
@@ -134,7 +139,12 @@ jobs:
         with:
           node-version: "22"
           cache: npm
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
       - run: npm ci
+      - run: python -m pip install -r browser-engine/requirements.txt
+      - run: python scripts/build-browser-engine.py
       - name: Sync version from tag
         if: github.ref_type == 'tag'
         run: node scripts/sync-version.mjs ${{ github.ref_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,8 @@ src-tauri/gen
 .DS_Store
 *.log
 screenshots
+browser-engine/build/
+browser-engine/dist/
+browser-engine/*.spec
 .xwin-cache
 xwin-cache

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ screenshots
 browser-engine/build/
 browser-engine/dist/
 browser-engine/*.spec
+__pycache__/
 .xwin-cache
 xwin-cache

--- a/browser-engine/LICENSE.browser-use
+++ b/browser-engine/LICENSE.browser-use
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Gregor Zunic
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/browser-engine/README.md
+++ b/browser-engine/README.md
@@ -1,0 +1,11 @@
+# Experimental browser engine
+
+This packaged MCP component exposes Browser Use's browser session, semantic DOM,
+and action primitives against an existing Clawbrowser CDP endpoint. It does not
+include Browser Use's Agent, prompts, LLM integrations, browser launcher, or
+cloud service. NextBrowser's selected agent remains the planner and `nextctl`
+remains responsible for profiles, proxy identity, CAPTCHA handling, and browser
+lifecycle.
+
+The component is optional and currently supported for Codex and Claude Code.
+Build it with `python scripts/build-browser-engine.py` before packaging the app.

--- a/browser-engine/requirements.txt
+++ b/browser-engine/requirements.txt
@@ -1,0 +1,3 @@
+browser-use[core]==0.13.7
+mcp==1.26.0
+pyinstaller==6.16.0

--- a/browser-engine/test_worker_verification.py
+++ b/browser-engine/test_worker_verification.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).parent))
+from verification import require_green_verification
+
+
+class VerificationContractTests(unittest.TestCase):
+    def test_accepts_green_requested_country(self):
+        result = require_green_verification({"data": {"verify": {
+            "finalized": True, "status": "pass",
+            "checks": [{"surface": "proxy", "pass": True, "expected": "US", "actual": "US (New York)"}],
+        }}}, "US")
+        self.assertEqual(result["status"], "pass")
+
+    def test_rejects_pending_failed_or_wrong_country(self):
+        cases = [
+            {"finalized": False, "visible_text": "Running checks"},
+            {"finalized": True, "status": "fail", "checks": [{"surface": "proxy", "pass": False}]},
+            {"finalized": True, "status": "pass", "checks": [{"surface": "proxy", "pass": True, "actual": "DE"}]},
+        ]
+        for verification in cases:
+            with self.subTest(verification=verification), self.assertRaises(RuntimeError):
+                require_green_verification({"data": {"verify": verification}}, "US")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/browser-engine/verification.py
+++ b/browser-engine/verification.py
@@ -1,0 +1,29 @@
+from typing import Any
+
+
+def require_green_verification(envelope: dict[str, Any], requested_country: str = "") -> dict[str, Any]:
+    data = envelope.get("data") or {}
+    verification = data.get("verify") or {}
+    if verification.get("finalized") is not True:
+        detail = verification.get("visible_text") or "verification did not finish"
+        raise RuntimeError(f"Clawbrowser verification is not green: {detail}")
+    if str(verification.get("status") or "").strip().lower() != "pass":
+        raise RuntimeError(f"Clawbrowser verification failed with status {verification.get('status') or 'unknown'}")
+    checks = verification.get("checks") or []
+    if not checks:
+        raise RuntimeError("Clawbrowser verification returned no checks")
+    failed = [str(check.get("surface") or "unknown") for check in checks if check.get("pass") is not True]
+    if failed:
+        raise RuntimeError(f"Clawbrowser verification failed: {', '.join(failed)}")
+    if requested_country:
+        proxy = next((check for check in checks if str(check.get("surface") or "").lower() == "proxy"), None)
+        if proxy is None:
+            raise RuntimeError("Clawbrowser verification did not return a proxy check")
+        actual = str(proxy.get("actual") or "").strip().upper()
+        expected = str(proxy.get("expected") or "").strip().upper()
+        if requested_country not in {actual[:2], expected[:2]}:
+            raise RuntimeError(
+                f"Clawbrowser proxy country mismatch: requested {requested_country}, "
+                f"verify reported {actual or expected or 'unknown'}"
+            )
+    return verification

--- a/browser-engine/worker.py
+++ b/browser-engine/worker.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import sys
+import time
 from typing import Any, Literal
 
 VERSION = "0.1.0"
@@ -27,6 +28,8 @@ from browser_use.browser.events import (
     NavigateToUrlEvent,
     ScreenshotEvent,
     ScrollEvent,
+    SelectDropdownOptionEvent,
+    SendKeysEvent,
     SwitchTabEvent,
     TypeTextEvent,
 )
@@ -218,6 +221,93 @@ async def browser_type(index: int, text: str, clear: bool = True) -> str:
             raise ValueError(f"Element index {index} is not present in the current DOM; call browser_state again")
         await dispatch(TypeTextEvent(node=node, text=text, clear=clear))
         return json.dumps(await state_payload(), ensure_ascii=False)
+
+
+@mcp.tool()
+async def browser_actions(actions: list[dict[str, Any]], return_state: bool = True) -> str:
+    """Run up to 32 mixed input, select, press, scroll, and click steps in one call. Stops on the first failure and returns one final semantic state."""
+    if not 1 <= len(actions) <= 32:
+        raise ValueError("actions must contain between 1 and 32 steps")
+    async with _lock:
+        current = await session()
+        results: list[dict[str, Any]] = []
+        for index, step in enumerate(actions):
+            started = time.perf_counter()
+            kind = str(step.get("type", "")).strip().lower()
+            try:
+                if kind in {"input", "type", "click", "select"}:
+                    element_index = step.get("element_id", step.get("index"))
+                    if not isinstance(element_index, int):
+                        raise ValueError(f"{kind} requires an integer element_id")
+                    state = await current.get_browser_state_summary(include_screenshot=False)
+                    node = state.dom_state.selector_map.get(element_index) if state.dom_state else None
+                    if node is None:
+                        raise ValueError(f"element {element_index} is not present in the current DOM")
+                    if kind in {"input", "type"}:
+                        text = step.get("text")
+                        if not isinstance(text, str):
+                            raise ValueError("input requires text")
+                        await dispatch(TypeTextEvent(node=node, text=text, clear=bool(step.get("clear", True))))
+                    elif kind == "click":
+                        await dispatch(ClickElementEvent(node=node))
+                    else:
+                        value = step.get("value")
+                        if not isinstance(value, str) or not value:
+                            raise ValueError("select requires value")
+                        await dispatch(SelectDropdownOptionEvent(node=node, text=value))
+                elif kind == "press":
+                    key = step.get("key")
+                    if not isinstance(key, str) or not key:
+                        raise ValueError("press requires key")
+                    await dispatch(SendKeysEvent(keys=key))
+                elif kind == "scroll":
+                    direction = str(step.get("direction", "down")).lower()
+                    if direction not in {"up", "down", "left", "right"}:
+                        raise ValueError("scroll direction must be up, down, left, or right")
+                    amount = int(step.get("amount", 600))
+                    await dispatch(ScrollEvent(direction=direction, amount=amount))
+                elif kind == "wait":
+                    wait_for = step.get("wait_for")
+                    if not isinstance(wait_for, dict):
+                        raise ValueError("wait requires wait_for")
+                    timeout = float(wait_for.get("timeout", 10))
+                    if timeout <= 0:
+                        raise ValueError("wait timeout must be positive")
+                    deadline = time.monotonic() + timeout
+                    matched = False
+                    while time.monotonic() < deadline:
+                        cdp = await current.get_or_create_cdp_session()
+                        if wait_for.get("load"):
+                            expression = "document.readyState === 'complete'"
+                        elif isinstance(wait_for.get("selector"), str):
+                            expression = f"Boolean(document.querySelector({json.dumps(wait_for['selector'])}))"
+                        elif isinstance(wait_for.get("text"), str):
+                            expression = f"Boolean(document.body && document.body.innerText.includes({json.dumps(wait_for['text'])}))"
+                        elif wait_for.get("settle"):
+                            await asyncio.sleep(0.5)
+                            matched = True
+                            break
+                        else:
+                            raise ValueError("wait_for requires load, settle, selector, or text")
+                        evaluated = await cdp.cdp_client.send.Runtime.evaluate(
+                            params={"expression": expression, "returnByValue": True}, session_id=cdp.session_id
+                        )
+                        if evaluated.get("result", {}).get("value") is True:
+                            matched = True
+                            break
+                        await asyncio.sleep(0.1)
+                    if not matched:
+                        raise TimeoutError("wait condition timed out")
+                else:
+                    raise ValueError(f"unsupported action type {kind!r}")
+                results.append({"index": index, "type": kind, "ok": True, "duration_ms": round((time.perf_counter() - started) * 1000)})
+            except Exception as exc:
+                results.append({"index": index, "type": kind, "ok": False, "duration_ms": round((time.perf_counter() - started) * 1000), "error": str(exc)})
+                return json.dumps({"ok": False, "completed": index, "results": results}, ensure_ascii=False)
+        payload: dict[str, Any] = {"ok": True, "completed": len(actions), "results": results}
+        if return_state:
+            payload["state"] = await state_payload()
+        return json.dumps(payload, ensure_ascii=False)
 
 
 @mcp.tool()

--- a/browser-engine/worker.py
+++ b/browser-engine/worker.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import sys
 from typing import Any, Literal
 
@@ -34,15 +35,15 @@ from mcp.server.fastmcp import FastMCP
 mcp = FastMCP("nextbrowser-browser-engine", log_level="ERROR")
 _session: BrowserSession | None = None
 _lock = asyncio.Lock()
+_cdp_url = os.environ.get("NEXTBROWSER_CDP_URL", "").strip()
 
 
 async def session() -> BrowserSession:
     global _session
     if _session is None:
-        cdp_url = os.environ.get("NEXTBROWSER_CDP_URL", "").strip()
-        if not cdp_url:
+        if not _cdp_url:
             raise RuntimeError("NEXTBROWSER_CDP_URL is required")
-        _session = BrowserSession(cdp_url=cdp_url, keep_alive=True)
+        _session = BrowserSession(cdp_url=_cdp_url, keep_alive=True)
         await _session.start()
     return _session
 
@@ -72,6 +73,86 @@ async def state_payload(include_screenshot: bool = False) -> dict[str, Any]:
     }
 
 
+async def run_nextctl(args: list[str]) -> dict[str, Any]:
+    binary = os.environ.get("NEXTBROWSER_NEXTCTL_BIN", "").strip()
+    if not binary:
+        raise RuntimeError("nextctl is unavailable in this engine session")
+    process = await asyncio.create_subprocess_exec(
+        binary,
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=120)
+    except TimeoutError:
+        process.kill()
+        await process.wait()
+        raise RuntimeError("nextctl timed out while preparing the proxy session")
+    output = stdout.decode("utf-8", errors="replace").strip()
+    try:
+        envelope = json.loads(output)
+    except json.JSONDecodeError:
+        detail = stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(detail or "nextctl returned no valid preparation result")
+    if process.returncode != 0 or not envelope.get("ok"):
+        error = envelope.get("error") or {}
+        raise RuntimeError(error.get("message") or "nextctl could not prepare the browser session")
+    return envelope
+
+
+@mcp.tool()
+async def browser_prepare(
+    country: str | None = None,
+    url: str | None = None,
+    profile: str | None = None,
+) -> str:
+    """Prepare the browser identity before browsing. MUST be the first browser tool called when the user requests a proxy, country, or identity. Country is a two-letter ISO code such as US. Returns only after nextctl has started/rotated and verified the proxy session."""
+    global _cdp_url, _session
+    async with _lock:
+        requested_country = (country or "").strip().upper()
+        if requested_country and not re.fullmatch(r"[A-Z]{2}", requested_country):
+            raise ValueError("country must be a two-letter ISO code such as US")
+        selected_profile = (profile or os.environ.get("NEXTBROWSER_PROFILE", "")).strip()
+        if selected_profile and not re.fullmatch(r"[A-Za-z0-9._-]+", selected_profile):
+            raise ValueError("profile contains unsupported characters")
+        if url and not re.match(r"^https?://", url, re.IGNORECASE):
+            raise ValueError("url must use http or https")
+
+        args: list[str] = []
+        if selected_profile:
+            args.extend(["--profile", selected_profile])
+        args.append("rotate" if requested_country else "start")
+        if requested_country:
+            args.extend(["--country", requested_country, "--proxy-scheme", "http", "--verify"])
+        if url:
+            args.extend(["--url", url])
+        args.extend(["--format", "json"])
+        envelope = await run_nextctl(args)
+        data = envelope.get("data") or {}
+        endpoint = (data.get("session") or {}).get("endpoint") or data.get("endpoint")
+        if not endpoint:
+            raise RuntimeError("nextctl prepared the session but returned no CDP endpoint")
+
+        old_session = _session
+        _session = None
+        _cdp_url = str(endpoint)
+        if old_session is not None:
+            try:
+                await old_session.event_bus.stop(clear=True, timeout=2)
+            except Exception:
+                pass
+        await session()
+        return json.dumps({
+            "prepared": True,
+            "verified": bool(requested_country),
+            "country": requested_country or None,
+            "profile": selected_profile or "default",
+            "endpoint": _cdp_url,
+            "next_step": "Use browser_state or browser_navigate only after this success response.",
+        }, ensure_ascii=False)
+
+
 @mcp.tool()
 async def browser_state(include_screenshot: bool = False) -> str:
     """Get the current semantic DOM. Use element indexes shown in semantic_dom for click/type."""
@@ -81,7 +162,7 @@ async def browser_state(include_screenshot: bool = False) -> str:
 
 @mcp.tool()
 async def browser_navigate(url: str, new_tab: bool = False) -> str:
-    """Navigate the active tab to a URL, or open it in a new tab."""
+    """Navigate the active tab to a URL, or open it in a new tab. If the request specified a proxy/country/identity, call browser_prepare first."""
     async with _lock:
         await dispatch(NavigateToUrlEvent(url=url, new_tab=new_tab, wait_until="domcontentloaded"))
         return json.dumps(await state_payload(), ensure_ascii=False)
@@ -205,8 +286,6 @@ async def main() -> None:
     # Browser Use keeps background watchdog tasks for a live session. This
     # sidecar owns neither the browser nor reusable state, so EOF is a terminal
     # condition and a direct process exit avoids hanging while those tasks wait.
-    sys.stdout.flush()
-    sys.stderr.flush()
     os._exit(0)
 
 

--- a/browser-engine/worker.py
+++ b/browser-engine/worker.py
@@ -45,6 +45,7 @@ async def session() -> BrowserSession:
             raise RuntimeError("NEXTBROWSER_CDP_URL is required")
         _session = BrowserSession(cdp_url=_cdp_url, keep_alive=True)
         await _session.start()
+        await sync_nextctl_active_tab(_session)
     return _session
 
 
@@ -99,6 +100,26 @@ async def run_nextctl(args: list[str]) -> dict[str, Any]:
         error = envelope.get("error") or {}
         raise RuntimeError(error.get("message") or "nextctl could not prepare the browser session")
     return envelope
+
+
+async def sync_nextctl_active_tab(current: BrowserSession) -> None:
+    """Keep Browser Use attached to the tab selected by nextctl/Clawbrowser."""
+    if not _cdp_url or not os.environ.get("NEXTBROWSER_NEXTCTL_BIN", "").strip():
+        return
+    try:
+        envelope = await run_nextctl(["--cdp", _cdp_url, "tabs", "list", "--format", "json"])
+        tabs = (envelope.get("data") or {}).get("tabs") or []
+        selected = next((tab for tab in tabs if tab.get("active") or tab.get("current")), None)
+        target_id = str((selected or {}).get("id") or "")
+        if not target_id:
+            return
+        browser_tabs = await current.get_tabs()
+        if any(str(tab.target_id) == target_id for tab in browser_tabs):
+            emitted = current.event_bus.dispatch(SwitchTabEvent(target_id=target_id))
+            await emitted.event_result(raise_if_none=False, raise_if_any=True)
+    except Exception:
+        # Attaching must still work with old nextctl builds or explicit raw CDP URLs.
+        return
 
 
 @mcp.tool()

--- a/browser-engine/worker.py
+++ b/browser-engine/worker.py
@@ -40,6 +40,8 @@ _session: BrowserSession | None = None
 _lock = asyncio.Lock()
 _cdp_url = os.environ.get("NEXTBROWSER_CDP_URL", "").strip()
 _prepared = False
+_prepared_country = ""
+_prepared_profile = ""
 
 
 async def session() -> BrowserSession:
@@ -128,6 +130,17 @@ async def sync_nextctl_active_tab(current: BrowserSession) -> None:
         return
 
 
+async def activate_requested_url(current: BrowserSession, url: str | None) -> None:
+    if not url:
+        return
+    requested = url.rstrip("/")
+    tabs = await current.get_tabs()
+    match = next((tab for tab in tabs if tab.url.rstrip("/") == requested), None)
+    if match is not None:
+        emitted = current.event_bus.dispatch(SwitchTabEvent(target_id=str(match.target_id)))
+        await emitted.event_result(raise_if_none=False, raise_if_any=True)
+
+
 @mcp.tool()
 async def browser_prepare(
     country: str | None = None,
@@ -135,7 +148,7 @@ async def browser_prepare(
     profile: str | None = None,
 ) -> str:
     """Prepare the browser identity before browsing. MUST be the first browser tool called when the user requests a proxy, country, or identity. Country is a two-letter ISO code such as US. Returns only after nextctl has started/rotated and verified the proxy session."""
-    global _cdp_url, _session, _prepared
+    global _cdp_url, _session, _prepared, _prepared_country, _prepared_profile
     async with _lock:
         requested_country = (country or "").strip().upper()
         if requested_country and not re.fullmatch(r"[A-Z]{2}", requested_country):
@@ -145,6 +158,27 @@ async def browser_prepare(
             raise ValueError("profile contains unsupported characters")
         if url and not re.match(r"^https?://", url, re.IGNORECASE):
             raise ValueError("url must use http or https")
+
+        same_identity = (
+            _prepared
+            and selected_profile == _prepared_profile
+            and (not requested_country or requested_country == _prepared_country)
+        )
+        if same_identity:
+            try:
+                current = await session()
+                await activate_requested_url(current, url)
+                return json.dumps({
+                    "prepared": True,
+                    "verified": bool(_prepared_country),
+                    "reused": True,
+                    "country": _prepared_country or None,
+                    "profile": selected_profile or "default",
+                    "endpoint": _cdp_url,
+                    "next_step": "Preparation is complete. Do not call browser_prepare again; continue with browser_state, browser_actions, or navigation.",
+                }, ensure_ascii=False)
+            except Exception:
+                _prepared = False
 
         scope: list[str] = []
         if selected_profile:
@@ -179,17 +213,20 @@ async def browser_prepare(
             except Exception:
                 pass
         try:
-            await session()
+            current = await session()
+            await activate_requested_url(current, url)
         except Exception:
             _prepared = False
             raise
+        _prepared_country = requested_country
+        _prepared_profile = selected_profile
         return json.dumps({
             "prepared": True,
             "verified": bool(requested_country),
             "country": requested_country or None,
             "profile": selected_profile or "default",
             "endpoint": _cdp_url,
-            "next_step": "Use browser_state or browser_navigate only after this success response.",
+            "next_step": "Preparation is complete. Do not call browser_prepare again; continue with browser_state, browser_actions, or navigation.",
         }, ensure_ascii=False)
 
 

--- a/browser-engine/worker.py
+++ b/browser-engine/worker.py
@@ -34,6 +34,7 @@ from browser_use.browser.events import (
     TypeTextEvent,
 )
 from mcp.server.fastmcp import FastMCP
+from verification import require_green_verification
 
 mcp = FastMCP("nextbrowser-browser-engine", log_level="ERROR")
 _session: BrowserSession | None = None
@@ -42,6 +43,8 @@ _cdp_url = os.environ.get("NEXTBROWSER_CDP_URL", "").strip()
 _prepared = False
 _prepared_country = ""
 _prepared_profile = ""
+_prepared_at = 0.0
+PREPARE_REUSE_SECONDS = 60.0
 
 
 async def session() -> BrowserSession:
@@ -148,7 +151,7 @@ async def browser_prepare(
     profile: str | None = None,
 ) -> str:
     """Prepare the browser identity before browsing. MUST be the first browser tool called when the user requests a proxy, country, or identity. Country is a two-letter ISO code such as US. Returns only after nextctl has started/rotated and verified the proxy session."""
-    global _cdp_url, _session, _prepared, _prepared_country, _prepared_profile
+    global _cdp_url, _session, _prepared, _prepared_country, _prepared_profile, _prepared_at
     async with _lock:
         requested_country = (country or "").strip().upper()
         if requested_country and not re.fullmatch(r"[A-Z]{2}", requested_country):
@@ -161,6 +164,7 @@ async def browser_prepare(
 
         same_identity = (
             _prepared
+            and time.monotonic() - _prepared_at < PREPARE_REUSE_SECONDS
             and selected_profile == _prepared_profile
             and (not requested_country or requested_country == _prepared_country)
         )
@@ -170,7 +174,7 @@ async def browser_prepare(
                 await activate_requested_url(current, url)
                 return json.dumps({
                     "prepared": True,
-                    "verified": bool(_prepared_country),
+                    "verified": True,
                     "reused": True,
                     "country": _prepared_country or None,
                     "profile": selected_profile or "default",
@@ -185,21 +189,24 @@ async def browser_prepare(
             scope.extend(["--profile", selected_profile])
         if requested_country:
             args = scope + ["rotate", "--country", requested_country, "--proxy-scheme", "http", "--verify"]
-            if url:
-                args.extend(["--url", url])
             envelope = await run_nextctl(args + ["--format", "json"])
         else:
             envelope = await run_nextctl(scope + ["status", "--format", "json"])
             status_data = envelope.get("data") or {}
             if status_data.get("status") != "running":
-                args = scope + ["start"]
-                if url:
-                    args.extend(["--url", url])
-                envelope = await run_nextctl(args + ["--format", "json"])
-            elif url:
-                envelope = await run_nextctl(scope + ["open", url, "--format", "json"])
+                envelope = await run_nextctl(scope + ["start", "--verify", "--format", "json"])
+
+        verification_envelope = await run_nextctl(scope + ["verify", "--timeout", "30s", "--format", "json"])
+        verification = require_green_verification(verification_envelope, requested_country)
+        if url:
+            await run_nextctl(scope + ["open", url, "--format", "json"])
         data = envelope.get("data") or {}
-        endpoint = (data.get("session") or {}).get("endpoint") or data.get("endpoint")
+        verification_data = verification_envelope.get("data") or {}
+        endpoint = (
+            (verification_data.get("session") or {}).get("endpoint")
+            or (data.get("session") or {}).get("endpoint")
+            or data.get("endpoint")
+        )
         if not endpoint:
             raise RuntimeError("nextctl prepared the session but returned no CDP endpoint")
 
@@ -220,9 +227,12 @@ async def browser_prepare(
             raise
         _prepared_country = requested_country
         _prepared_profile = selected_profile
+        _prepared_at = time.monotonic()
         return json.dumps({
             "prepared": True,
-            "verified": bool(requested_country),
+            "verified": True,
+            "verification_status": verification.get("status"),
+            "verification_checks": len(verification.get("checks") or []),
             "country": requested_country or None,
             "profile": selected_profile or "default",
             "endpoint": _cdp_url,

--- a/browser-engine/worker.py
+++ b/browser-engine/worker.py
@@ -1,0 +1,214 @@
+"""Minimal Browser Use DOM/action MCP adapter for an existing CDP browser."""
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from typing import Any, Literal
+
+VERSION = "0.1.0"
+if "--version" in sys.argv:
+    print(VERSION)
+    raise SystemExit(0)
+
+os.environ.setdefault("BROWSER_USE_LOGGING_LEVEL", "critical")
+os.environ.setdefault("BROWSER_USE_SETUP_LOGGING", "false")
+os.environ.setdefault("ANONYMIZED_TELEMETRY", "false")
+logging.disable(logging.CRITICAL)
+
+from browser_use.browser import BrowserSession
+from browser_use.browser.events import (
+    ClickCoordinateEvent,
+    ClickElementEvent,
+    CloseTabEvent,
+    GoBackEvent,
+    NavigateToUrlEvent,
+    ScreenshotEvent,
+    ScrollEvent,
+    SwitchTabEvent,
+    TypeTextEvent,
+)
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("nextbrowser-browser-engine", log_level="ERROR")
+_session: BrowserSession | None = None
+_lock = asyncio.Lock()
+
+
+async def session() -> BrowserSession:
+    global _session
+    if _session is None:
+        cdp_url = os.environ.get("NEXTBROWSER_CDP_URL", "").strip()
+        if not cdp_url:
+            raise RuntimeError("NEXTBROWSER_CDP_URL is required")
+        _session = BrowserSession(cdp_url=cdp_url, keep_alive=True)
+        await _session.start()
+    return _session
+
+
+async def dispatch(event: Any) -> Any:
+    current = await session()
+    emitted = current.event_bus.dispatch(event)
+    return await emitted.event_result(raise_if_none=False, raise_if_any=True)
+
+
+async def state_payload(include_screenshot: bool = False) -> dict[str, Any]:
+    current = await session()
+    state = await current.get_browser_state_summary(include_screenshot=include_screenshot)
+    tabs = await current.get_tabs()
+    dom = state.dom_state
+    return {
+        "engine": "browser-use-dom",
+        "url": state.url,
+        "title": state.title,
+        "semantic_dom": dom.llm_representation() if dom else "",
+        "interactive_element_count": len(dom.selector_map) if dom else 0,
+        "tabs": [
+            {"index": index, "target_id": str(tab.target_id), "url": tab.url, "title": tab.title}
+            for index, tab in enumerate(tabs)
+        ],
+        "screenshot_base64": state.screenshot if include_screenshot else None,
+    }
+
+
+@mcp.tool()
+async def browser_state(include_screenshot: bool = False) -> str:
+    """Get the current semantic DOM. Use element indexes shown in semantic_dom for click/type."""
+    async with _lock:
+        return json.dumps(await state_payload(include_screenshot), ensure_ascii=False)
+
+
+@mcp.tool()
+async def browser_navigate(url: str, new_tab: bool = False) -> str:
+    """Navigate the active tab to a URL, or open it in a new tab."""
+    async with _lock:
+        await dispatch(NavigateToUrlEvent(url=url, new_tab=new_tab, wait_until="domcontentloaded"))
+        return json.dumps(await state_payload(), ensure_ascii=False)
+
+
+@mcp.tool()
+async def browser_click(index: int | None = None, x: int | None = None, y: int | None = None) -> str:
+    """Click an element by semantic DOM index, or by x/y coordinates."""
+    async with _lock:
+        current = await session()
+        if index is not None:
+            state = await current.get_browser_state_summary(include_screenshot=False)
+            node = state.dom_state.selector_map.get(index) if state.dom_state else None
+            if node is None:
+                raise ValueError(f"Element index {index} is not present in the current DOM; call browser_state again")
+            await dispatch(ClickElementEvent(node=node))
+        elif x is not None and y is not None:
+            await dispatch(ClickCoordinateEvent(coordinate_x=x, coordinate_y=y))
+        else:
+            raise ValueError("Provide index, or both x and y")
+        return json.dumps(await state_payload(), ensure_ascii=False)
+
+
+@mcp.tool()
+async def browser_type(index: int, text: str, clear: bool = True) -> str:
+    """Type into an element from the latest semantic DOM by index."""
+    async with _lock:
+        current = await session()
+        state = await current.get_browser_state_summary(include_screenshot=False)
+        node = state.dom_state.selector_map.get(index) if state.dom_state else None
+        if node is None:
+            raise ValueError(f"Element index {index} is not present in the current DOM; call browser_state again")
+        await dispatch(TypeTextEvent(node=node, text=text, clear=clear))
+        return json.dumps(await state_payload(), ensure_ascii=False)
+
+
+@mcp.tool()
+async def browser_scroll(direction: Literal["up", "down", "left", "right"] = "down", amount: int = 600) -> str:
+    """Scroll the active page by pixels."""
+    async with _lock:
+        await dispatch(ScrollEvent(direction=direction, amount=amount))
+        return json.dumps(await state_payload(), ensure_ascii=False)
+
+
+@mcp.tool()
+async def browser_back() -> str:
+    """Go back in the active tab history."""
+    async with _lock:
+        await dispatch(GoBackEvent())
+        return json.dumps(await state_payload(), ensure_ascii=False)
+
+
+@mcp.tool()
+async def browser_html() -> str:
+    """Return the current page HTML for extraction when semantic DOM is insufficient."""
+    async with _lock:
+        current = await session()
+        cdp = await current.get_or_create_cdp_session()
+        result = await cdp.cdp_client.send.Runtime.evaluate(
+            params={"expression": "document.documentElement.outerHTML", "returnByValue": True},
+            session_id=cdp.session_id,
+        )
+        return str(result.get("result", {}).get("value", ""))
+
+
+@mcp.tool()
+async def browser_evaluate(expression: str) -> str:
+    """Evaluate JavaScript in the active page and return a JSON-serializable result."""
+    async with _lock:
+        current = await session()
+        cdp = await current.get_or_create_cdp_session()
+        result = await cdp.cdp_client.send.Runtime.evaluate(
+            params={"expression": expression, "returnByValue": True, "awaitPromise": True},
+            session_id=cdp.session_id,
+        )
+        if result.get("exceptionDetails"):
+            raise RuntimeError(str(result["exceptionDetails"]))
+        return json.dumps(result.get("result", {}).get("value"), ensure_ascii=False)
+
+
+@mcp.tool()
+async def browser_screenshot(full_page: bool = False) -> str:
+    """Return a base64 PNG screenshot of the active page."""
+    async with _lock:
+        return str(await dispatch(ScreenshotEvent(full_page=full_page)))
+
+
+@mcp.tool()
+async def browser_tabs() -> str:
+    """List browser tabs and their stable target IDs."""
+    async with _lock:
+        current = await session()
+        tabs = await current.get_tabs()
+        return json.dumps([
+            {"index": index, "target_id": str(tab.target_id), "url": tab.url, "title": tab.title}
+            for index, tab in enumerate(tabs)
+        ], ensure_ascii=False)
+
+
+@mcp.tool()
+async def browser_switch_tab(target_id: str) -> str:
+    """Switch to a tab by target_id from browser_tabs."""
+    async with _lock:
+        await dispatch(SwitchTabEvent(target_id=target_id))
+        return json.dumps(await state_payload(), ensure_ascii=False)
+
+
+@mcp.tool()
+async def browser_close_tab(target_id: str) -> str:
+    """Close a tab by target_id from browser_tabs."""
+    async with _lock:
+        await dispatch(CloseTabEvent(target_id=target_id))
+        return json.dumps(await state_payload(), ensure_ascii=False)
+
+
+async def main() -> None:
+    # The CDP browser is owned by nextctl. When stdio closes, let process exit
+    # tear down this adapter's tasks; BrowserSession.kill()/stop() could close
+    # the user's shared browser or race with MCP's already-closed stdio.
+    await mcp.run_stdio_async()
+    # Browser Use keeps background watchdog tasks for a live session. This
+    # sidecar owns neither the browser nor reusable state, so EOF is a terminal
+    # condition and a direct process exit avoids hanging while those tasks wait.
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/browser-engine/worker.py
+++ b/browser-engine/worker.py
@@ -39,10 +39,13 @@ mcp = FastMCP("nextbrowser-browser-engine", log_level="ERROR")
 _session: BrowserSession | None = None
 _lock = asyncio.Lock()
 _cdp_url = os.environ.get("NEXTBROWSER_CDP_URL", "").strip()
+_prepared = False
 
 
 async def session() -> BrowserSession:
     global _session
+    if not _prepared:
+        raise RuntimeError("Browser session is not prepared. Call browser_prepare before any browser action or inspection.")
     if _session is None:
         if not _cdp_url:
             raise RuntimeError("NEXTBROWSER_CDP_URL is required")
@@ -132,7 +135,7 @@ async def browser_prepare(
     profile: str | None = None,
 ) -> str:
     """Prepare the browser identity before browsing. MUST be the first browser tool called when the user requests a proxy, country, or identity. Country is a two-letter ISO code such as US. Returns only after nextctl has started/rotated and verified the proxy session."""
-    global _cdp_url, _session
+    global _cdp_url, _session, _prepared
     async with _lock:
         requested_country = (country or "").strip().upper()
         if requested_country and not re.fullmatch(r"[A-Z]{2}", requested_country):
@@ -143,16 +146,24 @@ async def browser_prepare(
         if url and not re.match(r"^https?://", url, re.IGNORECASE):
             raise ValueError("url must use http or https")
 
-        args: list[str] = []
+        scope: list[str] = []
         if selected_profile:
-            args.extend(["--profile", selected_profile])
-        args.append("rotate" if requested_country else "start")
+            scope.extend(["--profile", selected_profile])
         if requested_country:
-            args.extend(["--country", requested_country, "--proxy-scheme", "http", "--verify"])
-        if url:
-            args.extend(["--url", url])
-        args.extend(["--format", "json"])
-        envelope = await run_nextctl(args)
+            args = scope + ["rotate", "--country", requested_country, "--proxy-scheme", "http", "--verify"]
+            if url:
+                args.extend(["--url", url])
+            envelope = await run_nextctl(args + ["--format", "json"])
+        else:
+            envelope = await run_nextctl(scope + ["status", "--format", "json"])
+            status_data = envelope.get("data") or {}
+            if status_data.get("status") != "running":
+                args = scope + ["start"]
+                if url:
+                    args.extend(["--url", url])
+                envelope = await run_nextctl(args + ["--format", "json"])
+            elif url:
+                envelope = await run_nextctl(scope + ["open", url, "--format", "json"])
         data = envelope.get("data") or {}
         endpoint = (data.get("session") or {}).get("endpoint") or data.get("endpoint")
         if not endpoint:
@@ -161,12 +172,17 @@ async def browser_prepare(
         old_session = _session
         _session = None
         _cdp_url = str(endpoint)
+        _prepared = True
         if old_session is not None:
             try:
                 await old_session.event_bus.stop(clear=True, timeout=2)
             except Exception:
                 pass
-        await session()
+        try:
+            await session()
+        except Exception:
+            _prepared = False
+            raise
         return json.dumps({
             "prepared": True,
             "verified": bool(requested_country),

--- a/electron/agent-workspace.test.cjs
+++ b/electron/agent-workspace.test.cjs
@@ -37,6 +37,6 @@ test("terminal Codex keeps workspace isolation while allowing Clawbrowser networ
 test("terminal chat is isolated by conversation", () => {
   const terminal = fs.readFileSync(path.join(__dirname, "..", "src", "components", "AgentTerminal.tsx"), "utf8");
   const chat = fs.readFileSync(path.join(__dirname, "..", "src", "components", "ChatView.tsx"), "utf8");
-  assert.match(terminal, /\[agentId, conversationId, workingDir\]/);
+  assert.match(terminal, /\[agentId, browserEngine, conversationId, selectedProfile, workingDir\]/);
   assert.match(chat, /conversationId=\{conv\?\.id\}/);
 });

--- a/electron/agent-workspace.test.cjs
+++ b/electron/agent-workspace.test.cjs
@@ -40,3 +40,12 @@ test("terminal chat is isolated by conversation", () => {
   assert.match(terminal, /\[agentId, browserEngine, conversationId, selectedProfile, workingDir\]/);
   assert.match(chat, /conversationId=\{conv\?\.id\}/);
 });
+
+test("experimental Codex browser engine excludes user plugins while retaining login", () => {
+  const main = fs.readFileSync(path.join(__dirname, "main.cjs"), "utf8");
+  assert.match(main, /async function isolatedCodexHome\(\)/);
+  assert.match(main, /fs\.copyFile\(sourceAuth, targetAuth\)/);
+  assert.match(main, /\{ CODEX_HOME: await isolatedCodexHome\(\) \}/);
+  assert.match(main, /Use only the nextbrowser-browser MCP tools/);
+  assert.doesNotMatch(main, /if \(agentId === "codex"\) return \[\s*"--ignore-user-config"/);
+});

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -55,15 +55,21 @@ function browserEngineAgentArgs(agentId, engine) {
     "-c", "sandbox_workspace_write.network_access=true",
     "-c", `mcp_servers.nextbrowser_browser.command=${JSON.stringify(engine.command)}`,
     "-c", `mcp_servers.nextbrowser_browser.env.NEXTBROWSER_CDP_URL=${JSON.stringify(engine.cdpUrl)}`,
+    "-c", `mcp_servers.nextbrowser_browser.env.NEXTBROWSER_NEXTCTL_BIN=${JSON.stringify(engine.nextctlBin)}`,
+    "-c", `mcp_servers.nextbrowser_browser.env.NEXTBROWSER_PROFILE=${JSON.stringify(engine.profile || "")}`,
     "-c", "mcp_servers.nextbrowser_browser.default_tools_approval_mode=\"approve\"",
-    "-c", `developer_instructions=${JSON.stringify("Browser engine mode is active. Use only the nextbrowser-browser MCP tools for browser inspection and actions. Do not use clawbrowser MCP, nbc, nextctl, or shell commands for browser work. The browser session is already running.")}`,
+    "-c", `developer_instructions=${JSON.stringify("Browser engine mode is active. Use only the nextbrowser-browser MCP tools for browser work. If the request mentions a proxy, country, or identity, you MUST call browser_prepare with the ISO country before any navigation or page inspection and proceed only when it succeeds. Do not use clawbrowser MCP, nbc, nextctl, or shell commands for browser work.")}`,
   ];
   if (agentId === "claude") return [
     "--strict-mcp-config", "--mcp-config", JSON.stringify({
       mcpServers: {
         "nextbrowser-browser": {
           command: engine.command,
-          env: { NEXTBROWSER_CDP_URL: engine.cdpUrl },
+          env: {
+            NEXTBROWSER_CDP_URL: engine.cdpUrl,
+            NEXTBROWSER_NEXTCTL_BIN: engine.nextctlBin,
+            NEXTBROWSER_PROFILE: engine.profile || "",
+          },
         },
       },
     }),
@@ -434,7 +440,7 @@ async function browserEnginePrepare(profile) {
     cdpUrl = data?.session?.endpoint || data?.endpoint;
   }
   if (!envelope?.ok || !cdpUrl) throw new Error(envelope?.error?.message || "The browser session has no CDP endpoint.");
-  return { command, cdpUrl };
+  return { command, cdpUrl, nextctlBin: bin, profile: profile || "" };
 }
 async function migrateLegacyData() {
   const legacy = path.join(app.getPath("appData"), "clawdesk-electron");

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -55,6 +55,7 @@ function browserEngineAgentArgs(agentId, engine) {
     "-c", "sandbox_workspace_write.network_access=true",
     "-c", `mcp_servers.nextbrowser_browser.command=${JSON.stringify(engine.command)}`,
     "-c", `mcp_servers.nextbrowser_browser.env.NEXTBROWSER_CDP_URL=${JSON.stringify(engine.cdpUrl)}`,
+    "-c", `developer_instructions=${JSON.stringify("Browser engine mode is active. Use only the nextbrowser-browser MCP tools for browser inspection and actions. Do not use clawbrowser MCP, nbc, nextctl, or shell commands for browser work. The browser session is already running.")}`,
   ];
   if (agentId === "claude") return [
     "--strict-mcp-config", "--mcp-config", JSON.stringify({
@@ -67,6 +68,25 @@ function browserEngineAgentArgs(agentId, engine) {
     }),
   ];
   throw new Error("Browser engine is currently supported by Codex and Claude Code only.");
+}
+
+async function isolatedCodexHome() {
+  const target = path.join(dataDir(), "codex-browser-engine");
+  const sourceHome = String(process.env.CODEX_HOME || path.join(home(), ".codex"));
+  const sourceAuth = path.join(sourceHome, "auth.json");
+  const targetAuth = path.join(target, "auth.json");
+  await fs.mkdir(target, { recursive: true });
+  try {
+    await fs.copyFile(sourceAuth, targetAuth);
+    if (process.platform !== "win32") await fs.chmod(targetAuth, 0o600);
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+    throw new Error("Codex login was not found. Sign in to Codex before enabling the browser engine.");
+  }
+  // Keep this home intentionally minimal: auth is shared as a snapshot, while
+  // user plugins, skills, and MCP servers must not leak into the A/B engine run.
+  await fs.writeFile(path.join(target, "config.toml"), "", { encoding: "utf8", mode: 0o600 });
+  return target;
 }
 
 async function ensureCodexTerminalProfile() {
@@ -244,9 +264,9 @@ function resolveBinary(name, envVar) {
   return null;
 }
 function childEnv(extra = {}) { return { ...process.env, PATH: searchDirs().join(path.delimiter), ...extra }; }
-function terminalEnv() {
+function terminalEnv(extra = {}) {
   return Object.fromEntries(
-    Object.entries(childEnv({ TERM: "xterm-256color", COLORTERM: "truecolor" }))
+    Object.entries(childEnv({ TERM: "xterm-256color", COLORTERM: "truecolor", ...extra }))
       .filter(([, value]) => typeof value === "string"),
   );
 }
@@ -757,13 +777,16 @@ async function invokeCommand(command, args = {}) {
         ...(args.browserEngine ? browserEngineAgentArgs(args.agentId, args.browserEngine) : (agent.args || [])),
         ...writableDirs.flatMap((dir) => ["--add-dir", dir]),
       ];
+      const terminalExtraEnv = args.browserEngine && args.agentId === "codex"
+        ? { CODEX_HOME: await isolatedCodexHome() }
+        : {};
       const spec = commandSpec(bin, terminalArgs);
       const terminal = pty.spawn(spec.file, spec.args, {
         name: "xterm-256color",
         cols: Math.max(2, Math.min(500, Number(args.cols) || 80)),
         rows: Math.max(2, Math.min(300, Number(args.rows) || 24)),
         cwd: args.workingDir || home(),
-        env: terminalEnv(),
+        env: terminalEnv(terminalExtraEnv),
       });
       const record = { process: terminal, ready: false, buffer: [], exit: null };
       terminals.set(id, record);

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -47,6 +47,29 @@ function codexClawbrowserArgs() {
   ];
 }
 
+function browserEngineAgentArgs(agentId, engine) {
+  if (!engine) return [];
+  if (agentId === "codex") return [
+    "--ignore-user-config",
+    "--ask-for-approval", "never",
+    "--sandbox", "workspace-write",
+    "-c", "sandbox_workspace_write.network_access=true",
+    "-c", `mcp_servers.nextbrowser_browser.command=${JSON.stringify(engine.command)}`,
+    "-c", `mcp_servers.nextbrowser_browser.env.NEXTBROWSER_CDP_URL=${JSON.stringify(engine.cdpUrl)}`,
+  ];
+  if (agentId === "claude") return [
+    "--strict-mcp-config", "--mcp-config", JSON.stringify({
+      mcpServers: {
+        "nextbrowser-browser": {
+          command: engine.command,
+          env: { NEXTBROWSER_CDP_URL: engine.cdpUrl },
+        },
+      },
+    }),
+  ];
+  throw new Error("Browser engine is currently supported by Codex and Claude Code only.");
+}
+
 async function ensureCodexTerminalProfile() {
   const codexDir = String(process.env.CODEX_HOME || path.join(home(), ".codex"));
   await fs.mkdir(codexDir, { recursive: true });
@@ -354,6 +377,45 @@ async function resolveOrInstallNextctl() {
   return installManagedNextctl();
 }
 function dataDir() { return path.join(app.getPath("userData")); }
+
+function browserEngineExecutable() {
+  const executable = process.platform === "win32" ? "nextbrowser-browser-engine.exe" : "nextbrowser-browser-engine";
+  const configured = process.env.NEXTBROWSER_BROWSER_ENGINE_BIN;
+  const candidates = [
+    configured && expand(configured),
+    app.isPackaged && path.join(process.resourcesPath, "browser-engine", executable),
+    path.join(__dirname, "..", "browser-engine", "dist", "nextbrowser-browser-engine", executable),
+  ].filter(Boolean);
+  return candidates.find(launchable) || null;
+}
+
+async function browserEnginePrepare(profile) {
+  const command = browserEngineExecutable();
+  if (!command) throw new Error("The experimental browser engine is not installed in this build.");
+  const bin = await resolveOrInstallNextctl();
+  if (!bin) throw new Error("nextctl is required to resolve the running browser session.");
+  const profileArgs = profile ? ["--profile", String(profile)] : [];
+  const readStatus = async () => {
+    const result = await run(bin, [...profileArgs, "status", "--format", "json"]);
+    try { return JSON.parse(result.stdout); }
+    catch { throw new Error("nextctl returned an invalid browser status."); }
+  };
+  let envelope = await readStatus();
+  let data = envelope && envelope.data !== undefined ? envelope.data : envelope;
+  let cdpUrl = data?.session?.endpoint || data?.endpoint;
+  if (envelope?.ok && !cdpUrl && data?.status !== "running") {
+    const started = await run(bin, [...profileArgs, "start", "--format", "json"]);
+    let startEnvelope;
+    try { startEnvelope = JSON.parse(started.stdout); }
+    catch { throw new Error("nextctl returned an invalid browser start result."); }
+    if (!startEnvelope?.ok) throw new Error(startEnvelope?.error?.message || "The browser session could not start.");
+    envelope = await readStatus();
+    data = envelope && envelope.data !== undefined ? envelope.data : envelope;
+    cdpUrl = data?.session?.endpoint || data?.endpoint;
+  }
+  if (!envelope?.ok || !cdpUrl) throw new Error(envelope?.error?.message || "The browser session has no CDP endpoint.");
+  return { command, cdpUrl };
+}
 async function migrateLegacyData() {
   const legacy = path.join(app.getPath("appData"), "clawdesk-electron");
   const current = dataDir();
@@ -524,6 +586,11 @@ async function invokeCommand(command, args = {}) {
       const r = await run(bin, ["version"]); return r.stdout.trim();
     }
     case "nextctl_supports_skill": { const bin = await resolveOrInstallNextctl(); if (!bin) throw new Error("not found"); return nextctlHasSkill(bin); }
+    case "browser_engine_status": {
+      const command = browserEngineExecutable();
+      return { available: !!command, command };
+    }
+    case "browser_engine_prepare": return browserEnginePrepare(args.profile || "");
     case "proxy_traffic_top_up": return await topUpProxyTraffic();
     case "pairing_start": {
       return apiFetchJSON(args.apiBaseUrl, "/v1/pairing-requests/browser", {
@@ -685,10 +752,10 @@ async function invokeCommand(command, args = {}) {
       if (!bin) throw new Error(`${agent.binary} CLI not found.`);
       const id = randomUUID();
       const writableDirs = args.agentId === "codex" ? clawbrowserWritableDirs() : [];
-      if (args.agentId === "codex") await ensureCodexTerminalProfile();
+      if (args.agentId === "codex" && !args.browserEngine) await ensureCodexTerminalProfile();
       await Promise.all(writableDirs.map((dir) => fs.mkdir(dir, { recursive: true })));
       const terminalArgs = [
-        ...(agent.args || []),
+        ...(args.browserEngine ? browserEngineAgentArgs(args.agentId, args.browserEngine) : (agent.args || [])),
         ...writableDirs.flatMap((dir) => ["--add-dir", dir]),
       ];
       const spec = commandSpec(bin, terminalArgs);

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -55,6 +55,7 @@ function browserEngineAgentArgs(agentId, engine) {
     "-c", "sandbox_workspace_write.network_access=true",
     "-c", `mcp_servers.nextbrowser_browser.command=${JSON.stringify(engine.command)}`,
     "-c", `mcp_servers.nextbrowser_browser.env.NEXTBROWSER_CDP_URL=${JSON.stringify(engine.cdpUrl)}`,
+    "-c", "mcp_servers.nextbrowser_browser.default_tools_approval_mode=\"approve\"",
     "-c", `developer_instructions=${JSON.stringify("Browser engine mode is active. Use only the nextbrowser-browser MCP tools for browser inspection and actions. Do not use clawbrowser MCP, nbc, nextctl, or shell commands for browser work. The browser session is already running.")}`,
   ];
   if (agentId === "claude") return [

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -58,7 +58,7 @@ function browserEngineAgentArgs(agentId, engine) {
     "-c", `mcp_servers.nextbrowser_browser.env.NEXTBROWSER_NEXTCTL_BIN=${JSON.stringify(engine.nextctlBin)}`,
     "-c", `mcp_servers.nextbrowser_browser.env.NEXTBROWSER_PROFILE=${JSON.stringify(engine.profile || "")}`,
     "-c", "mcp_servers.nextbrowser_browser.default_tools_approval_mode=\"approve\"",
-    "-c", `developer_instructions=${JSON.stringify("Browser engine mode is active. Use only the nextbrowser-browser MCP tools. ALWAYS call browser_prepare before every other nextbrowser-browser tool and proceed only after it succeeds. If the request mentions a proxy, country, or identity, pass the requested two-letter ISO country so nextctl rotates and verifies the proxy before browser work. Never navigate, inspect, or act before preparation. Do not use clawbrowser MCP, nbc, nextctl, or shell commands for browser work.")}`,
+    "-c", `developer_instructions=${JSON.stringify("Browser engine mode is active. Use only the nextbrowser-browser MCP tools. Call browser_prepare exactly once at the beginning of a browser task and proceed only after it succeeds. Do not call browser_prepare again during the same task unless it failed or the user explicitly requests a different identity. If the request mentions a proxy, country, or identity, pass the requested two-letter ISO country so nextctl rotates and verifies the proxy before browser work. Never navigate, inspect, or act before preparation. Do not use clawbrowser MCP, nbc, nextctl, or shell commands for browser work.")}`,
   ];
   if (agentId === "claude") return [
     "--strict-mcp-config", "--mcp-config", JSON.stringify({

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -58,7 +58,7 @@ function browserEngineAgentArgs(agentId, engine) {
     "-c", `mcp_servers.nextbrowser_browser.env.NEXTBROWSER_NEXTCTL_BIN=${JSON.stringify(engine.nextctlBin)}`,
     "-c", `mcp_servers.nextbrowser_browser.env.NEXTBROWSER_PROFILE=${JSON.stringify(engine.profile || "")}`,
     "-c", "mcp_servers.nextbrowser_browser.default_tools_approval_mode=\"approve\"",
-    "-c", `developer_instructions=${JSON.stringify("Browser engine mode is active. Use only the nextbrowser-browser MCP tools for browser work. If the request mentions a proxy, country, or identity, you MUST call browser_prepare with the ISO country before any navigation or page inspection and proceed only when it succeeds. Do not use clawbrowser MCP, nbc, nextctl, or shell commands for browser work.")}`,
+    "-c", `developer_instructions=${JSON.stringify("Browser engine mode is active. Use only the nextbrowser-browser MCP tools. ALWAYS call browser_prepare before every other nextbrowser-browser tool and proceed only after it succeeds. If the request mentions a proxy, country, or identity, pass the requested two-letter ISO country so nextctl rotates and verifies the proxy before browser work. Never navigate, inspect, or act before preparation. Do not use clawbrowser MCP, nbc, nextctl, or shell commands for browser work.")}`,
   ];
   if (agentId === "claude") return [
     "--strict-mcp-config", "--mcp-config", JSON.stringify({

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -50,7 +50,6 @@ function codexClawbrowserArgs() {
 function browserEngineAgentArgs(agentId, engine) {
   if (!engine) return [];
   if (agentId === "codex") return [
-    "--ignore-user-config",
     "--ask-for-approval", "never",
     "--sandbox", "workspace-write",
     "-c", "sandbox_workspace_write.network_access=true",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "concurrently -k \"vite --port 1421\" \"wait-on tcp:1421 && cross-env VITE_DEV_SERVER_URL=http://localhost:1421 electron .\"",
     "build": "tsc && vite build",
     "postinstall": "electron-builder install-app-deps",
-    "test": "vitest run --exclude electron/agent-workspace.test.cjs --exclude electron/workspace-instructions.test.cjs --exclude electron/github-stars.test.cjs --exclude electron/command-runner.test.cjs --exclude electron/ssh-config.test.cjs --exclude electron/proxy-traffic.test.cjs && node --test electron/agent-workspace.test.cjs electron/workspace-instructions.test.cjs electron/github-stars.test.cjs electron/command-runner.test.cjs electron/ssh-config.test.cjs electron/proxy-traffic.test.cjs && node scripts/verify-pty.cjs",
+    "test": "vitest run --exclude electron/agent-workspace.test.cjs --exclude electron/workspace-instructions.test.cjs --exclude electron/github-stars.test.cjs --exclude electron/command-runner.test.cjs --exclude electron/ssh-config.test.cjs --exclude electron/proxy-traffic.test.cjs && node --test electron/agent-workspace.test.cjs electron/workspace-instructions.test.cjs electron/github-stars.test.cjs electron/command-runner.test.cjs electron/ssh-config.test.cjs electron/proxy-traffic.test.cjs && python3 -m unittest browser-engine/test_worker_verification.py && node scripts/verify-pty.cjs",
     "start": "electron .",
     "pack": "npm run build && electron-builder --dir",
     "dist": "npm run build && electron-builder --publish never",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "dist:publish": "npm run build && electron-builder --publish always",
     "dist:mac": "npm run build && electron-builder --mac dmg zip --publish never",
     "dist:win": "npm run build && electron-builder --win nsis --publish never",
-    "icons": "node scripts/generate-icons.mjs"
+    "icons": "node scripts/generate-icons.mjs",
+    "browser-engine:build": "python3 scripts/build-browser-engine.py"
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.11.0",
@@ -61,6 +62,12 @@
       "dist/**/*",
       "electron/**/*",
       "package.json"
+    ],
+    "extraResources": [
+      {
+        "from": "browser-engine/dist/nextbrowser-browser-engine",
+        "to": "browser-engine"
+      }
     ],
     "directories": {
       "output": "release"

--- a/scripts/build-browser-engine.py
+++ b/scripts/build-browser-engine.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Build the optional Browser Use engine as a self-contained sidecar."""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = ROOT / "browser-engine" / "worker.py"
+WORK = ROOT / "browser-engine" / "build"
+DIST = ROOT / "browser-engine" / "dist"
+NAME = "nextbrowser-browser-engine"
+
+shutil.rmtree(WORK, ignore_errors=True)
+shutil.rmtree(DIST, ignore_errors=True)
+subprocess.run([
+    sys.executable, "-m", "PyInstaller", "--noconfirm", "--clean", "--onedir",
+    "--name", NAME, "--distpath", str(DIST), "--workpath", str(WORK),
+    "--specpath", str(WORK), "--collect-submodules", "browser_use.browser",
+    "--collect-submodules", "browser_use.dom", "--collect-submodules", "browser_use.actor",
+    "--collect-submodules", "mcp.server", str(SOURCE),
+], cwd=ROOT, check=True)
+shutil.copy2(ROOT / "browser-engine" / "LICENSE.browser-use", DIST / NAME / "LICENSE.browser-use")
+print(DIST / NAME)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ import {
 } from "./lib/appNavigation";
 import { internalError } from "./lib/userFacingError";
 import { invoke, listen } from "./electronBridge";
-import { agentById } from "./agents";
+import { agentById, supportsBrowserEngine } from "./agents";
 import { UserFacingError } from "./components/UserFacingError";
 import { AgentInstallLink } from "./components/AgentInstallLink";
 
@@ -221,6 +221,9 @@ function SettingsModal({
   const logoutAgent = useStore((s) => s.logoutAgent);
   const terminalChat = useStore((s) => s.terminalChat);
   const setTerminalChat = useStore((s) => s.setTerminalChat);
+  const browserEngine = useStore((s) => s.browserEngine);
+  const browserEngineAvailable = useStore((s) => s.browserEngineAvailable);
+  const setBrowserEngine = useStore((s) => s.setBrowserEngine);
   const profiles = useStore((s) => {
     const defaultKnown = !!s.defaultSession?.session?.name || (s.defaultSession?.status ?? "unknown") !== "unknown";
     const hasListedDefault = s.profiles.some((profile) => profile.name === "default");
@@ -391,6 +394,30 @@ function SettingsModal({
               aria-checked={terminalChat}
               aria-label="Terminal chat"
               onClick={() => setTerminalChat(!terminalChat)}
+            >
+              <span />
+            </button>
+          </div>
+          <div className="settings-experiment-row">
+            <span className="settings-feature-icon">
+              <Icon name="globe" size={17} />
+            </span>
+            <span className="settings-feature-copy">
+              <strong>Browser Use engine <span className="experimental-pill">Experimental</span></strong>
+              <span className="muted small">
+                Browser Use handles semantic DOM and page actions. {supportsBrowserEngine(agentId)
+                  ? browserEngineAvailable ? "Your selected agent still plans every step." : "This build does not contain the engine component."
+                  : "Currently available for Codex and Claude Code."}
+              </span>
+            </span>
+            <button
+              type="button"
+              className={"settings-switch" + (browserEngine ? " is-on" : "")}
+              role="switch"
+              aria-checked={browserEngine}
+              aria-label="Browser Use engine"
+              disabled={!browserEngine && (!browserEngineAvailable || !supportsBrowserEngine(agentId))}
+              onClick={() => setBrowserEngine(!browserEngine)}
             >
               <span />
             </button>

--- a/src/agents.test.ts
+++ b/src/agents.test.ts
@@ -23,6 +23,7 @@ describe("agent invocation parity", () => {
     const invocation = agentInvocation(agentById("codex"), "scrape", {
       command: "/opt/nextbrowser-browser-engine",
       cdpUrl: "http://127.0.0.1:9222",
+      nextctlBin: "/opt/nbc",
     });
     expect(invocation.args).toContain("--ignore-user-config");
     expect(invocation.args.join(" ")).toContain("nextbrowser_browser");
@@ -34,6 +35,7 @@ describe("agent invocation parity", () => {
     const invocation = agentInvocation(agentById("claude"), "post", {
       command: "engine.exe",
       cdpUrl: "http://127.0.0.1:9333",
+      nextctlBin: "nbc.exe",
     });
     expect(invocation.args).toContain("--strict-mcp-config");
     expect(invocation.args.join(" ")).toContain("nextbrowser-browser");

--- a/src/agents.test.ts
+++ b/src/agents.test.ts
@@ -27,6 +27,7 @@ describe("agent invocation parity", () => {
     expect(invocation.args).toContain("--ignore-user-config");
     expect(invocation.args.join(" ")).toContain("nextbrowser_browser");
     expect(invocation.args.join(" ")).toContain("127.0.0.1:9222");
+    expect(invocation.args.join(" ")).toContain("default_tools_approval_mode");
     expect(invocation.stdin).toBe("scrape");
   });
   it("uses Claude strict MCP config without adding an LLM credential", () => {

--- a/src/agents.test.ts
+++ b/src/agents.test.ts
@@ -6,12 +6,37 @@ import {
   isMissingAgentInstallError,
   missingAgentInstallError,
   nextctlAgentAdapter,
+  supportsBrowserEngine,
 } from "./agents";
 
 describe("agent invocation parity", () => {
   it("maps app agent ids to nextctl adapters", () => {
     expect(nextctlAgentAdapter("claude")).toBe("claude-code");
     expect(nextctlAgentAdapter("codex")).toBe("codex");
+  });
+  it("limits the experimental browser engine to agents with isolated MCP config", () => {
+    expect(supportsBrowserEngine("codex")).toBe(true);
+    expect(supportsBrowserEngine("claude")).toBe(true);
+    expect(supportsBrowserEngine("gemini")).toBe(false);
+  });
+  it("injects only the browser engine MCP into Codex", () => {
+    const invocation = agentInvocation(agentById("codex"), "scrape", {
+      command: "/opt/nextbrowser-browser-engine",
+      cdpUrl: "http://127.0.0.1:9222",
+    });
+    expect(invocation.args).toContain("--ignore-user-config");
+    expect(invocation.args.join(" ")).toContain("nextbrowser_browser");
+    expect(invocation.args.join(" ")).toContain("127.0.0.1:9222");
+    expect(invocation.stdin).toBe("scrape");
+  });
+  it("uses Claude strict MCP config without adding an LLM credential", () => {
+    const invocation = agentInvocation(agentById("claude"), "post", {
+      command: "engine.exe",
+      cdpUrl: "http://127.0.0.1:9333",
+    });
+    expect(invocation.args).toContain("--strict-mcp-config");
+    expect(invocation.args.join(" ")).toContain("nextbrowser-browser");
+    expect(invocation.args.join(" ")).not.toMatch(/API_KEY|OPENAI|ANTHROPIC/);
   });
   it("links primary agents to their supported installation pages", () => {
     expect(agentById("claude").installUrl).toBe("https://code.claude.com/docs/en/installation");

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -127,17 +127,56 @@ export function nextctlAgentAdapter(id: string): string {
   return id === "claude" ? "claude-code" : id;
 }
 
+export interface BrowserEngineConfig {
+  command: string;
+  cdpUrl: string;
+}
+
+export function supportsBrowserEngine(agentId: string): boolean {
+  return agentId === "codex" || agentId === "claude";
+}
+
+function browserEngineMcp(config: BrowserEngineConfig) {
+  return {
+    mcpServers: {
+      "nextbrowser-browser": {
+        command: config.command,
+        env: { NEXTBROWSER_CDP_URL: config.cdpUrl },
+      },
+    },
+  };
+}
+
 /// Build CLI args (+ optional stdin) for one non-interactive prompt.
 export function agentInvocation(
   spec: AgentSpec,
   prompt: string,
+  browserEngine?: BrowserEngineConfig,
 ): { args: string[]; stdin?: string } {
   switch (spec.runStyle) {
     case "claudePrint":
-      return { args: ["-p", "--dangerously-skip-permissions", prompt] };
+      return { args: [
+        "-p",
+        "--dangerously-skip-permissions",
+        ...(browserEngine
+          ? ["--strict-mcp-config", "--mcp-config", JSON.stringify(browserEngineMcp(browserEngine))]
+          : []),
+        prompt,
+      ] };
     case "codexExec":
       return {
-        args: ["exec", "--skip-git-repo-check", "--dangerously-bypass-approvals-and-sandbox", "-"],
+        args: [
+          "exec",
+          "--skip-git-repo-check",
+          "--dangerously-bypass-approvals-and-sandbox",
+          ...(browserEngine ? [
+            "--ignore-user-config",
+            "-c", `mcp_servers.nextbrowser_browser.command=${JSON.stringify(browserEngine.command)}`,
+            "-c", `mcp_servers.nextbrowser_browser.env.NEXTBROWSER_CDP_URL=${JSON.stringify(browserEngine.cdpUrl)}`,
+            "-c", "mcp_servers.nextbrowser_browser.startup_timeout_sec=30",
+          ] : []),
+          "-",
+        ],
         stdin: prompt,
       };
     case "hermesOneshot":

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -174,6 +174,7 @@ export function agentInvocation(
             "-c", `mcp_servers.nextbrowser_browser.command=${JSON.stringify(browserEngine.command)}`,
             "-c", `mcp_servers.nextbrowser_browser.env.NEXTBROWSER_CDP_URL=${JSON.stringify(browserEngine.cdpUrl)}`,
             "-c", "mcp_servers.nextbrowser_browser.startup_timeout_sec=30",
+            "-c", "mcp_servers.nextbrowser_browser.default_tools_approval_mode=\"approve\"",
           ] : []),
           "-",
         ],

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -130,6 +130,8 @@ export function nextctlAgentAdapter(id: string): string {
 export interface BrowserEngineConfig {
   command: string;
   cdpUrl: string;
+  nextctlBin: string;
+  profile?: string;
 }
 
 export function supportsBrowserEngine(agentId: string): boolean {
@@ -141,7 +143,11 @@ function browserEngineMcp(config: BrowserEngineConfig) {
     mcpServers: {
       "nextbrowser-browser": {
         command: config.command,
-        env: { NEXTBROWSER_CDP_URL: config.cdpUrl },
+        env: {
+          NEXTBROWSER_CDP_URL: config.cdpUrl,
+          NEXTBROWSER_NEXTCTL_BIN: config.nextctlBin,
+          NEXTBROWSER_PROFILE: config.profile ?? "",
+        },
       },
     },
   };
@@ -173,6 +179,8 @@ export function agentInvocation(
             "--ignore-user-config",
             "-c", `mcp_servers.nextbrowser_browser.command=${JSON.stringify(browserEngine.command)}`,
             "-c", `mcp_servers.nextbrowser_browser.env.NEXTBROWSER_CDP_URL=${JSON.stringify(browserEngine.cdpUrl)}`,
+            "-c", `mcp_servers.nextbrowser_browser.env.NEXTBROWSER_NEXTCTL_BIN=${JSON.stringify(browserEngine.nextctlBin)}`,
+            "-c", `mcp_servers.nextbrowser_browser.env.NEXTBROWSER_PROFILE=${JSON.stringify(browserEngine.profile ?? "")}`,
             "-c", "mcp_servers.nextbrowser_browser.startup_timeout_sec=30",
             "-c", "mcp_servers.nextbrowser_browser.default_tools_approval_mode=\"approve\"",
           ] : []),

--- a/src/components/AgentTerminal.tsx
+++ b/src/components/AgentTerminal.tsx
@@ -10,6 +10,8 @@ interface AgentTerminalProps {
   agentName: string;
   conversationId?: string;
   workingDir?: string;
+  browserEngine?: boolean;
+  selectedProfile?: string;
   onClose: () => void;
 }
 
@@ -67,7 +69,7 @@ function activeTerminalTheme() {
     : DARK_TERMINAL_THEME;
 }
 
-export function AgentTerminal({ agentId, agentName, conversationId, workingDir, onClose }: AgentTerminalProps) {
+export function AgentTerminal({ agentId, agentName, conversationId, workingDir, browserEngine, selectedProfile, onClose }: AgentTerminalProps) {
   const hostRef = useRef<HTMLDivElement>(null);
   const terminalIdRef = useRef<string>();
   const [status, setStatus] = useState<"starting" | "running" | "exited" | "failed">("starting");
@@ -131,11 +133,15 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
         terminal.write(`\r\n\x1b[90mProcess exited (${exitCode}).\x1b[0m\r\n`);
         setStatus("exited");
       });
+      const engine = browserEngine
+        ? await invoke<{ command: string; cdpUrl: string }>("browser_engine_prepare", { profile: selectedProfile || null })
+        : null;
       const id = await invoke<string>("terminal_start", {
         agentId,
         workingDir: workingDir || null,
         cols: terminal.cols,
         rows: terminal.rows,
+        browserEngine: engine,
       });
       if (disposed) {
         await invoke("terminal_kill", { id });
@@ -171,7 +177,7 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
   // A terminal is the interactive state of one chat, not a global agent
   // process. Restart it when the selected conversation changes so pending
   // input, scrollback, or an unfinished prompt cannot leak into another chat.
-  }, [agentId, conversationId, workingDir]);
+  }, [agentId, browserEngine, conversationId, selectedProfile, workingDir]);
 
   return (
     <section className="agent-terminal-panel" aria-label={`${agentName} terminal`}>

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -299,6 +299,8 @@ export function ChatView() {
             agentName={agentName}
             conversationId={conv?.id}
             workingDir={s.workingDir}
+            browserEngine={s.browserEngine}
+            selectedProfile={s.selectedProfile}
             onClose={() => s.setTerminalChat(false)}
           />
         ) : (

--- a/src/store.ts
+++ b/src/store.ts
@@ -15,6 +15,8 @@ import {
   agentInvocation,
   missingAgentInstallError,
   nextctlAgentAdapter,
+  supportsBrowserEngine,
+  type BrowserEngineConfig,
   type AgentSpec,
 } from "./agents";
 import {
@@ -325,6 +327,8 @@ interface State {
   sidebarCollapsed: boolean;
   chatListCollapsed: boolean;
   terminalChat: boolean;
+  browserEngine: boolean;
+  browserEngineAvailable: boolean;
   dashboardKeyPromptOpen: boolean;
   accountPairing?: AccountPairingState;
   nextctlVersion: string;
@@ -379,6 +383,7 @@ interface State {
   setSidebarCollapsed: (v: boolean) => void;
   setChatListCollapsed: (v: boolean) => void;
   setTerminalChat: (v: boolean) => void;
+  setBrowserEngine: (v: boolean) => void;
   setDashboardKeyPromptOpen: (v: boolean) => void;
   setOnboardingStepIndex: (index: number) => void;
   suspendOnboardingForSetup: () => void;
@@ -865,6 +870,8 @@ export const useStore = create<State>((set, get) => {
   sidebarCollapsed: localStorage.getItem("sidebarCollapsed") === "true",
   chatListCollapsed: localStorage.getItem("chatListCollapsed") === "true",
   terminalChat: localStorage.getItem("terminalChat") === "true",
+  browserEngine: localStorage.getItem("browserEngine") === "true",
+  browserEngineAvailable: false,
   dashboardKeyPromptOpen: false,
   accountPairing: undefined,
   nextctlVersion: "",
@@ -921,13 +928,14 @@ export const useStore = create<State>((set, get) => {
     didBootstrap = true;
     const startedAt = performance.now();
     trackEvent("bootstrap_started");
-    const [rawConvs, rawSchedules, rawScripts, rawAppliedScripts, rawHistory, wd] = await Promise.all([
+    const [rawConvs, rawSchedules, rawScripts, rawAppliedScripts, rawHistory, wd, engineStatus] = await Promise.all([
       loadJson<Conversation[]>("conversations.json", []),
       loadJson<ScheduledRun[]>("scheduled-runs.json", []),
       loadJson<CustomScript[]>("custom-scripts.json", []),
       loadJson<SkillEntry[]>("applied-scripts.json", []),
       loadJson<UsageSnapshot[]>("usage-history.json", []),
       invoke<string>("working_directory").catch(() => ""),
+      invoke<{ available: boolean }>("browser_engine_status").catch(() => ({ available: false })),
     ]);
     const convs = rawConvs.map(normalizeConversation);
     const schedules = rawSchedules.map(normalizeSchedule);
@@ -946,6 +954,7 @@ export const useStore = create<State>((set, get) => {
       appliedScripts: rawAppliedScripts.filter((entry) => entry?.selector?.kind === "script"),
       usageHistory: history,
       workingDir: wd,
+      browserEngineAvailable: engineStatus.available,
     });
     get().reconcileQueues();
 
@@ -1364,7 +1373,7 @@ export const useStore = create<State>((set, get) => {
     });
     if (item.executionTarget === "local") get().startSessionPoll();
 
-    const prompt = composePrompt(
+    let prompt = composePrompt(
       get().conversations,
       item.conversationId,
       item.replyId,
@@ -1373,7 +1382,33 @@ export const useStore = create<State>((set, get) => {
       { nextctlAvailable: get().nextctlAvailable, executionTarget: item.executionTarget },
     );
     const a = agentById(agentId);
-    const { args, stdin } = agentInvocation(a, prompt);
+    let browserEngineConfig: BrowserEngineConfig | undefined;
+    if (get().browserEngine && item.executionTarget === "local") {
+      if (!supportsBrowserEngine(agentId)) {
+        get().setMessageStatus(item.conversationId, item.replyId, "failed", "Browser engine is currently supported by Codex and Claude Code only.");
+        replyExecutionTargets.delete(item.replyId);
+        set((s) => ({ runtime: { ...s.runtime, [agentId]: { ...s.runtime[agentId], runningReplyId: undefined } } }));
+        return;
+      }
+      try {
+        await prepareLocalSession({
+          selectedProfile: get().selectedProfile,
+          statuses: get().statuses,
+          defaultSession: get().defaultSession,
+        });
+        browserEngineConfig = await invoke<BrowserEngineConfig>("browser_engine_prepare", {
+          profile: get().selectedProfile || null,
+        });
+        prompt += "\n\nBrowser engine mode is enabled. Use only the nextbrowser-browser MCP tools for browser page inspection and actions. The browser session is already running; do not start another browser and do not use nextctl for page actions. You remain responsible for planning and interpreting results.";
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        get().setMessageStatus(item.conversationId, item.replyId, "failed", `Browser engine could not start: ${message}`);
+        replyExecutionTargets.delete(item.replyId);
+        set((s) => ({ runtime: { ...s.runtime, [agentId]: { ...s.runtime[agentId], runningReplyId: undefined } } }));
+        return;
+      }
+    }
+    const { args, stdin } = agentInvocation(a, prompt, browserEngineConfig);
 
     const watchdog = setInterval(() => {
       const conv = get().conversations.find((c) => c.id === item.conversationId);
@@ -2362,6 +2397,10 @@ export const useStore = create<State>((set, get) => {
   setTerminalChat: (v) => {
     localStorage.setItem("terminalChat", String(v));
     set({ terminalChat: v });
+  },
+  setBrowserEngine: (v) => {
+    localStorage.setItem("browserEngine", String(v));
+    set({ browserEngine: v });
   },
   setDashboardKeyPromptOpen: (v) => {
     trackEvent(v ? "dashboard_key_prompt_opened" : "dashboard_key_prompt_closed");

--- a/src/store.ts
+++ b/src/store.ts
@@ -1399,7 +1399,7 @@ export const useStore = create<State>((set, get) => {
         browserEngineConfig = await invoke<BrowserEngineConfig>("browser_engine_prepare", {
           profile: get().selectedProfile || null,
         });
-        prompt += "\n\nBrowser engine mode is enabled. Use only the nextbrowser-browser MCP tools for browser work. If the request mentions a proxy, country, or identity, you MUST call browser_prepare with the ISO country before any navigation or page inspection and proceed only when it succeeds. Do not invoke clawbrowser MCP, nbc, nextctl, or shell commands for browser work. You remain responsible for planning and interpreting results.";
+        prompt += "\n\nBrowser engine mode is enabled. Use only the nextbrowser-browser MCP tools for browser work. ALWAYS call browser_prepare before every other browser tool and proceed only after it succeeds. If the request mentions a proxy, country, or identity, pass the requested two-letter ISO country so nextctl rotates and verifies the proxy before browser work. Never navigate, inspect, or act before preparation. Do not invoke clawbrowser MCP, nbc, nextctl, or shell commands for browser work. You remain responsible for planning and interpreting results.";
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         get().setMessageStatus(item.conversationId, item.replyId, "failed", `Browser engine could not start: ${message}`);

--- a/src/store.ts
+++ b/src/store.ts
@@ -1399,7 +1399,7 @@ export const useStore = create<State>((set, get) => {
         browserEngineConfig = await invoke<BrowserEngineConfig>("browser_engine_prepare", {
           profile: get().selectedProfile || null,
         });
-        prompt += "\n\nBrowser engine mode is enabled. Use only the nextbrowser-browser MCP tools for browser page inspection and actions. The browser session is already running; do not start another browser and do not use nextctl for page actions. You remain responsible for planning and interpreting results.";
+        prompt += "\n\nBrowser engine mode is enabled. Use only the nextbrowser-browser MCP tools for browser work. If the request mentions a proxy, country, or identity, you MUST call browser_prepare with the ISO country before any navigation or page inspection and proceed only when it succeeds. Do not invoke clawbrowser MCP, nbc, nextctl, or shell commands for browser work. You remain responsible for planning and interpreting results.";
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         get().setMessageStatus(item.conversationId, item.replyId, "failed", `Browser engine could not start: ${message}`);

--- a/src/store.ts
+++ b/src/store.ts
@@ -1399,7 +1399,7 @@ export const useStore = create<State>((set, get) => {
         browserEngineConfig = await invoke<BrowserEngineConfig>("browser_engine_prepare", {
           profile: get().selectedProfile || null,
         });
-        prompt += "\n\nBrowser engine mode is enabled. Use only the nextbrowser-browser MCP tools for browser work. ALWAYS call browser_prepare before every other browser tool and proceed only after it succeeds. If the request mentions a proxy, country, or identity, pass the requested two-letter ISO country so nextctl rotates and verifies the proxy before browser work. Never navigate, inspect, or act before preparation. Do not invoke clawbrowser MCP, nbc, nextctl, or shell commands for browser work. You remain responsible for planning and interpreting results.";
+        prompt += "\n\nBrowser engine mode is enabled. Use only the nextbrowser-browser MCP tools for browser work. Call browser_prepare exactly once at the beginning of the browser task and proceed only after it succeeds. Do not call browser_prepare again during the same task unless it failed or the user explicitly requests a different identity. If the request mentions a proxy, country, or identity, pass the requested two-letter ISO country so nextctl rotates and verifies the proxy before browser work. Never navigate, inspect, or act before preparation. Do not invoke clawbrowser MCP, nbc, nextctl, or shell commands for browser work. You remain responsible for planning and interpreting results.";
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         get().setMessageStatus(item.conversationId, item.replyId, "failed", `Browser engine could not start: ${message}`);


### PR DESCRIPTION
## What changed

- adds an optional standalone MCP sidecar that uses Browser Use BrowserSession, semantic DOM, stable element indexes, and action events against the existing Clawbrowser CDP endpoint
- deliberately excludes Browser Use Agent, prompts, LLM selection, cloud browser launcher, and API keys; Codex or Claude remains the planner and nextctl remains the lifecycle/profile/proxy owner
- adds Settings → Browser Use engine (Experimental) for a direct A/B comparison with the current nextctl MCP path
- supports both standard chat and terminal chat for Codex and Claude Code
- packages native PyInstaller sidecars independently on macOS and Windows and ships the upstream MIT notice

## Browser tools

State/semantic DOM, navigate, indexed or coordinate click, indexed type, scroll, back, HTML, JavaScript evaluation, screenshot, list/switch/close tabs.

## Verification

- npm test (163 Vitest tests + 30 Electron/native tests)
- npm run build
- npm run pack
- packaged macOS app passes codesign --verify --deep --strict
- source MCP smoke test against a real CDP Chrome session: semantic DOM → indexed type → indexed click → result verification (works)
- packaged sidecar connected to the same CDP session and returned Browser Use DOM state/action result

CI builds and packages the sidecar separately on macOS arm64 and Windows x64 with Python 3.12.
