### PR TITLE
Save browser workflows as local skills

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -670,6 +670,19 @@ async function invokeCommand(command, args = {}) {
       const slug = String(args.slug || "custom").replace(/[^A-Za-z0-9_-]/g, "") || "custom";
       const file = path.join(os.tmpdir(), `${slug}-${process.pid}-${Date.now()}.md`); await fs.writeFile(file, args.content, "utf8"); return file;
     }
+    case "write_local_skill": {
+      const slug = String(args.slug || "browser-workflow").toLowerCase().replace(/[^a-z0-9_-]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "") || "browser-workflow";
+      const dir = path.join(dataDir(), "local-skills", slug);
+      await fs.mkdir(dir, { recursive: true });
+      const file = path.join(dir, "SKILL.md");
+      await fs.writeFile(file, String(args.content || ""), "utf8");
+      return file;
+    }
+    case "delete_local_skill": {
+      const slug = String(args.slug || "").toLowerCase().replace(/[^a-z0-9_-]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
+      if (slug) await fs.rm(path.join(dataDir(), "local-skills", slug), { recursive: true, force: true });
+      return null;
+    }
     case "remove_temp_file": {
       const file = path.resolve(args.path); if (path.dirname(file) !== path.resolve(os.tmpdir())) throw new Error("Refusing to remove a file outside the temporary directory.");
       await fs.rm(file, { force: true }); return null;

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -940,7 +940,7 @@ function SaveWorkflowModal({ task, answer, onClose, onSave }: {
     <div className="modal-overlay" onMouseDown={onClose}>
       <div className="modal-card workflow-save-modal" onMouseDown={(event) => event.stopPropagation()}>
         <strong>Save browser workflow</strong>
-        <p className="muted small">This creates a private skill stored only on this device.</p>
+        <p className="muted small">Saved locally first, then backed up privately to your account.</p>
         <label className="field-label">Skill name</label>
         <input value={title} autoFocus onChange={(event) => setTitle(event.target.value)} />
         <label className="field-label">Website</label>

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -15,6 +15,7 @@ import { UserFacingError } from "./UserFacingError";
 import { AgentInstallLink } from "./AgentInstallLink";
 import { takeGuideDraft } from "../lib/guideDraft";
 import { AgentTerminal } from "./AgentTerminal";
+import { uid } from "../lib/ids";
 
 function formatTime(ts: number) {
   return new Date(ts).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
@@ -50,6 +51,16 @@ function errorSummary(text: string): string {
   return cleaned.length > 140 ? cleaned.slice(0, 140) + "…" : cleaned;
 }
 
+function workflowDomain(text: string): string {
+  const match = text.match(/(?:https?:\/\/)?(?:www\.)?([a-z0-9-]+(?:\.[a-z0-9-]+)+)/i);
+  return match?.[1]?.toLowerCase() ?? "";
+}
+
+function workflowTitle(task: string, domain: string): string {
+  const plain = task.replace(/https?:\/\/\S+/g, "").trim().replace(/\s+/g, " ");
+  return (plain || (domain ? `${domain} workflow` : "Browser workflow")).slice(0, 64);
+}
+
 export function ChatView() {
   const s = useStore();
   const agentId = s.agentId;
@@ -76,6 +87,7 @@ export function ChatView() {
   const [convMenu, setConvMenu] = useState<{ id: string; x: number; y: number } | null>(null);
   const [promptDetail, setPromptDetail] = useState<string | null>(null);
   const [vpsSetupOpen, setVPSSetupOpen] = useState(false);
+  const [workflowDraft, setWorkflowDraft] = useState<{ task: string; answer: ChatMessage } | null>(null);
   const [terminalVisible, setTerminalVisible] = useState(s.terminalChat);
   const [terminalMounted, setTerminalMounted] = useState(s.terminalChat);
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -429,6 +441,11 @@ export function ChatView() {
                 });
                 setPromptDetail(m.text);
               }}
+              onSaveWorkflow={() => {
+                const index = messages.findIndex((candidate) => candidate.id === m.id);
+                const user = [...messages.slice(0, index)].reverse().find((candidate) => candidate.role === "user");
+                setWorkflowDraft({ task: user?.text ?? "", answer: m });
+              }}
             />
           ))}
           <div ref={bottomRef} />
@@ -701,6 +718,24 @@ export function ChatView() {
         </div>
       )}
 
+      {workflowDraft && (
+        <SaveWorkflowModal
+          task={workflowDraft.task}
+          answer={workflowDraft.answer}
+          onClose={() => setWorkflowDraft(null)}
+          onSave={(title, domain, instructions) => {
+            void s.saveLocalSkill({
+              id: uid(), title, domain, task: workflowDraft.task, instructions,
+              actions: (workflowDraft.answer.toolEvents ?? []).map((event) => event.detail ?? event.name),
+              createdAt: Date.now(), updatedAt: Date.now(),
+            });
+            setWorkflowDraft(null);
+            localStorage.setItem("openSkillsCategory", "my-skills");
+            s.setTab("skills");
+          }}
+        />
+      )}
+
       {vpsSetupOpen && <VPSSetupModal onClose={() => setVPSSetupOpen(false)} />}
     </div>
   );
@@ -714,6 +749,7 @@ function MessageBubble({
   running,
   queuedReplyId,
   onShowPrompt,
+  onSaveWorkflow,
 }: {
   message: ChatMessage;
   canQueue: boolean;
@@ -723,6 +759,7 @@ function MessageBubble({
   running: boolean;
   queuedReplyId?: string;
   onShowPrompt: () => void;
+  onSaveWorkflow: () => void;
 }) {
   const [clock, setClock] = useState(Date.now());
   const [showErrorDetails, setShowErrorDetails] = useState(false);
@@ -877,9 +914,45 @@ function MessageBubble({
           >
             <Icon name="doc.on.doc" size={12} />
           </button>
+          {m.status === "done" && ((m.toolEvents?.length ?? 0) > 0 || /https?:\/\//i.test(m.text)) && (
+            <button className="save-workflow-btn" title="Save this browser workflow as a local skill" onClick={onSaveWorkflow}>
+              <Icon name="sparkles" size={12} /> Save browser workflow
+            </button>
+          )}
           <span>{formatTime(m.createdAt)}</span>
         </div>
       )}
+    </div>
+  );
+}
+
+function SaveWorkflowModal({ task, answer, onClose, onSave }: {
+  task: string;
+  answer: ChatMessage;
+  onClose: () => void;
+  onSave: (title: string, domain: string, instructions: string) => void;
+}) {
+  const inferredDomain = workflowDomain(`${task}\n${answer.text}`);
+  const [title, setTitle] = useState(workflowTitle(task, inferredDomain));
+  const [domain, setDomain] = useState(inferredDomain);
+  const [instructions, setInstructions] = useState(answer.text);
+  return (
+    <div className="modal-overlay" onMouseDown={onClose}>
+      <div className="modal-card workflow-save-modal" onMouseDown={(event) => event.stopPropagation()}>
+        <strong>Save browser workflow</strong>
+        <p className="muted small">This creates a private skill stored only on this device.</p>
+        <label className="field-label">Skill name</label>
+        <input value={title} autoFocus onChange={(event) => setTitle(event.target.value)} />
+        <label className="field-label">Website</label>
+        <input value={domain} placeholder="example.com (optional)" onChange={(event) => setDomain(event.target.value)} />
+        <label className="field-label">Reusable instructions</label>
+        <textarea rows={8} value={instructions} onChange={(event) => setInstructions(event.target.value)} />
+        <div className="row" style={{ marginTop: 10, gap: 8 }}>
+          <span className="spacer" />
+          <button className="secondary" onClick={onClose}>Cancel</button>
+          <button className="primary" disabled={!title.trim() || !instructions.trim()} onClick={() => onSave(title.trim(), domain.trim(), instructions.trim())}>Save skill</button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/SkillsView.tsx
+++ b/src/components/SkillsView.tsx
@@ -91,7 +91,7 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
         >
           <Icon name="person.crop.circle" size={18} className="skills-nav-icon" />
           <span className="skills-nav-title">My skills</span>
-          <span className="muted small skills-nav-count">{s.localSkills.length}</span>
+          <span className="muted small skills-nav-count">{s.localSkills.length + s.privateCloudSkills.filter((cloud) => !s.localSkills.some((local) => local.serverSlug === cloud.id)).length}</span>
         </button>
         {categories.map((c) => (
           <button
@@ -258,7 +258,7 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
         </div>}
 
         {isMySkills && (
-          s.localSkills.length === 0 ? (
+          s.localSkills.length === 0 && s.privateCloudSkills.length === 0 ? (
             <div className="skills-empty-state">
               <span className="skills-empty-icon"><Icon name="sparkles" size={22} /></span>
               <strong>No local skills yet</strong>
@@ -271,10 +271,27 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
                   key={skill.id}
                   skill={skill}
                   ready={ready}
+                  sync={s.localSkillSync[skill.id] ?? (skill.submittedAt ? "synced" : "idle")}
                   onRun={() => void s.runLocalSkill(skill)}
+                  onSync={() => void s.saveLocalSkill(skill)}
                   onDelete={() => s.deleteLocalSkill(skill.id)}
                 />
               ))}
+              {s.privateCloudSkills
+                .filter((cloud) => !s.localSkills.some((local) => local.serverSlug === cloud.id))
+                .map((skill) => (
+                  <div className="skill-card claw-card" key={skill.id}>
+                    <div className="skill-card-head">
+                      <Icon name="sparkles" size={16} className="accent-icon" />
+                      <div className="skill-title">{skill.title}</div>
+                      <span className="mode-badge agent">Private cloud</span>
+                    </div>
+                    <div className="muted small">{skill.description || "Private skill from your account"}</div>
+                    <div className="skill-actions">
+                      <button className="btn-bordered-prominent full" disabled={!ready} onClick={() => void s.runScript(skill)}>Run</button>
+                    </div>
+                  </div>
+                ))}
             </div>
           )
         )}
@@ -314,7 +331,7 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
                   My scripts
                 </h3>
                 <p className="muted small">
-                  Stored only on this device and never uploaded to the cloud catalog.
+                  Backed up privately to your account and never shared with other users.
                 </p>
               </div>
               <button className="btn-bordered-prominent" title="Create a new private custom script" onClick={() => setScriptEditor("new")}>
@@ -335,10 +352,12 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
                   <CustomScriptCard
                     key={cs.id}
                     script={cs}
+                    sync={s.scriptSync[cs.id]}
                     sessionName={sessionName}
                     onEdit={() => setScriptEditor(cs)}
                     onDelete={() => s.deleteCustomScript(cs.id)}
                     onUse={() => s.runCustomScript(cs)}
+                    onSync={() => void s.saveCustomScript(cs)}
                   />
                 ))}
               </div>
@@ -361,10 +380,12 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
   );
 }
 
-function LocalSkillCard({ skill, ready, onRun, onDelete }: {
+function LocalSkillCard({ skill, ready, sync, onRun, onSync, onDelete }: {
   skill: BrowserWorkflowSkill;
   ready: boolean;
+  sync: string;
   onRun: () => void;
+  onSync: () => void;
   onDelete: () => void;
 }) {
   return (
@@ -377,6 +398,10 @@ function LocalSkillCard({ skill, ready, onRun, onDelete }: {
       <div className="muted small">{skill.domain || "Any website"}</div>
       <p className="small instructions-preview">{skill.instructions.slice(0, 150)}{skill.instructions.length > 150 ? "…" : ""}</p>
       <div className="small muted">{skill.actions.length} recorded browser action{skill.actions.length === 1 ? "" : "s"}</div>
+      {sync === "idle" && <button className="link small sync-link" onClick={onSync}>Back up privately</button>}
+      {sync === "syncing" && <span className="muted small">Backing up…</span>}
+      {sync === "synced" && <span className="ok small"><Icon name="lock.fill" size={11} /> Private cloud backup</span>}
+      {sync === "failed" && <button className="link small" onClick={onSync}>Saved locally · Retry backup</button>}
       <div className="skill-actions">
         <button className="btn-bordered-prominent full" disabled={!ready} onClick={onRun}>Run</button>
         <button className="plain-icon-btn" title="Delete local skill" onClick={onDelete}>
@@ -389,16 +414,20 @@ function LocalSkillCard({ skill, ready, onRun, onDelete }: {
 
 function CustomScriptCard({
   script,
+  sync,
   sessionName,
   onEdit,
   onDelete,
   onUse,
+  onSync,
 }: {
   script: CustomScript;
+  sync?: string;
   sessionName: string;
   onEdit: () => void;
   onDelete: () => void;
   onUse: () => void;
+  onSync: () => void;
 }) {
   return (
     <div className="skill-card claw-card custom-script-card">
@@ -406,7 +435,10 @@ function CustomScriptCard({
       <div className="muted small">{script.domain || "(any domain)"}</div>
       <div className="muted small">Runs in {sessionName}</div>
       <p className="small instructions-preview">{script.instructions.slice(0, 120)}…</p>
-      <span className="muted small"><Icon name="lock.fill" size={11} /> Local only</span>
+      {(!sync || sync === "idle") && <button className="link small sync-link" onClick={onSync}>Back up privately</button>}
+      {sync === "syncing" && <span className="muted small">Backing up…</span>}
+      {sync === "synced" && <span className="ok small"><Icon name="lock.fill" size={11} /> Private cloud backup</span>}
+      {sync === "failed" && <button className="link small" onClick={onSync}>Backup failed · Retry</button>}
       <div className="skill-actions">
         <button className="btn-bordered-prominent full" title={`Use ${script.title} in chat`} onClick={onUse}>
           Use
@@ -465,6 +497,8 @@ function CustomScriptSheet({
                 instructions: instructions.trim(),
                 createdAt: script?.createdAt ?? Date.now(),
                 updatedAt: Date.now(),
+                serverSlug: script?.serverSlug,
+                submittedAt: script?.submittedAt,
               })
             }
           >

--- a/src/components/SkillsView.tsx
+++ b/src/components/SkillsView.tsx
@@ -5,7 +5,7 @@ import {
   selectorIcon,
   selectorTargetHost,
 } from "../skillsCatalog";
-import type { CustomScript } from "../types";
+import type { BrowserWorkflowSkill, CustomScript } from "../types";
 import { uid } from "../lib/ids";
 import { internalError } from "../lib/userFacingError";
 import { Icon } from "./Icon";
@@ -20,8 +20,10 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
 
   const cat = categories.find((c) => c.id === category);
   const isSkillsOverview = category === "__skills__";
+  const isMySkills = category === "my-skills";
   const isScripts = category === "my-scripts";
   const skillCount = categories.reduce((total, current) => total + current.entries.length, 0);
+  const publishedScripts = s.appliedScripts.filter((entry) => entry.selector.kind === "script");
   const visibleEntries = isSkillsOverview ? categories.flatMap((current) => current.entries) : (cat?.entries ?? []);
   useEffect(() => {
     const pendingCategory = localStorage.getItem("openSkillsCategory");
@@ -83,6 +85,14 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
           <span className="skills-nav-title">Skills</span>
           <span className="muted small skills-nav-count">{skillCount}</span>
         </button>
+        <button
+          className={"skills-nav-item" + (isMySkills ? " active" : "")}
+          onClick={() => setCategory("my-skills")}
+        >
+          <Icon name="person.crop.circle" size={18} className="skills-nav-icon" />
+          <span className="skills-nav-title">My skills</span>
+          <span className="muted small skills-nav-count">{s.localSkills.length}</span>
+        </button>
         {categories.map((c) => (
           <button
             key={c.id}
@@ -101,22 +111,24 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
         >
           <Icon name="scroll.fill" size={18} className="skills-nav-icon" />
           <span className="skills-nav-title">Scripts</span>
-          <span className="muted small skills-nav-count">{s.customScripts.length}</span>
+          <span className="muted small skills-nav-count">{publishedScripts.length + s.customScripts.length}</span>
         </button>
       </nav>
       <hr className="divider skills-divider" />
       <div className="skills-main">
         <div className="skills-main-head">
           <h2 className="skills-category-title">
-            <Icon name={isScripts ? "scroll.fill" : cat?.icon ?? "sparkles"} size={22} className="accent-icon" />
-            {isScripts ? "Scripts" : cat?.title ?? "Skills"}
+            <Icon name={isScripts ? "scroll.fill" : isMySkills ? "person.crop.circle" : cat?.icon ?? "sparkles"} size={22} className="accent-icon" />
+            {isScripts ? "Scripts" : isMySkills ? "My skills" : cat?.title ?? "Skills"}
           </h2>
           <p className="muted">
             {isScripts
               ? "Quick reusable commands for common browser tasks."
+              : isMySkills
+                ? "Browser workflows saved locally on this device."
               : cat?.blurb ?? "Extend your agents with reusable browser capabilities."}
           </p>
-          {!isScripts && (
+          {!isScripts && !isMySkills && (
             <p className="skills-apply-hint muted small">
               <Icon name="arrow.down.circle" size={14} />
               Applied skills work with any connected agent.
@@ -124,7 +136,7 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
           )}
         </div>
 
-        {!isScripts && !s.nextctlSupportsSkill && (
+        {!isScripts && !isMySkills && !s.nextctlSupportsSkill && (
           <div className="warning-banner skills-warning">
             <Icon name="exclamationmark.triangle.fill" size={16} />
             <div>
@@ -135,7 +147,7 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
             </div>
           </div>
         )}
-        {!isScripts && s.nextctlSupportsSkill && !ready && (
+        {!isScripts && !isMySkills && s.nextctlSupportsSkill && !ready && (
           <div className="skills-connect-hint">
             <Icon name="bolt.fill" size={16} />
             <div>
@@ -148,7 +160,7 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
           </div>
         )}
 
-        {!isScripts && visibleEntries.length === 0 && (
+        {!isScripts && !isMySkills && visibleEntries.length === 0 && (
           <div className="skills-empty-state">
             <span className="skills-empty-icon"><Icon name="sparkles" size={22} /></span>
             <strong>No skills available yet</strong>
@@ -156,7 +168,7 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
           </div>
         )}
 
-        {!isScripts && <div className="skills-grid">
+        {!isScripts && !isMySkills && <div className="skills-grid">
           {visibleEntries.map((e) => {
             const st = applyState(e.id);
             const applyError = s.skillApplyError(e.id);
@@ -245,8 +257,55 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
           })}
         </div>}
 
+        {isMySkills && (
+          s.localSkills.length === 0 ? (
+            <div className="skills-empty-state">
+              <span className="skills-empty-icon"><Icon name="sparkles" size={22} /></span>
+              <strong>No local skills yet</strong>
+              <span className="muted small">After a successful browser task, use “Save browser workflow” below the answer.</span>
+            </div>
+          ) : (
+            <div className="skills-grid">
+              {s.localSkills.map((skill) => (
+                <LocalSkillCard
+                  key={skill.id}
+                  skill={skill}
+                  ready={ready}
+                  onRun={() => void s.runLocalSkill(skill)}
+                  onDelete={() => s.deleteLocalSkill(skill.id)}
+                />
+              ))}
+            </div>
+          )
+        )}
+
         {isScripts && (
           <div className="custom-scripts">
+            {publishedScripts.length > 0 && (
+              <>
+                <div className="row custom-scripts-head">
+                  <div>
+                    <h3 className="custom-scripts-title"><Icon name="checkmark.seal.fill" size={18} /> Published scripts</h3>
+                    <p className="muted small">Ready-to-run scripts from your account.</p>
+                  </div>
+                </div>
+                <div className="skills-grid">
+                  {publishedScripts.map((script) => (
+                    <div className="skill-card claw-card" key={script.id}>
+                      <div className="skill-card-head">
+                        <Icon name="scroll.fill" size={16} className="accent-icon" />
+                        <div className="skill-title">{script.title}</div>
+                        <span className="mode-badge agent">Script</span>
+                      </div>
+                      <div className="muted small">{script.description || script.subtitle}</div>
+                      <div className="skill-actions">
+                        <button className="btn-bordered-prominent full" disabled={!ready} onClick={() => void s.runScript(script)}>Run</button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
             <hr className="divider" />
             <div className="row custom-scripts-head">
               <div>
@@ -255,7 +314,7 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
                   My scripts
                 </h3>
                 <p className="muted small">
-                  Synced to your account on our server, but never shared back to other users.
+                  Stored only on this device and never uploaded to the cloud catalog.
                 </p>
               </div>
               <button className="btn-bordered-prominent" title="Create a new private custom script" onClick={() => setScriptEditor("new")}>
@@ -276,12 +335,10 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
                   <CustomScriptCard
                     key={cs.id}
                     script={cs}
-                    sync={s.scriptSync[cs.id]}
                     sessionName={sessionName}
                     onEdit={() => setScriptEditor(cs)}
                     onDelete={() => s.deleteCustomScript(cs.id)}
                     onUse={() => s.runCustomScript(cs)}
-                    onSync={() => void s.saveCustomScript(cs)}
                   />
                 ))}
               </div>
@@ -304,22 +361,44 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
   );
 }
 
+function LocalSkillCard({ skill, ready, onRun, onDelete }: {
+  skill: BrowserWorkflowSkill;
+  ready: boolean;
+  onRun: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div className="skill-card claw-card">
+      <div className="skill-card-head">
+        <Icon name="sparkles" size={16} className="accent-icon" />
+        <div className="skill-title">{skill.title}</div>
+        <span className="mode-badge agent">Local</span>
+      </div>
+      <div className="muted small">{skill.domain || "Any website"}</div>
+      <p className="small instructions-preview">{skill.instructions.slice(0, 150)}{skill.instructions.length > 150 ? "…" : ""}</p>
+      <div className="small muted">{skill.actions.length} recorded browser action{skill.actions.length === 1 ? "" : "s"}</div>
+      <div className="skill-actions">
+        <button className="btn-bordered-prominent full" disabled={!ready} onClick={onRun}>Run</button>
+        <button className="plain-icon-btn" title="Delete local skill" onClick={onDelete}>
+          <Icon name="trash" size={14} className="error" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function CustomScriptCard({
   script,
-  sync,
   sessionName,
   onEdit,
   onDelete,
   onUse,
-  onSync,
 }: {
   script: CustomScript;
-  sync?: string;
   sessionName: string;
   onEdit: () => void;
   onDelete: () => void;
   onUse: () => void;
-  onSync: () => void;
 }) {
   return (
     <div className="skill-card claw-card custom-script-card">
@@ -327,24 +406,7 @@ function CustomScriptCard({
       <div className="muted small">{script.domain || "(any domain)"}</div>
       <div className="muted small">Runs in {sessionName}</div>
       <p className="small instructions-preview">{script.instructions.slice(0, 120)}…</p>
-      {(!sync || sync === "idle") && (
-        <button className="link small sync-link" title="Sync this script to your account" onClick={onSync}>
-          Sync to server
-        </button>
-      )}
-      {sync === "syncing" && <span className="muted small">Syncing…</span>}
-      {sync === "synced" && <span className="ok small">Synced to your account</span>}
-      {sync === "failed" && (
-        <span className="error small sync-failed-row">
-          <UserFacingError
-            message={internalError("We couldn't sync this script.")}
-            surface="script_sync"
-          />
-          <button className="link small" title="Retry script sync" onClick={onSync}>
-            Retry
-          </button>
-        </span>
-      )}
+      <span className="muted small"><Icon name="lock.fill" size={11} /> Local only</span>
       <div className="skill-actions">
         <button className="btn-bordered-prominent full" title={`Use ${script.title} in chat`} onClick={onUse}>
           Use
@@ -403,8 +465,6 @@ function CustomScriptSheet({
                 instructions: instructions.trim(),
                 createdAt: script?.createdAt ?? Date.now(),
                 updatedAt: Date.now(),
-                serverSlug: script?.serverSlug,
-                submittedAt: script?.submittedAt,
               })
             }
           >

--- a/src/lib/persistence.test.ts
+++ b/src/lib/persistence.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   normalizeConversation,
   normalizeSchedule,
+  normalizeWorkflowSkill,
   serializeConversations,
   serializeSchedules,
+  serializeWorkflowSkills,
 } from "./persistence";
 import type { Conversation, ScheduledRun } from "../types";
 import { VPS_PROMPT_MARKER } from "./vpsPrompt";
@@ -75,5 +77,17 @@ describe("Swift-compatible persistence", () => {
     const normalized = normalizeSchedule(raw);
     expect(normalized.lastFiredAt).toBe(Date.parse("2026-07-03T10:20:30Z"));
     expect(serializeSchedules([normalized])[0].lastFiredAt).toBe(804_766_830);
+  });
+
+  it("round-trips locally saved browser workflow skills", () => {
+    const normalized = normalizeWorkflowSkill({
+      id: "wf", title: "Search cars", domain: "999.md", task: "Find Matiz",
+      instructions: "Search and deduplicate listings.", actions: ["navigate", "extract"],
+      createdAt: "2026-08-04T10:00:00Z", updatedAt: "2026-08-04T10:01:00Z",
+    } as never);
+    expect(normalized.createdAt).toBe(Date.parse("2026-08-04T10:00:00Z"));
+    expect(serializeWorkflowSkills([normalized])[0]).toMatchObject({
+      domain: "999.md", actions: ["navigate", "extract"], createdAt: "2026-08-04T10:00:00Z",
+    });
   });
 });

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -1,6 +1,7 @@
 import { uid } from "./ids";
 import type {
   Conversation,
+  BrowserWorkflowSkill,
   CustomScript,
   ScheduledRun,
   UsageSnapshot,
@@ -123,6 +124,18 @@ export function serializeScripts(scripts: CustomScript[]) {
     createdAt: isoSeconds(script.createdAt),
     updatedAt: isoSeconds(script.updatedAt),
     submittedAt: script.submittedAt == null ? undefined : isoSeconds(script.submittedAt),
+  }));
+}
+
+export function normalizeWorkflowSkill(skill: BrowserWorkflowSkill): BrowserWorkflowSkill {
+  return { ...skill, createdAt: parseMillis(skill.createdAt), updatedAt: parseMillis(skill.updatedAt) };
+}
+
+export function serializeWorkflowSkills(skills: BrowserWorkflowSkill[]) {
+  return skills.map((skill) => ({
+    ...skill,
+    createdAt: isoSeconds(skill.createdAt),
+    updatedAt: isoSeconds(skill.updatedAt),
   }));
 }
 

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -128,7 +128,12 @@ export function serializeScripts(scripts: CustomScript[]) {
 }
 
 export function normalizeWorkflowSkill(skill: BrowserWorkflowSkill): BrowserWorkflowSkill {
-  return { ...skill, createdAt: parseMillis(skill.createdAt), updatedAt: parseMillis(skill.updatedAt) };
+  return {
+    ...skill,
+    createdAt: parseMillis(skill.createdAt),
+    updatedAt: parseMillis(skill.updatedAt),
+    submittedAt: skill.submittedAt == null ? undefined : parseMillis(skill.submittedAt),
+  };
 }
 
 export function serializeWorkflowSkills(skills: BrowserWorkflowSkill[]) {
@@ -136,6 +141,7 @@ export function serializeWorkflowSkills(skills: BrowserWorkflowSkill[]) {
     ...skill,
     createdAt: isoSeconds(skill.createdAt),
     updatedAt: isoSeconds(skill.updatedAt),
+    submittedAt: skill.submittedAt == null ? undefined : isoSeconds(skill.submittedAt),
   }));
 }
 

--- a/src/skillsCatalog.ts
+++ b/src/skillsCatalog.ts
@@ -40,7 +40,7 @@ export function selectorIcon(s: Selector): string {
 }
 
 export function withLocalScripts(categories: SkillCategory[]): SkillCategory[] {
-  return [...categories, { id: "my-scripts", title: "My scripts", blurb: "Private reusable scripts stored only on this device.", icon: "scroll.fill", entries: [] }];
+  return [...categories, { id: "my-scripts", title: "My scripts", blurb: "Private reusable scripts backed up to your account.", icon: "scroll.fill", entries: [] }];
 }
 
 export const SCRIPTS: SkillEntry[] = [];

--- a/src/skillsCatalog.ts
+++ b/src/skillsCatalog.ts
@@ -40,7 +40,7 @@ export function selectorIcon(s: Selector): string {
 }
 
 export function withLocalScripts(categories: SkillCategory[]): SkillCategory[] {
-  return [...categories, { id: "my-scripts", title: "My scripts", blurb: "Private reusable scripts synced to your account.", icon: "scroll.fill", entries: [] }];
+  return [...categories, { id: "my-scripts", title: "My scripts", blurb: "Private reusable scripts stored only on this device.", icon: "scroll.fill", entries: [] }];
 }
 
 export const SCRIPTS: SkillEntry[] = [];

--- a/src/store.ts
+++ b/src/store.ts
@@ -41,16 +41,19 @@ import { loadJson, saveJson } from "./lib/storage";
 import { apiBaseUrl } from "./constants";
 import {
   normalizeConversation,
+  normalizeWorkflowSkill,
   normalizeSchedule,
   normalizeScript,
   normalizeUsage,
   serializeConversations,
+  serializeWorkflowSkills,
   serializeSchedules,
   serializeScripts,
   serializeUsage,
 } from "./lib/persistence";
 import type {
   AppTab,
+  BrowserWorkflowSkill,
   ChatAttachment,
   ChatMessage,
   Conversation,
@@ -66,10 +69,6 @@ import type {
   UsageSnapshot,
 } from "./types";
 import type { RotationCountry } from "./lib/countryFlag";
-import {
-  customPrivateSlug,
-  customPublishSelector,
-} from "./types";
 
 interface QueuedItem {
   conversationId: string;
@@ -322,6 +321,7 @@ interface State {
   skillState: Record<string, SkillApplyState | string>;
   scheduledRuns: ScheduledRun[];
   customScripts: CustomScript[];
+  localSkills: BrowserWorkflowSkill[];
   appliedScripts: SkillEntry[];
   scriptSync: Record<string, ScriptSyncState>;
   usageHistory: UsageSnapshot[];
@@ -439,6 +439,9 @@ interface State {
   saveCustomScript: (script: CustomScript) => Promise<void>;
   deleteCustomScript: (id: string) => void;
   runCustomScript: (script: CustomScript) => Promise<void>;
+  saveLocalSkill: (skill: BrowserWorkflowSkill) => Promise<void>;
+  deleteLocalSkill: (id: string) => void;
+  runLocalSkill: (skill: BrowserWorkflowSkill) => Promise<void>;
 
   // Internal queue/runtime helpers
   reconcileQueues: () => void;
@@ -595,6 +598,10 @@ function persistSchedules(runs: ScheduledRun[]) {
 
 function persistScripts(scripts: CustomScript[]) {
   void saveJson("custom-scripts.json", serializeScripts(scripts));
+}
+
+function persistLocalSkills(skills: BrowserWorkflowSkill[]) {
+  void saveJson("local-skills.json", serializeWorkflowSkills(skills));
 }
 
 function persistAppliedScripts(scripts: SkillEntry[]) {
@@ -870,6 +877,7 @@ export const useStore = create<State>((set, get) => {
   skillCategories: [],
   scheduledRuns: [],
   customScripts: [],
+  localSkills: [],
   appliedScripts: [],
   scriptSync: {},
   usageHistory: [],
@@ -936,10 +944,11 @@ export const useStore = create<State>((set, get) => {
     didBootstrap = true;
     const startedAt = performance.now();
     trackEvent("bootstrap_started");
-    const [rawConvs, rawSchedules, rawScripts, rawAppliedScripts, rawHistory, wd] = await Promise.all([
+    const [rawConvs, rawSchedules, rawScripts, rawLocalSkills, rawAppliedScripts, rawHistory, wd] = await Promise.all([
       loadJson<Conversation[]>("conversations.json", []),
       loadJson<ScheduledRun[]>("scheduled-runs.json", []),
       loadJson<CustomScript[]>("custom-scripts.json", []),
+      loadJson<BrowserWorkflowSkill[]>("local-skills.json", []),
       loadJson<SkillEntry[]>("applied-scripts.json", []),
       loadJson<UsageSnapshot[]>("usage-history.json", []),
       invoke<string>("working_directory").catch(() => ""),
@@ -958,6 +967,7 @@ export const useStore = create<State>((set, get) => {
       activeConvId,
       scheduledRuns: schedules,
       customScripts: scripts,
+      localSkills: rawLocalSkills.map(normalizeWorkflowSkill),
       appliedScripts: rawAppliedScripts.filter((entry) => entry?.selector?.kind === "script"),
       usageHistory: history,
       workingDir: wd,
@@ -1857,19 +1867,28 @@ export const useStore = create<State>((set, get) => {
     if (!get().nextctlSupportsSkill) return;
     try {
       const catalog = await nextctlJson<{ categories: Array<{ id: string; title: string; icon: string; order: number; skills: SkillRef[] }> }>(["skill", "list"]);
-      set({
-        skillCategories: catalog.categories.map((category) => ({
+      const backendScripts: SkillEntry[] = [];
+      const skillCategories: SkillCategory[] = catalog.categories.map((category) => ({
           id: category.id, title: category.title, icon: category.icon,
           blurb: `Published ${category.title.toLowerCase()} available from the backend.`,
           entries: category.skills
             .filter((ref) => ref.slug && ref.title && ref.selector && (ref.kind === "domain" || ref.kind === "captcha"))
-            .map((ref) => ({
+            .map((ref): SkillEntry => ({
               id: ref.slug!, title: ref.title!, subtitle: ref.selector!, description: ref.description,
               category: category.id, categoryTitle: category.title,
               categoryIcon: category.icon, categoryOrder: category.order,
               selector: { kind: ref.kind === "domain" && ref.selector!.endsWith(".script") ? "script" : ref.kind!, value: ref.selector! },
-            })),
-        })),
+            }))
+            .filter((entry) => {
+              if (entry.selector.kind !== "script") return true;
+              backendScripts.push(entry);
+              return false;
+            }),
+        }));
+      const localApplied = get().appliedScripts.filter((entry) => !entry.id.startsWith("catalog:"));
+      set({
+        skillCategories,
+        appliedScripts: [...localApplied, ...backendScripts.map((entry) => ({ ...entry, id: `catalog:${entry.id}` }))],
       });
       trackEvent("skill_catalog_loaded", {
         category_count: catalog.categories.length,
@@ -3217,58 +3236,12 @@ export const useStore = create<State>((set, get) => {
       ? get().customScripts.map((s) => (s.id === script.id ? updated : s))
       : [...get().customScripts, updated];
     persistScripts(scripts);
-    set({ customScripts: scripts, scriptSync: { ...get().scriptSync, [script.id]: "syncing" } });
-    let tempPath: string | undefined;
-    try {
-      const slug = customPrivateSlug(updated);
-      const selector = customPublishSelector(updated);
-      const description = updated.domain
-        ? `Private custom script for ${updated.domain} (not shared).`
-        : "Private custom script (not shared).";
-      const markdown = `---\nname: ${updated.title || "Custom script"}\ndescription: ${description}\n---\n\n${updated.instructions}`;
-      tempPath = await invoke<string>("write_temp_skill", { slug, content: markdown });
-      const { env, res } = await nextctlEnvelope<SkillRef>([
-        "skill",
-        "add",
-        "--domain",
-        selector,
-        "--private",
-        "--slug",
-        slug,
-        "--title",
-        updated.title || slug,
-        "--description",
-        "Private custom script (not shared)",
-        "--file",
-        tempPath,
-      ]);
-      if (res.code !== 0 || env.ok === false) throw new Error(nextctlErrorMessage(res));
-      const synced = {
-        ...updated,
-        serverSlug: env.data?.slug ?? slug,
-        submittedAt: now(),
-      };
-      const final = scripts.map((s) => (s.id === script.id ? synced : s));
-      persistScripts(final);
-      set({
-        customScripts: final,
-        scriptSync: { ...get().scriptSync, [script.id]: "synced" },
-      });
-      trackTiming("custom_script_save_completed", startedAt, {
-        existing: !!existing,
-        has_domain: !!script.domain.trim(),
-      });
-    } catch {
-      set((s) => ({
-        scriptSync: { ...s.scriptSync, [script.id]: "failed" },
-      }));
-      trackTiming("custom_script_save_failed", startedAt, {
-        existing: !!existing,
-        has_domain: !!script.domain.trim(),
-      });
-    } finally {
-      if (tempPath) void invoke("remove_temp_file", { path: tempPath });
-    }
+    set({ customScripts: scripts, scriptSync: { ...get().scriptSync, [script.id]: "idle" } });
+    trackTiming("custom_script_save_completed", startedAt, {
+      existing: !!existing,
+      has_domain: !!script.domain.trim(),
+      storage: "local",
+    });
   },
 
   deleteCustomScript: (id) => {
@@ -3324,6 +3297,39 @@ export const useStore = create<State>((set, get) => {
     const note = pageReadyNote(prep.host, prep.directFallback);
     const prompt = `Run my custom script "${script.title}" on ${target} in the active NextBrowser session.${note}\nFollow these steps exactly:\n\n${script.instructions}`;
     get().enqueue(prompt, chip, cid);
+  },
+
+  saveLocalSkill: async (skill) => {
+    const existing = get().localSkills.some((item) => item.id === skill.id);
+    const updated = { ...skill, updatedAt: now(), createdAt: existing ? skill.createdAt : now() };
+    const localSkills = existing
+      ? get().localSkills.map((item) => item.id === skill.id ? updated : item)
+      : [...get().localSkills, updated];
+    persistLocalSkills(localSkills);
+    set({ localSkills });
+    const slug = `workflow-${skill.id.slice(0, 8)}`;
+    const body = `---\nname: ${skill.title}\ndescription: Reusable browser workflow${skill.domain ? ` for ${skill.domain}` : ""}.\n---\n\n# ${skill.title}\n\n## When to use\n\n${skill.task}\n\n## Workflow\n\n${skill.instructions}\n\n## Recorded browser actions\n\n${skill.actions.map((action, index) => `${index + 1}. ${action}`).join("\n") || "No action trace was captured."}\n`;
+    await invoke<string>("write_local_skill", { slug, content: body });
+    trackEvent("browser_workflow_saved", { has_domain: !!skill.domain, action_count: skill.actions.length });
+  },
+
+  deleteLocalSkill: (id) => {
+    const localSkills = get().localSkills.filter((skill) => skill.id !== id);
+    persistLocalSkills(localSkills);
+    set({ localSkills });
+    void invoke("delete_local_skill", { slug: `workflow-${id.slice(0, 8)}` });
+  },
+
+  runLocalSkill: async (skill) => {
+    if (!get().agentReady()) return;
+    set({ tab: "chat" });
+    const cid = get().activeConversation()?.id ?? get().newChat();
+    const target = skill.domain || "the active website";
+    get().enqueue(
+      `Use my local browser skill "${skill.title}" for ${target}. Reuse this proven workflow, adapting selectors only when the page changed.\n\nOriginal task:\n${skill.task}\n\nWorkflow instructions:\n${skill.instructions}\n\nObserved browser actions:\n${skill.actions.map((action, index) => `${index + 1}. ${action}`).join("\n") || "No recorded action trace; follow the workflow instructions."}`,
+      { kind: "skill", title: skill.title, detail: skill.domain || "Local skill" },
+      cid,
+    );
   },
 
   startRemoteStream: async (profile) => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -69,6 +69,7 @@ import type {
   UsageSnapshot,
 } from "./types";
 import type { RotationCountry } from "./lib/countryFlag";
+import { customPrivateSlug, customPublishSelector } from "./types";
 
 interface QueuedItem {
   conversationId: string;
@@ -322,6 +323,8 @@ interface State {
   scheduledRuns: ScheduledRun[];
   customScripts: CustomScript[];
   localSkills: BrowserWorkflowSkill[];
+  localSkillSync: Record<string, ScriptSyncState>;
+  privateCloudSkills: SkillEntry[];
   appliedScripts: SkillEntry[];
   scriptSync: Record<string, ScriptSyncState>;
   usageHistory: UsageSnapshot[];
@@ -878,6 +881,8 @@ export const useStore = create<State>((set, get) => {
   scheduledRuns: [],
   customScripts: [],
   localSkills: [],
+  localSkillSync: {},
+  privateCloudSkills: [],
   appliedScripts: [],
   scriptSync: {},
   usageHistory: [],
@@ -1868,6 +1873,7 @@ export const useStore = create<State>((set, get) => {
     try {
       const catalog = await nextctlJson<{ categories: Array<{ id: string; title: string; icon: string; order: number; skills: SkillRef[] }> }>(["skill", "list"]);
       const backendScripts: SkillEntry[] = [];
+      const privateCloudSkills: SkillEntry[] = [];
       const skillCategories: SkillCategory[] = catalog.categories.map((category) => ({
           id: category.id, title: category.title, icon: category.icon,
           blurb: `Published ${category.title.toLowerCase()} available from the backend.`,
@@ -1880,14 +1886,19 @@ export const useStore = create<State>((set, get) => {
               selector: { kind: ref.kind === "domain" && ref.selector!.endsWith(".script") ? "script" : ref.kind!, value: ref.selector! },
             }))
             .filter((entry) => {
+              if (category.id === "my-skills") {
+                privateCloudSkills.push(entry);
+                return false;
+              }
               if (entry.selector.kind !== "script") return true;
               backendScripts.push(entry);
               return false;
             }),
-        }));
+        })).filter((category) => category.id !== "my-skills");
       const localApplied = get().appliedScripts.filter((entry) => !entry.id.startsWith("catalog:"));
       set({
         skillCategories,
+        privateCloudSkills,
         appliedScripts: [...localApplied, ...backendScripts.map((entry) => ({ ...entry, id: `catalog:${entry.id}` }))],
       });
       trackEvent("skill_catalog_loaded", {
@@ -3236,12 +3247,32 @@ export const useStore = create<State>((set, get) => {
       ? get().customScripts.map((s) => (s.id === script.id ? updated : s))
       : [...get().customScripts, updated];
     persistScripts(scripts);
-    set({ customScripts: scripts, scriptSync: { ...get().scriptSync, [script.id]: "idle" } });
-    trackTiming("custom_script_save_completed", startedAt, {
-      existing: !!existing,
-      has_domain: !!script.domain.trim(),
-      storage: "local",
-    });
+    set({ customScripts: scripts, scriptSync: { ...get().scriptSync, [script.id]: "syncing" } });
+    let tempPath: string | undefined;
+    try {
+      const slug = customPrivateSlug(updated);
+      const selector = customPublishSelector(updated);
+      const description = updated.domain
+        ? `Private custom script for ${updated.domain} (not shared).`
+        : "Private custom script (not shared).";
+      const markdown = `---\nname: ${updated.title || "Custom script"}\ndescription: ${description}\n---\n\n${updated.instructions}`;
+      tempPath = await invoke<string>("write_temp_skill", { slug, content: markdown });
+      const { env, res } = await nextctlEnvelope<SkillRef>([
+        "skill", "add", "--domain", selector, "--private", "--slug", slug,
+        "--title", updated.title || slug, "--description", description, "--file", tempPath,
+      ]);
+      if (res.code !== 0 || env.ok === false) throw new Error(nextctlErrorMessage(res));
+      const synced = { ...updated, serverSlug: env.data?.slug ?? slug, submittedAt: now() };
+      const final = scripts.map((s) => s.id === script.id ? synced : s);
+      persistScripts(final);
+      set({ customScripts: final, scriptSync: { ...get().scriptSync, [script.id]: "synced" } });
+      trackTiming("custom_script_save_completed", startedAt, { existing: !!existing, has_domain: !!script.domain.trim() });
+    } catch {
+      set((s) => ({ scriptSync: { ...s.scriptSync, [script.id]: "failed" } }));
+      trackTiming("custom_script_save_failed", startedAt, { existing: !!existing, has_domain: !!script.domain.trim() });
+    } finally {
+      if (tempPath) void invoke("remove_temp_file", { path: tempPath });
+    }
   },
 
   deleteCustomScript: (id) => {
@@ -3310,7 +3341,28 @@ export const useStore = create<State>((set, get) => {
     const slug = `workflow-${skill.id.slice(0, 8)}`;
     const body = `---\nname: ${skill.title}\ndescription: Reusable browser workflow${skill.domain ? ` for ${skill.domain}` : ""}.\n---\n\n# ${skill.title}\n\n## When to use\n\n${skill.task}\n\n## Workflow\n\n${skill.instructions}\n\n## Recorded browser actions\n\n${skill.actions.map((action, index) => `${index + 1}. ${action}`).join("\n") || "No action trace was captured."}\n`;
     await invoke<string>("write_local_skill", { slug, content: body });
-    trackEvent("browser_workflow_saved", { has_domain: !!skill.domain, action_count: skill.actions.length });
+    set((state) => ({ localSkillSync: { ...state.localSkillSync, [skill.id]: "syncing" } }));
+    let tempPath: string | undefined;
+    try {
+      tempPath = await invoke<string>("write_temp_skill", { slug, content: body });
+      const { env, res } = await nextctlEnvelope<SkillRef>([
+        "skill", "add", "--domain", `${slug}.script`, "--private", "--slug", slug,
+        "--title", skill.title, "--description", `Private browser skill${skill.domain ? ` for ${skill.domain}` : ""}.`,
+        "--category", "my-skills", "--category-title", "My skills", "--category-icon", "person.crop.circle",
+        "--file", tempPath,
+      ]);
+      if (res.code !== 0 || env.ok === false) throw new Error(nextctlErrorMessage(res));
+      const synced = { ...updated, serverSlug: env.data?.slug ?? slug, submittedAt: now() };
+      const final = localSkills.map((item) => item.id === skill.id ? synced : item);
+      persistLocalSkills(final);
+      set((state) => ({ localSkills: final, localSkillSync: { ...state.localSkillSync, [skill.id]: "synced" } }));
+      trackEvent("browser_workflow_saved", { has_domain: !!skill.domain, action_count: skill.actions.length, storage: "private_cloud" });
+    } catch {
+      set((state) => ({ localSkillSync: { ...state.localSkillSync, [skill.id]: "failed" } }));
+      trackEvent("browser_workflow_saved", { has_domain: !!skill.domain, action_count: skill.actions.length, storage: "local_only" });
+    } finally {
+      if (tempPath) void invoke("remove_temp_file", { path: tempPath });
+    }
   },
 
   deleteLocalSkill: (id) => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -2132,6 +2132,21 @@ button, input, textarea, select { color: var(--text); }
 .chip-kind { font-size: 10px; font-weight: 500; color: var(--muted); }
 .msg-user-meta { display: flex; align-items: center; gap: 6px; }
 .msg-assistant-meta { display: flex; align-items: center; gap: 6px; margin-top: 4px; padding-left: 4px; }
+.save-workflow-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 0;
+  padding: 2px 5px;
+  color: var(--muted);
+  background: transparent;
+  font: inherit;
+  cursor: pointer;
+}
+.save-workflow-btn:hover { color: var(--text); }
+.workflow-save-modal { width: min(560px, calc(100vw - 48px)); }
+.workflow-save-modal .field-label { display: block; margin: 10px 0 5px; color: var(--muted); font-size: 12px; }
+.workflow-save-modal textarea { width: 100%; resize: vertical; }
 .msg-assistant-wrap { display: flex; flex-direction: column; align-items: flex-start; }
 .assistant-bubble {
   max-width: 85%;

--- a/src/types.ts
+++ b/src/types.ts
@@ -188,6 +188,8 @@ export interface BrowserWorkflowSkill {
   actions: string[];
   createdAt: number;
   updatedAt: number;
+  serverSlug?: string;
+  submittedAt?: number;
 }
 
 export function customPrivateSlug(script: CustomScript): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -179,6 +179,17 @@ export interface CustomScript {
   submittedAt?: number;
 }
 
+export interface BrowserWorkflowSkill {
+  id: string;
+  title: string;
+  domain: string;
+  task: string;
+  instructions: string;
+  actions: string[];
+  createdAt: number;
+  updatedAt: number;
+}
+
 export function customPrivateSlug(script: CustomScript): string {
   return script.serverSlug ?? `custom-${script.id.slice(0, 8).toLowerCase()}`;
 }


### PR DESCRIPTION
## Summary
- add Save browser workflow on completed browser answers
- persist generated SKILL.md files locally and list them under My skills
- back up user-created skills and scripts as owner-scoped private cloud entries
- show private cloud skills only to their owner and surface public backend scripts such as Hello World
- keep recipes as an internal implementation detail instead of a user-facing concept

## Verification
- npm test -- --run
- npm run build
- git diff --check