### PR TITLE
Use the managed nextctl binary for terminal MCP

### DIFF
--- a/electron/agent-workspace.test.cjs
+++ b/electron/agent-workspace.test.cjs
@@ -27,6 +27,9 @@ test("terminal Codex keeps workspace isolation while allowing Clawbrowser networ
   assert.match(main, /default_tools_approval_mode = "approve"/);
   assert.match(main, /\[plugins\."browser@openai-bundled"\][\s\S]*enabled = false/);
   assert.match(main, /ensureCodexTerminalProfile\(\)/);
+  assert.match(main, /const nextctlBin = await resolveOrInstallNextctl\(\)/);
+  assert.match(main, /mcp_servers\.clawbrowser\.command=/);
+  assert.match(main, /mcp_servers\.clawbrowser\.args=/);
   assert.match(main, /"--add-dir", dir/);
   assert.match(main, /\.cache", "clawbrowser"/);
   assert.match(main, /\.local", "share", "clawbrowser"/);

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -38,12 +38,15 @@ enabled = false
 default_tools_approval_mode = "approve"
 `;
 
-function codexClawbrowserArgs() {
+function codexClawbrowserArgs(nextctlBin) {
   return [
     "--profile", CODEX_TERMINAL_PROFILE,
     "--ask-for-approval", "never",
     "--sandbox", "workspace-write",
     "-c", "sandbox_workspace_write.network_access=true",
+    "-c", `mcp_servers.clawbrowser.command=${JSON.stringify(nextctlBin)}`,
+    "-c", `mcp_servers.clawbrowser.args=${JSON.stringify(["mcp"])}`,
+    "-c", "mcp_servers.clawbrowser.startup_timeout_sec=30",
   ];
 }
 
@@ -78,7 +81,6 @@ const TERMINAL_AGENTS = {
   codex: {
     binary: "codex",
     envVar: "CODEX_BIN",
-    args: codexClawbrowserArgs(),
   },
   hermes: { binary: "hermes", envVar: "HERMES_BIN" },
   kilo: { binary: "kilo", envVar: "KILO_BIN" },
@@ -710,10 +712,16 @@ async function invokeCommand(command, args = {}) {
       if (!bin) throw new Error(`${agent.binary} CLI not found.`);
       const id = randomUUID();
       const writableDirs = args.agentId === "codex" ? clawbrowserWritableDirs() : [];
-      if (args.agentId === "codex") await ensureCodexTerminalProfile();
+      let agentArgs = agent.args || [];
+      if (args.agentId === "codex") {
+        await ensureCodexTerminalProfile();
+        const nextctlBin = await resolveOrInstallNextctl();
+        if (!nextctlBin) throw new Error("nextctl is required for Clawbrowser MCP.");
+        agentArgs = codexClawbrowserArgs(nextctlBin);
+      }
       await Promise.all(writableDirs.map((dir) => fs.mkdir(dir, { recursive: true })));
       const terminalArgs = [
-        ...(agent.args || []),
+        ...agentArgs,
         ...writableDirs.flatMap((dir) => ["--add-dir", dir]),
       ];
       const spec = commandSpec(bin, terminalArgs);


### PR DESCRIPTION
Fixes terminal Codex sessions failing the clawbrowser MCP handshake when a stale user plugin still points at an obsolete ~/.local/bin/nbc.

NextBrowser now resolves or installs its managed nextctl and explicitly overrides the clawbrowser MCP command and args for the Codex terminal profile. User plugin skills and approval settings remain available, but MCP execution no longer depends on a stale user binary.

Verified:
- managed nextctl 0.1.10 completes MCP initialize and exposes 46 tools
- 163 app tests pass
- production build succeeds