### PR TITLE
Auto-approve Clawbrowser tools in terminal chat

### DIFF
--- a/electron/agent-workspace.test.cjs
+++ b/electron/agent-workspace.test.cjs
@@ -30,6 +30,7 @@ test("terminal Codex keeps workspace isolation while allowing Clawbrowser networ
   assert.match(main, /const nextctlBin = await resolveOrInstallNextctl\(\)/);
   assert.match(main, /mcp_servers\.clawbrowser\.command=/);
   assert.match(main, /mcp_servers\.clawbrowser\.args=/);
+  assert.match(main, /mcp_servers\.clawbrowser\.default_tools_approval_mode=approve/);
   assert.match(main, /"--add-dir", dir/);
   assert.match(main, /\.cache", "clawbrowser"/);
   assert.match(main, /\.local", "share", "clawbrowser"/);

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -47,6 +47,7 @@ function codexClawbrowserArgs(nextctlBin) {
     "-c", `mcp_servers.clawbrowser.command=${JSON.stringify(nextctlBin)}`,
     "-c", `mcp_servers.clawbrowser.args=${JSON.stringify(["mcp"])}`,
     "-c", "mcp_servers.clawbrowser.startup_timeout_sec=30",
+    "-c", "mcp_servers.clawbrowser.default_tools_approval_mode=approve",
   ];
 }
 


### PR DESCRIPTION
The managed nextctl override added in #167 registers clawbrowser as a direct MCP server, while the existing approval default applied only to the plugin-provided server. New tools such as site_recipe_run therefore still prompted.

This applies default_tools_approval_mode=approve to the direct clawbrowser MCP configuration passed to terminal Codex. It covers current and future Clawbrowser tools without maintaining a hardcoded allow-list.

Validated against the current Codex config schema, 163 tests pass, and the production build succeeds.