### PR TITLE
Handle failed browser verification before local tasks

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -581,6 +581,31 @@ async function invokeCommand(command, args = {}) {
       return null;
     }
     case "read_file": return fs.readFile(args.path, "utf8");
+    case "browser_verification_failure_choice": {
+      const owner = BrowserWindow.getFocusedWindow() || BrowserWindow.getAllWindows()[0];
+      const surfaces = Array.isArray(args.failedSurfaces)
+        ? args.failedSurfaces.map((value) => String(value).trim()).filter(Boolean).slice(0, 8)
+        : [];
+      const detail = [
+        surfaces.length ? `Failed checks: ${surfaces.join(", ")}.` : "The browser verification did not complete successfully.",
+        "You can retry, or continue this task in the direct browser session without the selected proxy.",
+        "Continuing without proxy may expose your real IP and will not preserve the requested country.",
+      ].join("\n\n");
+      const options = {
+        type: "warning",
+        title: "Proxy verification failed",
+        message: "The selected proxy could not be verified.",
+        detail,
+        buttons: ["Retry verification", "Continue without proxy", "Cancel"],
+        defaultId: 0,
+        cancelId: 2,
+        noLink: true,
+      };
+      const result = owner
+        ? await dialog.showMessageBox(owner, options)
+        : await dialog.showMessageBox(options);
+      return ["retry", "direct", "cancel"][result.response] || "cancel";
+    }
     case "ssh_config_hosts": {
       const requestedPath = typeof args.configPath === "string" ? args.configPath.trim() : "";
       if (requestedPath.length > 4096 || requestedPath.includes("\0")) throw new Error("Invalid SSH config path.");

--- a/src/preflight.test.ts
+++ b/src/preflight.test.ts
@@ -138,4 +138,48 @@ describe("prepareSession command reporting", () => {
     expect(onStep).not.toHaveBeenCalledWith("Browser verified");
     expect(nextctl.run).not.toHaveBeenCalled();
   });
+
+  it("retries verification when the user chooses retry", async () => {
+    const onStep = vi.fn();
+    const onVerificationFailure = vi.fn().mockResolvedValue("retry");
+    nextctl.json
+      .mockResolvedValueOnce({
+        verify: { finalized: true, status: "fail", checks: [{ surface: "Proxy", pass: false }] },
+      })
+      .mockResolvedValueOnce(greenVerification)
+      .mockResolvedValueOnce({ tabs: [{ id: "page", url: "about:blank" }] });
+
+    const result = await prepareSession({
+      statuses: {},
+      defaultSession: { status: "running" },
+      onStep,
+      onVerificationFailure,
+    });
+
+    expect(onVerificationFailure).toHaveBeenCalledTimes(1);
+    expect(onStep).toHaveBeenCalledWith("Browser verified");
+    expect(result.directFallback).toBe(false);
+  });
+
+  it("switches the current task to the direct session when the user bypasses the proxy", async () => {
+    const onStep = vi.fn();
+    nextctl.json
+      .mockResolvedValueOnce({
+        verify: { finalized: true, status: "fail", checks: [{ surface: "Proxy", pass: false }] },
+      })
+      .mockResolvedValueOnce({ tabs: [{ id: "direct", url: "about:blank" }] });
+
+    const result = await prepareSession({
+      selectedProfile: "proxy-profile",
+      statuses: { "proxy-profile": "running" },
+      defaultSession: { status: "running" },
+      onStep,
+      onVerificationFailure: async () => "direct",
+    });
+
+    expect(result.profileArgs).toEqual([]);
+    expect(result.directFallback).toBe(true);
+    expect(onStep).toHaveBeenCalledWith("Continuing without proxy");
+    expect(nextctl.run).not.toHaveBeenCalled();
+  });
 });

--- a/src/preflight.test.ts
+++ b/src/preflight.test.ts
@@ -15,11 +15,19 @@ vi.mock("./nextctl", () => ({
 }));
 
 const success = { stdout: "", stderr: "", code: 0 };
+const greenVerification = {
+  verify: {
+    finalized: true,
+    status: "pass",
+    checks: [{ surface: "Proxy", pass: true }],
+  },
+};
 
 beforeEach(() => {
   nextctl.json.mockReset();
   nextctl.run.mockReset();
-  nextctl.json.mockResolvedValue({ tabs: [] });
+  nextctl.json.mockImplementation(async (args: string[]) =>
+    args.includes("verify") ? greenVerification : { tabs: [] });
   nextctl.run.mockResolvedValue(success);
 });
 
@@ -96,6 +104,7 @@ describe("prepareSession command reporting", () => {
   it("does not report a blank page when nextctl returns no tab", async () => {
     const onStep = vi.fn();
     nextctl.json
+      .mockResolvedValueOnce(greenVerification)
       .mockResolvedValueOnce({ tabs: [] })
       .mockResolvedValueOnce({});
 
@@ -106,5 +115,27 @@ describe("prepareSession command reporting", () => {
     })).rejects.toThrow("Could not open a blank page: nextctl returned no tab");
 
     expect(onStep).not.toHaveBeenCalledWith("Opened a blank page");
+  });
+
+  it("stops before navigation when browser verification is not green", async () => {
+    const onStep = vi.fn();
+    nextctl.json.mockResolvedValueOnce({
+      verify: {
+        finalized: true,
+        status: "fail",
+        checks: [{ surface: "Proxy", pass: false }],
+      },
+    });
+
+    await expect(prepareSession({
+      host: "example.com",
+      statuses: {},
+      defaultSession: { status: "running" },
+      onStep,
+    })).rejects.toThrow("Browser verification is not green: Proxy");
+
+    expect(onStep).toHaveBeenCalledWith("Session running");
+    expect(onStep).not.toHaveBeenCalledWith("Browser verified");
+    expect(nextctl.run).not.toHaveBeenCalled();
   });
 });

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -87,6 +87,24 @@ interface VerificationResult {
   };
 }
 
+export type VerificationFailureChoice = "retry" | "direct" | "cancel";
+
+export interface VerificationFailure {
+  message: string;
+  failedSurfaces: string[];
+}
+
+class BrowserVerificationError extends Error {
+  readonly failedSurfaces: string[];
+
+  constructor(failedSurfaces: string[]) {
+    const suffix = failedSurfaces.length ? `: ${failedSurfaces.join(", ")}` : ".";
+    super(`Browser verification is not green${suffix}`);
+    this.name = "BrowserVerificationError";
+    this.failedSurfaces = failedSurfaces;
+  }
+}
+
 async function requireGreenVerification(args: string[]): Promise<void> {
   const data = await nextctlJson<VerificationResult>([
     ...args,
@@ -97,8 +115,8 @@ async function requireGreenVerification(args: string[]): Promise<void> {
   const verification = data.verify;
   const failed = verification?.checks?.filter((check) => check.pass !== true) ?? [];
   if (verification?.finalized !== true || verification.status !== "pass" || failed.length > 0) {
-    const surfaces = failed.map((check) => check.surface).filter(Boolean).join(", ");
-    throw new Error(`Browser verification is not green${surfaces ? `: ${surfaces}` : "."}`);
+    const surfaces = failed.flatMap((check) => check.surface ? [check.surface] : []);
+    throw new BrowserVerificationError(surfaces);
   }
 }
 
@@ -121,6 +139,7 @@ export interface PrepareResult {
   profileArgs: string[];
   host?: string;
   steps: string[];
+  directFallback?: boolean;
 }
 
 export async function prepareSession(opts: {
@@ -129,9 +148,11 @@ export async function prepareSession(opts: {
   statuses: Record<string, string>;
   defaultSession?: SessionStatus;
   onStep?: (step: string) => void;
+  onVerificationFailure?: (failure: VerificationFailure) => Promise<VerificationFailureChoice>;
 }): Promise<PrepareResult> {
-  const args = profileArgs(opts.selectedProfile);
+  let args = profileArgs(opts.selectedProfile);
   const steps: string[] = [];
+  let directFallback = false;
   const rawHost = opts.host?.trim();
   const step = (text: string) => {
     steps.push(text);
@@ -149,8 +170,29 @@ export async function prepareSession(opts: {
     step("Started NextBrowser");
   }
 
-  await requireGreenVerification(args);
-  step("Browser verified");
+  while (true) {
+    try {
+      await requireGreenVerification(args);
+      step("Browser verified");
+      break;
+    } catch (error) {
+      if (!(error instanceof BrowserVerificationError) || !opts.onVerificationFailure) throw error;
+      const choice = await opts.onVerificationFailure({
+        message: error.message,
+        failedSurfaces: error.failedSurfaces,
+      });
+      if (choice === "retry") continue;
+      if (choice !== "direct") throw error;
+
+      args = [];
+      directFallback = true;
+      if (opts.defaultSession?.status !== "running") {
+        await runChecked(["start", "--format", "json"], "Could not start a direct NextBrowser session");
+      }
+      step("Continuing without proxy");
+      break;
+    }
+  }
 
   if (rawHost) {
     if (await activateMatchingTab(args, rawHost)) {
@@ -173,5 +215,5 @@ export async function prepareSession(opts: {
     step("Opened a blank page");
   }
 
-  return { profileArgs: args, host: rawHost || undefined, steps };
+  return { profileArgs: args, host: rawHost || undefined, steps, directFallback };
 }

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -74,6 +74,34 @@ async function runChecked(args: string[], message: string): Promise<void> {
   }
 }
 
+interface VerificationCheck {
+  pass?: boolean;
+  surface?: string;
+}
+
+interface VerificationResult {
+  verify?: {
+    finalized?: boolean;
+    status?: string;
+    checks?: VerificationCheck[];
+  };
+}
+
+async function requireGreenVerification(args: string[]): Promise<void> {
+  const data = await nextctlJson<VerificationResult>([
+    ...args,
+    "verify",
+    "--timeout",
+    "30s",
+  ]);
+  const verification = data.verify;
+  const failed = verification?.checks?.filter((check) => check.pass !== true) ?? [];
+  if (verification?.finalized !== true || verification.status !== "pass" || failed.length > 0) {
+    const surfaces = failed.map((check) => check.surface).filter(Boolean).join(", ");
+    throw new Error(`Browser verification is not green${surfaces ? `: ${surfaces}` : "."}`);
+  }
+}
+
 async function openBlankActivePage(args: string[]): Promise<void> {
   const data = await nextctlJson<{ tab?: { id: string } }>([
     ...args,
@@ -120,6 +148,9 @@ export async function prepareSession(opts: {
     );
     step("Started NextBrowser");
   }
+
+  await requireGreenVerification(args);
+  step("Browser verified");
 
   if (rawHost) {
     if (await activateMatchingTab(args, rawHost)) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -8,7 +8,7 @@ import {
   type NextctlRunOptions,
   type RunResult,
 } from "./nextctl";
-import { prepareSession } from "./preflight";
+import { prepareSession, type VerificationFailureChoice } from "./preflight";
 import {
   AGENTS,
   agentById,
@@ -217,9 +217,12 @@ function skillKey(agentId: string, entryId: string) {
   return `${agentId}:${entryId}`;
 }
 
-function pageReadyNote(openedHost?: string): string {
-  if (!openedHost) return "";
-  return ` The page ${openedHost} is already open in the active NextBrowser profile — work there and don't navigate away unless the steps require it.`;
+function pageReadyNote(openedHost?: string, directFallback = false): string {
+  const direct = directFallback
+    ? " Use the default direct NextBrowser session for this task; do not switch back to the selected proxy profile."
+    : "";
+  if (!openedHost) return direct;
+  return ` The page ${openedHost} is already open in the active NextBrowser profile — work there and don't navigate away unless the steps require it.${direct}`;
 }
 
 function skillAgentPrompt(
@@ -228,10 +231,11 @@ function skillAgentPrompt(
   md: string | undefined,
   slug: string | undefined,
   openedHost?: string,
+  directFallback = false,
 ): string {
   const startHint = openedHost
-    ? pageReadyNote(openedHost)
-    : ` Start by opening ${target} in the active NextBrowser profile.`;
+    ? pageReadyNote(openedHost, directFallback)
+    : ` Start by opening ${target} in the active NextBrowser profile.${pageReadyNote(undefined, directFallback)}`;
   if (md) {
     return `Use the "${title}" skill to work with ${target}.${startHint} Follow this SKILL.md exactly, step by step:\n\n${md}`;
   }
@@ -247,8 +251,9 @@ function scriptAgentPrompt(
   md: string | undefined,
   slug: string | undefined,
   openedHost?: string,
+  directFallback = false,
 ): string {
-  const note = pageReadyNote(openedHost);
+  const note = pageReadyNote(openedHost, directFallback);
   if (md) {
     return `Run the "${title}" script ${where}.${note} Follow this SKILL.md exactly, step by step:\n\n${md}`;
   }
@@ -543,7 +548,13 @@ async function nextctlEnvelope<T>(
 async function prepareLocalSession(
   options: Parameters<typeof prepareSession>[0],
 ): ReturnType<typeof prepareSession> {
-  return runLocalNextctlOperation(() => prepareSession(options));
+  return runLocalNextctlOperation(() => prepareSession({
+    ...options,
+    onVerificationFailure: options.onVerificationFailure ?? ((failure) =>
+      invoke<VerificationFailureChoice>("browser_verification_failure_choice", {
+        failedSurfaces: failure.failedSurfaces,
+      })),
+  }));
 }
 
 async function waitForLocalNextctlIdle(getState: () => State): Promise<void> {
@@ -2945,6 +2956,7 @@ export const useStore = create<State>((set, get) => {
       md,
       ref?.slug ?? ref?.title,
       prep.host,
+      prep.directFallback,
     );
     get().enqueue(prompt, chip, cid);
     await get().loadDefaultSession();
@@ -3117,6 +3129,7 @@ export const useStore = create<State>((set, get) => {
       md,
       ref?.slug ?? ref?.title,
       prep.host,
+      prep.directFallback,
     );
     get().enqueue(
       prompt,
@@ -3308,7 +3321,7 @@ export const useStore = create<State>((set, get) => {
       title: script.title,
       detail: domain || get().currentSessionDisplayName(),
     };
-    const note = pageReadyNote(prep.host);
+    const note = pageReadyNote(prep.host, prep.directFallback);
     const prompt = `Run my custom script "${script.title}" on ${target} in the active NextBrowser session.${note}\nFollow these steps exactly:\n\n${script.instructions}`;
     get().enqueue(prompt, chip, cid);
   },


### PR DESCRIPTION
Extracts the useful verification contract discovered in the experimental browser-use work into the normal nextctl preflight.

Behavior:
- green verification continues automatically
- failed verification opens a native Retry verification / Continue without proxy / Cancel dialog
- Retry runs verification again
- Continue without proxy switches only the current task to the default direct session
- the selected proxy profile is preserved for future tasks
- agents are explicitly told to remain in the direct session for the bypassed task

This contains no browser-use engine or Python dependency.

Validation:
- 163 frontend and Electron tests pass
- production TypeScript/Vite build succeeds