### PR TITLE
Save terminal browser workflows as skills

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -718,6 +718,28 @@ async function invokeCommand(command, args = {}) {
       child.on("close", (code) => { children.delete(args.replyId); emit("agent:done", [args.replyId, code ?? -1, stderr]); });
       if (args.stdinText != null) child.stdin.end(args.stdinText); return null;
     }
+    case "workflow_author_run": {
+      const bin = resolveBinary(args.binary, args.envVar); if (!bin) throw new Error(`${args.binary} executable not found.`);
+      const spec = commandSpec(bin, args.args || []);
+      return new Promise((resolve, reject) => {
+        const child = spawn(spec.file, spec.args, {
+          cwd: args.workingDir || undefined,
+          env: childEnv(), windowsHide: true,
+          stdio: [args.stdinText != null ? "pipe" : "ignore", "pipe", "pipe"],
+        });
+        let stdout = ""; let stderr = ""; let settled = false;
+        const append = (current, chunk) => (current + chunk.toString()).slice(-32 * 1024);
+        child.stdout.on("data", (chunk) => { stdout = append(stdout, chunk); });
+        child.stderr.on("data", (chunk) => { stderr = append(stderr, chunk); });
+        const timer = setTimeout(() => { if (!settled) child.kill(); }, 45_000);
+        child.on("error", (error) => { clearTimeout(timer); if (!settled) { settled = true; reject(error); } });
+        child.on("close", (code) => {
+          clearTimeout(timer);
+          if (!settled) { settled = true; resolve({ code: code ?? -1, stdout, stderr }); }
+        });
+        if (args.stdinText != null) child.stdin.end(args.stdinText);
+      });
+    }
     case "agent_terminate": { const child = children.get(args.replyId); if (child) { child.kill(); children.delete(args.replyId); } return null; }
     case "terminal_start": {
       const agent = TERMINAL_AGENTS[String(args.agentId || "")];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -868,7 +868,9 @@ export function App() {
         </nav>
         <hr className="divider" />
         <div className={"tab-content" + (tab === "skills" ? " tab-content-bleed" : "")}>
-          {tab === "chat" && <ChatView />}
+          <div className={"persistent-tab-panel" + (tab === "chat" ? "" : " is-hidden")}>
+            <ChatView />
+          </div>
           {tab === "skills" && <SkillsView onOpenAgentSettings={() => openSettings("agent")} />}
           <div className={"persistent-tab-panel" + (tab === "live" ? "" : " is-hidden")}>
             <LiveView active={tab === "live"} />

--- a/src/components/AgentTerminal.tsx
+++ b/src/components/AgentTerminal.tsx
@@ -203,7 +203,6 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
           }}
           title="Save this terminal browser workflow as a private skill"
         >
-          <Icon name="sparkles" size={12} />
           Save browser workflow
         </button>
         <button className="plain-icon-btn plain-icon-btn-compact" onClick={onClose} title="Hide terminal" aria-label="Hide terminal">

--- a/src/components/AgentTerminal.tsx
+++ b/src/components/AgentTerminal.tsx
@@ -11,6 +11,7 @@ interface AgentTerminalProps {
   conversationId?: string;
   workingDir?: string;
   onClose: () => void;
+  onSaveWorkflow: (transcript: string) => void;
 }
 
 const DARK_TERMINAL_THEME = {
@@ -67,9 +68,10 @@ function activeTerminalTheme() {
     : DARK_TERMINAL_THEME;
 }
 
-export function AgentTerminal({ agentId, agentName, conversationId, workingDir, onClose }: AgentTerminalProps) {
+export function AgentTerminal({ agentId, agentName, conversationId, workingDir, onClose, onSaveWorkflow }: AgentTerminalProps) {
   const hostRef = useRef<HTMLDivElement>(null);
   const terminalIdRef = useRef<string>();
+  const terminalRef = useRef<Terminal>();
   const [status, setStatus] = useState<"starting" | "running" | "exited" | "failed">("starting");
   const [error, setError] = useState<string>();
 
@@ -92,6 +94,7 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
     const fit = new FitAddon();
     terminal.loadAddon(fit);
     terminal.open(host);
+    terminalRef.current = terminal;
 
     const resize = () => {
       if (disposed || !host.isConnected || host.clientWidth === 0 || host.clientHeight === 0) return;
@@ -165,6 +168,7 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
       removeExit?.();
       const id = terminalIdRef.current;
       terminalIdRef.current = undefined;
+      terminalRef.current = undefined;
       if (id) void invoke("terminal_kill", { id });
       terminal.dispose();
     };
@@ -184,6 +188,24 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
         {status === "running" && <span className="terminal-status-dot" title="Running" />}
         {status === "exited" && <span className="muted small">Exited</span>}
         {status === "failed" && <span className="error small" title={error}>Failed</span>}
+        <button
+          className="mini terminal-save-skill"
+          disabled={status !== "running"}
+          onClick={() => {
+            const terminal = terminalRef.current;
+            if (!terminal) return;
+            const buffer = terminal.buffer.active;
+            const first = Math.max(0, buffer.length - 500);
+            const transcript = Array.from({ length: buffer.length - first }, (_, index) =>
+              buffer.getLine(first + index)?.translateToString(true) ?? ""
+            ).join("\n").trim();
+            if (transcript) onSaveWorkflow(transcript);
+          }}
+          title="Save this terminal browser workflow as a private skill"
+        >
+          <Icon name="sparkles" size={12} />
+          Save browser workflow
+        </button>
         <button className="plain-icon-btn plain-icon-btn-compact" onClick={onClose} title="Hide terminal" aria-label="Hide terminal">
           <Icon name="xmark" size={13} />
         </button>

--- a/src/components/AgentTerminal.tsx
+++ b/src/components/AgentTerminal.tsx
@@ -10,6 +10,7 @@ interface AgentTerminalProps {
   agentName: string;
   conversationId?: string;
   workingDir?: string;
+  savingWorkflow?: boolean;
   onClose: () => void;
   onSaveWorkflow: (transcript: string) => void;
 }
@@ -68,7 +69,7 @@ function activeTerminalTheme() {
     : DARK_TERMINAL_THEME;
 }
 
-export function AgentTerminal({ agentId, agentName, conversationId, workingDir, onClose, onSaveWorkflow }: AgentTerminalProps) {
+export function AgentTerminal({ agentId, agentName, conversationId, workingDir, savingWorkflow, onClose, onSaveWorkflow }: AgentTerminalProps) {
   const hostRef = useRef<HTMLDivElement>(null);
   const terminalIdRef = useRef<string>();
   const terminalRef = useRef<Terminal>();
@@ -190,7 +191,7 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
         {status === "failed" && <span className="error small" title={error}>Failed</span>}
         <button
           className="mini terminal-save-skill"
-          disabled={status !== "running"}
+          disabled={status !== "running" || savingWorkflow}
           onClick={() => {
             const terminal = terminalRef.current;
             if (!terminal) return;
@@ -209,7 +210,7 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
           }}
           title="Save this terminal browser workflow as a private skill"
         >
-          Save as skill
+          {savingWorkflow && <Spinner size={11} />} {savingWorkflow ? "Preparing…" : "Save as skill"}
         </button>
         <button className="plain-icon-btn plain-icon-btn-compact" onClick={onClose} title="Hide terminal" aria-label="Hide terminal">
           <Icon name="xmark" size={13} />

--- a/src/components/AgentTerminal.tsx
+++ b/src/components/AgentTerminal.tsx
@@ -203,7 +203,7 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
           }}
           title="Save this terminal browser workflow as a private skill"
         >
-          Save browser workflow
+          Save as skill
         </button>
         <button className="plain-icon-btn plain-icon-btn-compact" onClick={onClose} title="Hide terminal" aria-label="Hide terminal">
           <Icon name="xmark" size={13} />

--- a/src/components/AgentTerminal.tsx
+++ b/src/components/AgentTerminal.tsx
@@ -196,9 +196,15 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
             if (!terminal) return;
             const buffer = terminal.buffer.active;
             const first = Math.max(0, buffer.length - 500);
-            const transcript = Array.from({ length: buffer.length - first }, (_, index) =>
-              buffer.getLine(first + index)?.translateToString(true) ?? ""
-            ).join("\n").trim();
+            const rows: string[] = [];
+            for (let index = first; index < buffer.length; index += 1) {
+              const line = buffer.getLine(index);
+              if (!line) continue;
+              const text = line.translateToString(true);
+              if (line.isWrapped && rows.length > 0) rows[rows.length - 1] += text;
+              else rows.push(text);
+            }
+            const transcript = rows.join("\n").trim();
             if (transcript) onSaveWorkflow(transcript);
           }}
           title="Save this terminal browser workflow as a private skill"

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -18,7 +18,7 @@ import { AgentTerminal } from "./AgentTerminal";
 import { uid } from "../lib/ids";
 import {
   terminalBrowserTask,
-  workflowDomain,
+  capturedWorkflowDomain,
   workflowInstructions,
   workflowTitle,
 } from "../lib/workflowCapture";
@@ -966,7 +966,7 @@ function SaveWorkflowModal({ task, answer, agent, workingDir, onClose, onSave }:
   onClose: () => void;
   onSave: (title: string, domain: string, instructions: string) => void;
 }) {
-  const inferredDomain = workflowDomain(task) || workflowDomain(answer.text);
+  const inferredDomain = capturedWorkflowDomain(task, answer.text);
   const [title, setTitle] = useState(workflowTitle(task, inferredDomain));
   const [domain, setDomain] = useState(inferredDomain);
   const fallbackInstructions = workflowInstructions(task, answer.text);

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -922,7 +922,7 @@ function MessageBubble({
           </button>
           {m.status === "done" && (
             <button className="save-workflow-btn" title="Save this browser workflow as a local skill" onClick={onSaveWorkflow}>
-              Save browser workflow
+              Save as skill
             </button>
           )}
           <span>{formatTime(m.createdAt)}</span>
@@ -945,7 +945,7 @@ function SaveWorkflowModal({ task, answer, onClose, onSave }: {
   return (
     <div className="modal-overlay" onMouseDown={onClose}>
       <div className="modal-card workflow-save-modal" onMouseDown={(event) => event.stopPropagation()}>
-        <strong>Save browser workflow</strong>
+        <strong>Save as skill</strong>
         <p className="muted small">Saved locally first, then backed up privately to your account.</p>
         <label className="field-label">Skill name</label>
         <input value={title} autoFocus onChange={(event) => setTitle(event.target.value)} />

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -2,12 +2,12 @@ import { type ClipboardEvent, type DragEvent, useEffect, useRef, useState } from
 import { useStore } from "../store";
 import { SCRIPTS } from "../skillsCatalog";
 import { MarkdownText } from "./MarkdownText";
-import { Icon } from "./Icon";
+import { Icon, Spinner } from "./Icon";
 import { BrandLogo } from "./BrandLogo";
 import type { ChatAttachment, ChatMessage } from "../types";
 import { filePathForFile, invoke } from "../electronBridge";
 import { conversationPreview } from "../types";
-import { agentById } from "../agents";
+import { agentById, agentInvocation, type AgentSpec } from "../agents";
 import { trackEvent } from "../lib/analytics";
 import { needsSupportLink } from "../lib/userFacingError";
 import { VPSSetupModal } from "./VPSSetupModal";
@@ -22,6 +22,30 @@ import {
   workflowInstructions,
   workflowTitle,
 } from "../lib/workflowCapture";
+import {
+  parseDistilledWorkflow,
+  workflowDistillationPrompt,
+  type DistilledWorkflow,
+} from "../lib/workflowDistillation";
+
+async function authorWorkflowWithAgent(agent: AgentSpec, workingDir: string, fallback: DistilledWorkflow): Promise<DistilledWorkflow | undefined> {
+  const prompt = workflowDistillationPrompt(fallback);
+  const invocation = agentInvocation(agent, prompt);
+  const { args, stdin } = agent.id === "codex"
+    ? { args: ["exec", "--skip-git-repo-check", "--sandbox", "read-only", "-"], stdin: prompt }
+    : agent.id === "claude"
+      ? { args: ["-p", "--permission-mode", "dontAsk", "--tools", "", prompt], stdin: undefined }
+      : invocation;
+  try {
+    const result = await invoke<{ code: number; stdout: string }>("workflow_author_run", {
+      binary: agent.binary, envVar: agent.envVar, args,
+      stdinText: stdin ?? null, workingDir: workingDir || null,
+    });
+    return result.code === 0 ? parseDistilledWorkflow(result.stdout, fallback) : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 function formatTime(ts: number) {
   return new Date(ts).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
@@ -728,6 +752,8 @@ export function ChatView() {
         <SaveWorkflowModal
           task={workflowDraft.task}
           answer={workflowDraft.answer}
+          agent={ready ? agentSpec : undefined}
+          workingDir={s.workingDir}
           onClose={() => setWorkflowDraft(null)}
           onSave={(title, domain, instructions) => {
             void s.saveLocalSkill({
@@ -932,31 +958,58 @@ function MessageBubble({
   );
 }
 
-function SaveWorkflowModal({ task, answer, onClose, onSave }: {
+function SaveWorkflowModal({ task, answer, agent, workingDir, onClose, onSave }: {
   task: string;
   answer: ChatMessage;
+  agent?: AgentSpec;
+  workingDir: string;
   onClose: () => void;
   onSave: (title: string, domain: string, instructions: string) => void;
 }) {
   const inferredDomain = workflowDomain(task) || workflowDomain(answer.text);
   const [title, setTitle] = useState(workflowTitle(task, inferredDomain));
   const [domain, setDomain] = useState(inferredDomain);
-  const [instructions, setInstructions] = useState(workflowInstructions(task, answer.text));
+  const fallbackInstructions = workflowInstructions(task, answer.text);
+  const [instructions, setInstructions] = useState(fallbackInstructions);
+  const [refining, setRefining] = useState(!!agent);
+  const [authorStatus, setAuthorStatus] = useState(agent ? `Asking ${agent.name} to improve this skill…` : "Using the captured browser workflow.");
+  useEffect(() => {
+    if (!agent) return;
+    let cancelled = false;
+    const fallback = { title: workflowTitle(task, inferredDomain), domain: inferredDomain, instructions: fallbackInstructions };
+    void authorWorkflowWithAgent(agent, workingDir, fallback).then((authored) => {
+      if (cancelled) return;
+      if (authored) {
+        setTitle(authored.title);
+        setDomain(authored.domain);
+        setInstructions(authored.instructions);
+        setAuthorStatus(`Improved and validated by ${agent.name}.`);
+      } else {
+        setAuthorStatus(`${agent.name} did not return a valid skill. Using the captured workflow.`);
+      }
+      setRefining(false);
+    });
+    return () => { cancelled = true; };
+  }, [agent?.id, answer.id, task, inferredDomain, fallbackInstructions, workingDir]);
   return (
     <div className="modal-overlay" onMouseDown={onClose}>
       <div className="modal-card workflow-save-modal" onMouseDown={(event) => event.stopPropagation()}>
         <strong>Save as skill</strong>
         <p className="muted small">Saved locally first, then backed up privately to your account.</p>
+        <div className="small workflow-author-status" role="status">
+          {refining && <Spinner size={12} />}
+          <span className={refining ? "muted" : "ok"}>{authorStatus}</span>
+        </div>
         <label className="field-label">Skill name</label>
-        <input value={title} autoFocus onChange={(event) => setTitle(event.target.value)} />
+        <input value={title} autoFocus disabled={refining} onChange={(event) => setTitle(event.target.value)} />
         <label className="field-label">Website</label>
-        <input value={domain} placeholder="example.com (optional)" onChange={(event) => setDomain(event.target.value)} />
+        <input value={domain} disabled={refining} placeholder="example.com (optional)" onChange={(event) => setDomain(event.target.value)} />
         <label className="field-label">Reusable instructions</label>
-        <textarea rows={8} value={instructions} onChange={(event) => setInstructions(event.target.value)} />
+        <textarea rows={10} disabled={refining} value={instructions} onChange={(event) => setInstructions(event.target.value)} />
         <div className="row" style={{ marginTop: 10, gap: 8 }}>
           <span className="spacer" />
           <button className="secondary" onClick={onClose}>Cancel</button>
-          <button className="primary" disabled={!title.trim() || !instructions.trim()} onClick={() => onSave(title.trim(), domain.trim(), instructions.trim())}>Save skill</button>
+          <button className="primary" disabled={refining || !title.trim() || !instructions.trim()} onClick={() => onSave(title.trim(), domain.trim(), instructions.trim())}>{refining ? "Preparing…" : "Save skill"}</button>
         </div>
       </div>
     </div>

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -108,7 +108,8 @@ export function ChatView() {
   const [convMenu, setConvMenu] = useState<{ id: string; x: number; y: number } | null>(null);
   const [promptDetail, setPromptDetail] = useState<string | null>(null);
   const [vpsSetupOpen, setVPSSetupOpen] = useState(false);
-  const [workflowDraft, setWorkflowDraft] = useState<{ task: string; answer: ChatMessage } | null>(null);
+  const [workflowDraft, setWorkflowDraft] = useState<{ task: string; answer: ChatMessage; prepared: DistilledWorkflow } | null>(null);
+  const [preparingWorkflowId, setPreparingWorkflowId] = useState<string | null>(null);
   const [terminalVisible, setTerminalVisible] = useState(s.terminalChat);
   const [terminalMounted, setTerminalMounted] = useState(s.terminalChat);
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -230,6 +231,18 @@ export function ChatView() {
 
   const agentSpec = agentById(agentId);
   const agentName = agentSpec.name;
+  const prepareWorkflow = async (task: string, answer: ChatMessage, sourceId: string) => {
+    if (preparingWorkflowId) return;
+    setPreparingWorkflowId(sourceId);
+    const domain = capturedWorkflowDomain(task, answer.text);
+    const fallback = {
+      title: workflowTitle(task, domain), domain,
+      instructions: workflowInstructions(task, answer.text),
+    };
+    const authored = ready ? await authorWorkflowWithAgent(agentSpec, s.workingDir, fallback) : undefined;
+    setWorkflowDraft({ task, answer, prepared: authored ?? fallback });
+    setPreparingWorkflowId(null);
+  };
   const showDefaultSession =
     !s.selectedProfile && s.defaultSession?.status === "running";
 
@@ -356,15 +369,14 @@ export function ChatView() {
               agentName={agentName}
               conversationId={conv?.id}
               workingDir={s.workingDir}
+              savingWorkflow={preparingWorkflowId === "terminal"}
               onClose={() => setTerminalVisible(false)}
               onSaveWorkflow={(transcript) => {
-                setWorkflowDraft({
-                  task: terminalBrowserTask(transcript),
-                  answer: {
-                    id: uid(), role: "assistant", text: transcript, status: "done",
-                    createdAt: Date.now(),
-                  },
-                });
+                const answer = {
+                  id: uid(), role: "assistant" as const, text: transcript, status: "done" as const,
+                  createdAt: Date.now(),
+                };
+                void prepareWorkflow(terminalBrowserTask(transcript), answer, "terminal");
               }}
             />
           </div>
@@ -474,8 +486,9 @@ export function ChatView() {
               onSaveWorkflow={() => {
                 const index = messages.findIndex((candidate) => candidate.id === m.id);
                 const user = [...messages.slice(0, index)].reverse().find((candidate) => candidate.role === "user");
-                setWorkflowDraft({ task: user?.text ?? "", answer: m });
+                void prepareWorkflow(user?.text ?? "", m, m.id);
               }}
+              savingWorkflow={preparingWorkflowId === m.id}
             />
           ))}
           <div ref={bottomRef} />
@@ -752,8 +765,7 @@ export function ChatView() {
         <SaveWorkflowModal
           task={workflowDraft.task}
           answer={workflowDraft.answer}
-          agent={ready ? agentSpec : undefined}
-          workingDir={s.workingDir}
+          prepared={workflowDraft.prepared}
           onClose={() => setWorkflowDraft(null)}
           onSave={(title, domain, instructions) => {
             void s.saveLocalSkill({
@@ -782,6 +794,7 @@ function MessageBubble({
   queuedReplyId,
   onShowPrompt,
   onSaveWorkflow,
+  savingWorkflow,
 }: {
   message: ChatMessage;
   canQueue: boolean;
@@ -792,6 +805,7 @@ function MessageBubble({
   queuedReplyId?: string;
   onShowPrompt: () => void;
   onSaveWorkflow: () => void;
+  savingWorkflow: boolean;
 }) {
   const [clock, setClock] = useState(Date.now());
   const [showErrorDetails, setShowErrorDetails] = useState(false);
@@ -947,8 +961,8 @@ function MessageBubble({
             <Icon name="doc.on.doc" size={12} />
           </button>
           {m.status === "done" && (
-            <button className="save-workflow-btn" title="Save this browser workflow as a local skill" onClick={onSaveWorkflow}>
-              Save as skill
+            <button className="save-workflow-btn" disabled={savingWorkflow} title="Save this browser workflow as a local skill" onClick={onSaveWorkflow}>
+              {savingWorkflow && <Spinner size={11} />} {savingWorkflow ? "Preparing…" : "Save as skill"}
             </button>
           )}
           <span>{formatTime(m.createdAt)}</span>
@@ -958,58 +972,31 @@ function MessageBubble({
   );
 }
 
-function SaveWorkflowModal({ task, answer, agent, workingDir, onClose, onSave }: {
+function SaveWorkflowModal({ prepared, onClose, onSave }: {
   task: string;
   answer: ChatMessage;
-  agent?: AgentSpec;
-  workingDir: string;
+  prepared: DistilledWorkflow;
   onClose: () => void;
   onSave: (title: string, domain: string, instructions: string) => void;
 }) {
-  const inferredDomain = capturedWorkflowDomain(task, answer.text);
-  const [title, setTitle] = useState(workflowTitle(task, inferredDomain));
-  const [domain, setDomain] = useState(inferredDomain);
-  const fallbackInstructions = workflowInstructions(task, answer.text);
-  const [instructions, setInstructions] = useState(fallbackInstructions);
-  const [refining, setRefining] = useState(!!agent);
-  const [authorStatus, setAuthorStatus] = useState(agent ? `Asking ${agent.name} to improve this skill…` : "Using the captured browser workflow.");
-  useEffect(() => {
-    if (!agent) return;
-    let cancelled = false;
-    const fallback = { title: workflowTitle(task, inferredDomain), domain: inferredDomain, instructions: fallbackInstructions };
-    void authorWorkflowWithAgent(agent, workingDir, fallback).then((authored) => {
-      if (cancelled) return;
-      if (authored) {
-        setTitle(authored.title);
-        setDomain(authored.domain);
-        setInstructions(authored.instructions);
-        setAuthorStatus(`Improved and validated by ${agent.name}.`);
-      } else {
-        setAuthorStatus(`${agent.name} did not return a valid skill. Using the captured workflow.`);
-      }
-      setRefining(false);
-    });
-    return () => { cancelled = true; };
-  }, [agent?.id, answer.id, task, inferredDomain, fallbackInstructions, workingDir]);
+  const [title, setTitle] = useState(prepared.title);
+  const [domain, setDomain] = useState(prepared.domain);
+  const [instructions, setInstructions] = useState(prepared.instructions);
   return (
     <div className="modal-overlay" onMouseDown={onClose}>
       <div className="modal-card workflow-save-modal" onMouseDown={(event) => event.stopPropagation()}>
         <strong>Save as skill</strong>
         <p className="muted small">Saved locally first, then backed up privately to your account.</p>
-        <div className="small workflow-author-status" role="status">
-          {refining && <Spinner size={12} />}
-          <span className={refining ? "muted" : "ok"}>{authorStatus}</span>
-        </div>
         <label className="field-label">Skill name</label>
-        <input value={title} autoFocus disabled={refining} onChange={(event) => setTitle(event.target.value)} />
+        <input value={title} autoFocus onChange={(event) => setTitle(event.target.value)} />
         <label className="field-label">Website</label>
-        <input value={domain} disabled={refining} placeholder="example.com (optional)" onChange={(event) => setDomain(event.target.value)} />
+        <input value={domain} placeholder="example.com (optional)" onChange={(event) => setDomain(event.target.value)} />
         <label className="field-label">Reusable instructions</label>
-        <textarea rows={10} disabled={refining} value={instructions} onChange={(event) => setInstructions(event.target.value)} />
+        <textarea rows={10} value={instructions} onChange={(event) => setInstructions(event.target.value)} />
         <div className="row" style={{ marginTop: 10, gap: 8 }}>
           <span className="spacer" />
           <button className="secondary" onClick={onClose}>Cancel</button>
-          <button className="primary" disabled={refining || !title.trim() || !instructions.trim()} onClick={() => onSave(title.trim(), domain.trim(), instructions.trim())}>{refining ? "Preparing…" : "Save skill"}</button>
+          <button className="primary" disabled={!title.trim() || !instructions.trim()} onClick={() => onSave(title.trim(), domain.trim(), instructions.trim())}>Save skill</button>
         </div>
       </div>
     </div>

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -61,6 +61,11 @@ function workflowTitle(task: string, domain: string): string {
   return (plain || (domain ? `${domain} workflow` : "Browser workflow")).slice(0, 64);
 }
 
+function terminalTask(transcript: string): string {
+  const prompts = transcript.split("\n").map((line) => line.trim()).filter((line) => line.startsWith("›"));
+  return prompts.at(-1)?.replace(/^›\s*/, "").trim() ?? "";
+}
+
 export function ChatView() {
   const s = useStore();
   const agentId = s.agentId;
@@ -336,6 +341,15 @@ export function ChatView() {
               conversationId={conv?.id}
               workingDir={s.workingDir}
               onClose={() => setTerminalVisible(false)}
+              onSaveWorkflow={(transcript) => {
+                setWorkflowDraft({
+                  task: terminalTask(transcript),
+                  answer: {
+                    id: uid(), role: "assistant", text: transcript, status: "done",
+                    createdAt: Date.now(),
+                  },
+                });
+              }}
             />
           </div>
         )}
@@ -914,7 +928,7 @@ function MessageBubble({
           >
             <Icon name="doc.on.doc" size={12} />
           </button>
-          {m.status === "done" && ((m.toolEvents?.length ?? 0) > 0 || /https?:\/\//i.test(m.text)) && (
+          {m.status === "done" && (
             <button className="save-workflow-btn" title="Save this browser workflow as a local skill" onClick={onSaveWorkflow}>
               <Icon name="sparkles" size={12} /> Save browser workflow
             </button>

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -16,6 +16,12 @@ import { AgentInstallLink } from "./AgentInstallLink";
 import { takeGuideDraft } from "../lib/guideDraft";
 import { AgentTerminal } from "./AgentTerminal";
 import { uid } from "../lib/ids";
+import {
+  terminalBrowserTask,
+  workflowDomain,
+  workflowInstructions,
+  workflowTitle,
+} from "../lib/workflowCapture";
 
 function formatTime(ts: number) {
   return new Date(ts).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
@@ -51,20 +57,6 @@ function errorSummary(text: string): string {
   return cleaned.length > 140 ? cleaned.slice(0, 140) + "…" : cleaned;
 }
 
-function workflowDomain(text: string): string {
-  const match = text.match(/(?:https?:\/\/)?(?:www\.)?([a-z0-9-]+(?:\.[a-z0-9-]+)+)/i);
-  return match?.[1]?.toLowerCase() ?? "";
-}
-
-function workflowTitle(task: string, domain: string): string {
-  const plain = task.replace(/https?:\/\/\S+/g, "").trim().replace(/\s+/g, " ");
-  return (plain || (domain ? `${domain} workflow` : "Browser workflow")).slice(0, 64);
-}
-
-function terminalTask(transcript: string): string {
-  const prompts = transcript.split("\n").map((line) => line.trim()).filter((line) => line.startsWith("›"));
-  return prompts.at(-1)?.replace(/^›\s*/, "").trim() ?? "";
-}
 
 export function ChatView() {
   const s = useStore();
@@ -343,7 +335,7 @@ export function ChatView() {
               onClose={() => setTerminalVisible(false)}
               onSaveWorkflow={(transcript) => {
                 setWorkflowDraft({
-                  task: terminalTask(transcript),
+                  task: terminalBrowserTask(transcript),
                   answer: {
                     id: uid(), role: "assistant", text: transcript, status: "done",
                     createdAt: Date.now(),
@@ -930,7 +922,7 @@ function MessageBubble({
           </button>
           {m.status === "done" && (
             <button className="save-workflow-btn" title="Save this browser workflow as a local skill" onClick={onSaveWorkflow}>
-              <Icon name="sparkles" size={12} /> Save browser workflow
+              Save browser workflow
             </button>
           )}
           <span>{formatTime(m.createdAt)}</span>
@@ -946,10 +938,10 @@ function SaveWorkflowModal({ task, answer, onClose, onSave }: {
   onClose: () => void;
   onSave: (title: string, domain: string, instructions: string) => void;
 }) {
-  const inferredDomain = workflowDomain(`${task}\n${answer.text}`);
+  const inferredDomain = workflowDomain(task) || workflowDomain(answer.text);
   const [title, setTitle] = useState(workflowTitle(task, inferredDomain));
   const [domain, setDomain] = useState(inferredDomain);
-  const [instructions, setInstructions] = useState(answer.text);
+  const [instructions, setInstructions] = useState(workflowInstructions(task, answer.text));
   return (
     <div className="modal-overlay" onMouseDown={onClose}>
       <div className="modal-card workflow-save-modal" onMouseDown={(event) => event.stopPropagation()}>

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -20,6 +20,7 @@ import {
   terminalBrowserTask,
   capturedWorkflowDomain,
   workflowInstructions,
+  workflowQuality,
   workflowTitle,
 } from "../lib/workflowCapture";
 import {
@@ -110,6 +111,7 @@ export function ChatView() {
   const [vpsSetupOpen, setVPSSetupOpen] = useState(false);
   const [workflowDraft, setWorkflowDraft] = useState<{ task: string; answer: ChatMessage; prepared: DistilledWorkflow } | null>(null);
   const [preparingWorkflowId, setPreparingWorkflowId] = useState<string | null>(null);
+  const [workflowRejection, setWorkflowRejection] = useState<string | null>(null);
   const [terminalVisible, setTerminalVisible] = useState(s.terminalChat);
   const [terminalMounted, setTerminalMounted] = useState(s.terminalChat);
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -234,13 +236,22 @@ export function ChatView() {
   const prepareWorkflow = async (task: string, answer: ChatMessage, sourceId: string) => {
     if (preparingWorkflowId) return;
     setPreparingWorkflowId(sourceId);
-    const domain = capturedWorkflowDomain(task, answer.text);
+    const toolTrace = (answer.toolEvents ?? []).map((event) =>
+      `Called ${event.name}${event.detail ? `(${event.detail})` : ""}`,
+    ).join("\n");
+    const evidence = [toolTrace, answer.text].filter(Boolean).join("\n");
+    const capturedAnswer = { ...answer, text: evidence };
+    const domain = capturedWorkflowDomain(task, evidence);
+    const quality = workflowQuality(task, evidence, domain);
     const fallback = {
       title: workflowTitle(task, domain), domain,
-      instructions: workflowInstructions(task, answer.text),
+      instructions: workflowInstructions(task, evidence),
+      ...quality,
     };
-    const authored = ready ? await authorWorkflowWithAgent(agentSpec, s.workingDir, fallback) : undefined;
-    setWorkflowDraft({ task, answer, prepared: authored ?? fallback });
+    const authored = quality.reusable && ready ? await authorWorkflowWithAgent(agentSpec, s.workingDir, fallback) : undefined;
+    const prepared = authored ?? fallback;
+    if (!prepared.reusable) setWorkflowRejection(prepared.reason);
+    else setWorkflowDraft({ task, answer: capturedAnswer, prepared });
     setPreparingWorkflowId(null);
   };
   const showDefaultSession =
@@ -778,6 +789,17 @@ export function ChatView() {
             s.setTab("skills");
           }}
         />
+      )}
+
+      {workflowRejection && (
+        <div className="modal-overlay" onMouseDown={() => setWorkflowRejection(null)}>
+          <div className="modal-card workflow-quality-modal" onMouseDown={(event) => event.stopPropagation()}>
+            <strong>Nothing reusable to save yet</strong>
+            <p className="muted">{workflowRejection}</p>
+            <p className="muted small">Complete a browser search, extraction, form, or posting task successfully, then try again.</p>
+            <div className="row"><span className="spacer" /><button className="primary" onClick={() => setWorkflowRejection(null)}>OK</button></div>
+          </div>
+        </div>
       )}
 
       {vpsSetupOpen && <VPSSetupModal onClose={() => setVPSSetupOpen(false)} />}

--- a/src/components/SkillsView.tsx
+++ b/src/components/SkillsView.tsx
@@ -17,6 +17,7 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
   const [category, setCategory] = useState("__skills__");
   const [status, setStatus] = useState<Record<string, string>>({});
   const [scriptEditor, setScriptEditor] = useState<CustomScript | "new" | null>(null);
+  const [skillRun, setSkillRun] = useState<BrowserWorkflowSkill | null>(null);
 
   const cat = categories.find((c) => c.id === category);
   const isSkillsOverview = category === "__skills__";
@@ -272,7 +273,7 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
                   skill={skill}
                   ready={ready}
                   sync={s.localSkillSync[skill.id] ?? (skill.submittedAt ? "synced" : "idle")}
-                  onRun={() => void s.runLocalSkill(skill)}
+                  onRun={() => setSkillRun(skill)}
                   onSync={() => void s.saveLocalSkill(skill)}
                   onDelete={() => s.deleteLocalSkill(skill.id)}
                 />
@@ -376,6 +377,45 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
           }}
         />
       )}
+      {skillRun && (
+        <RunLocalSkillSheet
+          skill={skillRun}
+          sessionName={sessionName}
+          onClose={() => setSkillRun(null)}
+          onRun={(task) => {
+            const skill = skillRun;
+            setSkillRun(null);
+            void s.runLocalSkill(skill, task);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function RunLocalSkillSheet({ skill, sessionName, onClose, onRun }: {
+  skill: BrowserWorkflowSkill;
+  sessionName: string;
+  onClose: () => void;
+  onRun: (task: string) => void;
+}) {
+  const [task, setTask] = useState(skill.task);
+  return (
+    <div className="modal-overlay" onMouseDown={onClose}>
+      <div className="modal-card skill-run-modal" onMouseDown={(event) => event.stopPropagation()}>
+        <strong>Run {skill.title}</strong>
+        <p className="muted small">
+          The app will verify <strong>{sessionName}</strong>{skill.domain ? ` and open ${skill.domain}` : ""} before the agent starts.
+        </p>
+        <label className="field-label">Task for this run</label>
+        <textarea rows={5} autoFocus value={task} onChange={(event) => setTask(event.target.value)} />
+        <p className="muted small">Change the search, filters, content, or other values while keeping the saved workflow.</p>
+        <div className="row" style={{ gap: 8 }}>
+          <span className="spacer" />
+          <button className="secondary" onClick={onClose}>Cancel</button>
+          <button className="primary" disabled={!task.trim()} onClick={() => onRun(task.trim())}>Run skill</button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/SkillsView.tsx
+++ b/src/components/SkillsView.tsx
@@ -262,7 +262,7 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
             <div className="skills-empty-state">
               <span className="skills-empty-icon"><Icon name="sparkles" size={22} /></span>
               <strong>No local skills yet</strong>
-              <span className="muted small">After a successful browser task, use “Save browser workflow” below the answer.</span>
+              <span className="muted small">After a successful browser task, use “Save as skill” below the answer.</span>
             </div>
           ) : (
             <div className="skills-grid">

--- a/src/lib/workflowCapture.test.ts
+++ b/src/lib/workflowCapture.test.ts
@@ -4,9 +4,9 @@ import { terminalBrowserTask, workflowDomain, workflowInstructions, workflowTitl
 const transcript = `
 │ model:     gpt-5.6-sol low   /model to change │
 › открой makler.md c американской проксей и найди все матизы
-• Called clawbrowser.start({"country":"US","url":"https://makler.md"})
-• Called clawbrowser.multi_action({"actions":[]})
-• Called clawbrowser.paginate_extract({"limit":100})
+• Called clawbrowser.start({"profile":"us-makler-md","country":"US","url":"https://makler.md","return_state":true})
+• Called clawbrowser.multi_action({"profile":"us-makler-md","actions":[{"type":"input","element_id":6,"text":"Matiz"},{"type":"press","key":"Enter"}],"stop_on_navigation":true})
+• Called clawbrowser.paginate_extract({"profile":"us-makler-md","container":"a[href]","filters":[{"field":"title","op":"contains","value":"Matiz"}],"dedupe_by":["url"],"scroll":true,"max_pages":5,"limit":100})
 • Нашёл 2 объявления.
 › Explain this codebase
   gpt-5.6-sol low · ~/.nextbrowser/workspace
@@ -27,6 +27,10 @@ describe("terminal workflow capture", () => {
     const instructions = workflowInstructions(task, transcript);
     expect(instructions).toContain("verify the requested proxy country");
     expect(instructions).toContain("deduplicate by canonical URL");
+    expect(instructions).toContain('clawbrowser.start({"profile":"us-makler-md","country":"US","url":"https://makler.md"})');
+    expect(instructions).toContain('"element_id":6');
+    expect(instructions).toContain('"dedupe_by":["url"]');
+    expect(instructions).not.toContain("return_state");
     expect(instructions).not.toContain("gpt-5.6-sol");
   });
 });

--- a/src/lib/workflowCapture.test.ts
+++ b/src/lib/workflowCapture.test.ts
@@ -30,6 +30,11 @@ describe("terminal workflow capture", () => {
     expect(capturedWorkflowDomain(terminalBrowserTask(verified), verified)).toBe("makler.md");
   });
 
+  it("uses a public result link when normal chat output has no embedded tool trace", () => {
+    const answer = "Нашёл объявление: [Daewoo Matiz](https://makler.md/ro/transport/cars/an/467749). Verification: https://app.clawbrowser.ai/dashboard/browser-streaming.";
+    expect(capturedWorkflowDomain("найди все матизы", answer)).toBe("makler.md");
+  });
+
   it("creates a useful title and normalized instructions", () => {
     const task = terminalBrowserTask(transcript);
     expect(workflowTitle(task, "makler.md")).toBe("makler.md — матизы");

--- a/src/lib/workflowCapture.test.ts
+++ b/src/lib/workflowCapture.test.ts
@@ -33,4 +33,24 @@ describe("terminal workflow capture", () => {
     expect(instructions).not.toContain("return_state");
     expect(instructions).not.toContain("gpt-5.6-sol");
   });
+
+  it("keeps one successful extraction and marks a non-self-contained search", () => {
+    const retryTranscript = `
+› открой makler.md c американской проксей и найди все матизы
+• Called clawbrowser.start({"profile":"us-makler-md","country":"US","url":"https://makler.md"})
+  {"ok":true}
+• Called clawbrowser.paginate_extract({"container":"li","fields":{"title":{"selector":"h3"}},"limit":500})
+  {"rows":[],"count":0}
+• Called clawbrowser.paginate_extract({"container":"li","fields":{"title":{"selector":"h3 a"}},"scroll":true,"limit":500})
+  Error: selector failed
+• Called clawbrowser.paginate_extract({"container":"a[href]","fields":{"title":{"selector":""},"url":{"selector":"","attribute":"href"}},"filters":[{"field":"title","op":"contains","value":"Matiz"}],"dedupe_by":["url"],"scroll":true,"limit":500})
+  {"rows":[{"title":"Daewoo Matiz","url":"https://makler.md/1"}],"count":1}
+`;
+    const instructions = workflowInstructions(terminalBrowserTask(retryTranscript), retryTranscript);
+    expect(instructions.match(/clawbrowser\.paginate_extract/g)).toHaveLength(1);
+    expect(instructions).toContain('"container":"a[href]"');
+    expect(instructions).toContain("fast path is partial");
+    expect(instructions).toContain("apply the requested search");
+    expect(instructions).not.toContain("element_id values");
+  });
 });

--- a/src/lib/workflowCapture.test.ts
+++ b/src/lib/workflowCapture.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { capturedWorkflowDomain, terminalBrowserTask, workflowDomain, workflowInstructions, workflowTitle } from "./workflowCapture";
+import { capturedWorkflowDomain, terminalBrowserTask, workflowDomain, workflowInstructions, workflowQuality, workflowTitle } from "./workflowCapture";
 
 const transcript = `
 │ model:     gpt-5.6-sol low   /model to change │
@@ -66,5 +66,11 @@ describe("terminal workflow capture", () => {
     expect(instructions).toContain("fast path is partial");
     expect(instructions).toContain("apply the requested search");
     expect(instructions).not.toContain("element_id values");
+  });
+
+  it("rejects empty and failed runs but accepts successful extraction", () => {
+    expect(workflowQuality("открой makler.md", "No browser calls").reusable).toBe(false);
+    expect(workflowQuality("открой makler.md", 'Called clawbrowser.navigate({"url":"https://makler.md"})\nError: failed').reusable).toBe(false);
+    expect(workflowQuality(terminalBrowserTask(transcript), transcript).reusable).toBe(true);
   });
 });

--- a/src/lib/workflowCapture.test.ts
+++ b/src/lib/workflowCapture.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { terminalBrowserTask, workflowDomain, workflowInstructions, workflowTitle } from "./workflowCapture";
+import { capturedWorkflowDomain, terminalBrowserTask, workflowDomain, workflowInstructions, workflowTitle } from "./workflowCapture";
 
 const transcript = `
 │ model:     gpt-5.6-sol low   /model to change │
@@ -19,6 +19,15 @@ describe("terminal workflow capture", () => {
 
   it("does not mistake a model version for a website", () => {
     expect(workflowDomain(`${terminalBrowserTask(transcript)}\n${transcript}`)).toBe("makler.md");
+  });
+
+  it("ignores verification and service domains when resolving the target website", () => {
+    const verified = `
+› найди все матизы
+• Called clawbrowser.start({"url":"https://app.clawbrowser.ai/dashboard/browser-streaming?id=rs_123"})
+• Called clawbrowser.navigate({"url":"https://makler.md/ro/an/search?query=Matiz"})
+`;
+    expect(capturedWorkflowDomain(terminalBrowserTask(verified), verified)).toBe("makler.md");
   });
 
   it("creates a useful title and normalized instructions", () => {

--- a/src/lib/workflowCapture.test.ts
+++ b/src/lib/workflowCapture.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { terminalBrowserTask, workflowDomain, workflowInstructions, workflowTitle } from "./workflowCapture";
+
+const transcript = `
+│ model:     gpt-5.6-sol low   /model to change │
+› открой makler.md c американской проксей и найди все матизы
+• Called clawbrowser.start({"country":"US","url":"https://makler.md"})
+• Called clawbrowser.multi_action({"actions":[]})
+• Called clawbrowser.paginate_extract({"limit":100})
+• Нашёл 2 объявления.
+› Explain this codebase
+  gpt-5.6-sol low · ~/.nextbrowser/workspace
+`;
+
+describe("terminal workflow capture", () => {
+  it("binds the workflow to the prompt before the last browser run", () => {
+    expect(terminalBrowserTask(transcript)).toBe("открой makler.md c американской проксей и найди все матизы");
+  });
+
+  it("does not mistake a model version for a website", () => {
+    expect(workflowDomain(`${terminalBrowserTask(transcript)}\n${transcript}`)).toBe("makler.md");
+  });
+
+  it("creates a useful title and normalized instructions", () => {
+    const task = terminalBrowserTask(transcript);
+    expect(workflowTitle(task, "makler.md")).toBe("makler.md — матизы");
+    const instructions = workflowInstructions(task, transcript);
+    expect(instructions).toContain("verify the requested proxy country");
+    expect(instructions).toContain("deduplicate by canonical URL");
+    expect(instructions).not.toContain("gpt-5.6-sol");
+  });
+});

--- a/src/lib/workflowCapture.ts
+++ b/src/lib/workflowCapture.ts
@@ -95,6 +95,36 @@ export function workflowDomain(text: string): string {
   return bare?.[1]?.toLowerCase() ?? "";
 }
 
+const INTERNAL_BROWSER_HOSTS = new Set([
+  "app.clawbrowser.ai",
+  "api.nextbrowser.com",
+  "app.nextbrowser.com",
+]);
+
+function publicDomainFromURL(value: unknown): string {
+  if (typeof value !== "string") return "";
+  try {
+    const url = new URL(value);
+    const host = url.hostname.toLowerCase().replace(/^www\./, "");
+    if (!["http:", "https:"].includes(url.protocol)) return "";
+    if (host === "localhost" || host === "127.0.0.1" || INTERNAL_BROWSER_HOSTS.has(host)) return "";
+    return workflowDomain(host);
+  } catch {
+    return "";
+  }
+}
+
+/** Resolve the task's website without accidentally selecting verification/API URLs from tool output. */
+export function capturedWorkflowDomain(task: string, transcript: string): string {
+  const requested = workflowDomain(task);
+  if (requested) return requested;
+  for (const call of capturedCalls(transcript)) {
+    const domain = publicDomainFromURL(call.args.url);
+    if (domain) return domain;
+  }
+  return "";
+}
+
 export function terminalBrowserTask(transcript: string): string {
   const lastTool = Math.max(
     transcript.lastIndexOf("clawbrowser."),

--- a/src/lib/workflowCapture.ts
+++ b/src/lib/workflowCapture.ts
@@ -1,0 +1,50 @@
+const PROMPT_MARKER = /^\s*›\s*(.+)$/gm;
+const CLAWBROWSER_CALL = /clawbrowser\.([a-z_]+)/g;
+
+export function workflowDomain(text: string): string {
+  const explicit = text.match(/https?:\/\/(?:www\.)?([a-z0-9-]+(?:\.[a-z0-9-]+)*\.[a-z]{2,})(?=[/:?#\s]|$)/i);
+  if (explicit?.[1]) return explicit[1].toLowerCase();
+  const bare = text.match(/\b(?:www\.)?([a-z0-9-]+(?:\.[a-z0-9-]+)*\.[a-z]{2,})(?=[/:?#\s]|$)/i);
+  return bare?.[1]?.toLowerCase() ?? "";
+}
+
+export function terminalBrowserTask(transcript: string): string {
+  const lastTool = Math.max(
+    transcript.lastIndexOf("clawbrowser."),
+    transcript.lastIndexOf("nbc "),
+    transcript.lastIndexOf("nextctl "),
+  );
+  if (lastTool < 0) return "";
+  const beforeTool = transcript.slice(0, lastTool);
+  const prompts = [...beforeTool.matchAll(PROMPT_MARKER)];
+  return prompts.at(-1)?.[1]?.trim() ?? "";
+}
+
+export function workflowTitle(task: string, domain: string): string {
+  const subject = task.match(/(?:найди|find|search(?:\s+for)?)\s+(?:все\s+|all\s+)?(.+?)(?:\s+(?:на|on|with|с)\s+|$)/i)?.[1]
+    ?.replace(/[.,;:!?]+$/g, "")
+    .trim();
+  if (domain && subject) return `${domain} — ${subject}`.slice(0, 64);
+  if (domain) return `${domain} browser workflow`;
+  return "Browser workflow";
+}
+
+export function workflowInstructions(task: string, transcript: string): string {
+  const tools = [...transcript.matchAll(CLAWBROWSER_CALL)].map((match) => match[1]);
+  const unique = tools.filter((tool, index) => tools.indexOf(tool) === index);
+  const steps: string[] = [];
+  if (unique.includes("start") || unique.includes("prepare")) {
+    steps.push("Start or reattach the requested Clawbrowser profile and verify the requested proxy country before interacting with the site.");
+  }
+  if (unique.some((tool) => ["open", "navigate"].includes(tool))) {
+    steps.push("Open the target website in the verified browser session.");
+  }
+  if (unique.some((tool) => ["multi_action", "input", "click", "press"].includes(tool))) {
+    steps.push("Use the site's controls to apply the requested search and filters, waiting for navigation or page settlement when needed.");
+  }
+  if (unique.some((tool) => ["paginate_extract", "extract", "state"].includes(tool))) {
+    steps.push("Extract all matching results, paginate or scroll as needed, deduplicate by canonical URL, and exclude irrelevant matches.");
+  }
+  steps.push("Return a concise result list with titles, URLs, and the important details requested by the user.");
+  return `Task pattern:\n${task || "Repeat the saved browser task on the selected website."}\n\nWorkflow:\n${steps.map((step, index) => `${index + 1}. ${step}`).join("\n")}`;
+}

--- a/src/lib/workflowCapture.ts
+++ b/src/lib/workflowCapture.ts
@@ -114,6 +114,15 @@ function publicDomainFromURL(value: unknown): string {
   }
 }
 
+function publicDomainsInText(text: string): string[] {
+  const domains: string[] = [];
+  for (const match of text.matchAll(/https?:\/\/[^\s<>"')\]]+/gi)) {
+    const domain = publicDomainFromURL(match[0].replace(/[.,;:!?]+$/, ""));
+    if (domain && !domains.includes(domain)) domains.push(domain);
+  }
+  return domains;
+}
+
 /** Resolve the task's website without accidentally selecting verification/API URLs from tool output. */
 export function capturedWorkflowDomain(task: string, transcript: string): string {
   const requested = workflowDomain(task);
@@ -122,7 +131,9 @@ export function capturedWorkflowDomain(task: string, transcript: string): string
     const domain = publicDomainFromURL(call.args.url);
     if (domain) return domain;
   }
-  return "";
+  // Normal chat messages may keep tool events outside the rendered answer. Result
+  // links are still a reliable fallback once internal verification hosts are removed.
+  return publicDomainsInText(transcript)[0] ?? "";
 }
 
 export function terminalBrowserTask(transcript: string): string {

--- a/src/lib/workflowCapture.ts
+++ b/src/lib/workflowCapture.ts
@@ -1,6 +1,66 @@
 const PROMPT_MARKER = /^\s*›\s*(.+)$/gm;
 const CLAWBROWSER_CALL = /clawbrowser\.([a-z_]+)/g;
 
+interface CapturedCall {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+function capturedCalls(transcript: string): CapturedCall[] {
+  const calls: CapturedCall[] = [];
+  for (const match of transcript.matchAll(CLAWBROWSER_CALL)) {
+    const name = match[1];
+    const open = transcript.indexOf("(", (match.index ?? 0) + match[0].length);
+    if (open < 0) continue;
+    let depth = 0;
+    let quoted = false;
+    let escaped = false;
+    let close = -1;
+    for (let index = open; index < transcript.length; index += 1) {
+      const char = transcript[index];
+      if (quoted) {
+        if (escaped) escaped = false;
+        else if (char === "\\") escaped = true;
+        else if (char === '"') quoted = false;
+        continue;
+      }
+      if (char === '"') quoted = true;
+      else if (char === "(") depth += 1;
+      else if (char === ")" && --depth === 0) {
+        close = index;
+        break;
+      }
+    }
+    if (close < 0) continue;
+    try {
+      const args = JSON.parse(transcript.slice(open + 1, close)) as Record<string, unknown>;
+      calls.push({ name, args });
+    } catch {
+      // Truncated calls still contribute their tool name to the generic workflow.
+    }
+  }
+  return calls;
+}
+
+function pick(source: Record<string, unknown>, keys: string[]): Record<string, unknown> {
+  return Object.fromEntries(keys.filter((key) => source[key] !== undefined).map((key) => [key, source[key]]));
+}
+
+function fastPath(transcript: string): string[] {
+  return capturedCalls(transcript).flatMap(({ name, args }) => {
+    if (["start", "prepare"].includes(name)) {
+      return [`clawbrowser.${name}(${JSON.stringify(pick(args, ["profile", "country", "url", "verify", "wait_for"]))})`];
+    }
+    if (name === "multi_action") {
+      return [`clawbrowser.multi_action(${JSON.stringify(pick(args, ["actions", "stop_on_navigation", "wait_for", "state_mode"]))})`];
+    }
+    if (["paginate_extract", "extract"].includes(name)) {
+      return [`clawbrowser.${name}(${JSON.stringify(pick(args, ["container", "fields", "filters", "dedupe_by", "transform", "scroll", "max_pages", "limit", "initial_wait", "timeout"]))})`];
+    }
+    return [];
+  });
+}
+
 export function workflowDomain(text: string): string {
   const explicit = text.match(/https?:\/\/(?:www\.)?([a-z0-9-]+(?:\.[a-z0-9-]+)*\.[a-z]{2,})(?=[/:?#\s]|$)/i);
   if (explicit?.[1]) return explicit[1].toLowerCase();
@@ -46,5 +106,9 @@ export function workflowInstructions(task: string, transcript: string): string {
     steps.push("Extract all matching results, paginate or scroll as needed, deduplicate by canonical URL, and exclude irrelevant matches.");
   }
   steps.push("Return a concise result list with titles, URLs, and the important details requested by the user.");
-  return `Task pattern:\n${task || "Repeat the saved browser task on the selected website."}\n\nWorkflow:\n${steps.map((step, index) => `${index + 1}. ${step}`).join("\n")}`;
+  const calls = fastPath(transcript);
+  const technical = calls.length
+    ? `\n\nTechnical fast path:\nRun these operations in order. Reuse the saved arguments first; inspect the page and adapt only if an operation fails or the page structure changed.\n\n${calls.map((call, index) => `${index + 1}. ${call}`).join("\n")}\n\nTreat saved element_id values as short-lived hints. Resolve the element again by role, label, text, or selector if the id no longer matches.`
+    : "";
+  return `Task pattern:\n${task || "Repeat the saved browser task on the selected website."}\n\nWorkflow:\n${steps.map((step, index) => `${index + 1}. ${step}`).join("\n")}${technical}`;
 }

--- a/src/lib/workflowCapture.ts
+++ b/src/lib/workflowCapture.ts
@@ -136,6 +136,24 @@ export function capturedWorkflowDomain(task: string, transcript: string): string
   return publicDomainsInText(transcript)[0] ?? "";
 }
 
+export function workflowQuality(task: string, transcript: string, domain = capturedWorkflowDomain(task, transcript)): { reusable: boolean; reason: string } {
+  if (!domain) return { reusable: false, reason: "The website could not be identified." };
+  const calls = capturedCalls(transcript);
+  if (calls.length === 0) return { reusable: false, reason: "No browser actions were captured." };
+  const meaningful = calls.filter((call) => !["state", "tabs", "wait", "verify"].includes(call.name));
+  if (meaningful.length === 0) return { reusable: false, reason: "The run only inspected the browser and did not perform a reusable task." };
+  const last = calls.at(-1);
+  if (last && last.score < 0) return { reusable: false, reason: "The browser workflow ended with a failed action." };
+  const successfulExtraction = calls.some((call) => ["extract", "paginate_extract"].includes(call.name) && call.score > 0);
+  const postingConfirmation = /\b(posted|published|submitted|saved draft|commented|sent successfully)\b|опубликован|отправлен|сохран[её]н\s+черновик/i.test(transcript);
+  const interaction = calls.some((call) => ["multi_action", "input", "click", "press", "upload"].includes(call.name));
+  const navigation = calls.some((call) => ["start", "prepare", "open", "navigate"].includes(call.name));
+  if (!successfulExtraction && !postingConfirmation && !(interaction && navigation)) {
+    return { reusable: false, reason: "No successful extraction, posting confirmation, or complete browser interaction was captured." };
+  }
+  return { reusable: true, reason: "The trace contains a completed, repeatable browser workflow." };
+}
+
 export function terminalBrowserTask(transcript: string): string {
   const lastTool = Math.max(
     transcript.lastIndexOf("clawbrowser."),

--- a/src/lib/workflowCapture.ts
+++ b/src/lib/workflowCapture.ts
@@ -4,6 +4,9 @@ const CLAWBROWSER_CALL = /clawbrowser\.([a-z_]+)/g;
 interface CapturedCall {
   name: string;
   args: Record<string, unknown>;
+  start: number;
+  end: number;
+  score: number;
 }
 
 function capturedCalls(transcript: string): CapturedCall[] {
@@ -34,25 +37,49 @@ function capturedCalls(transcript: string): CapturedCall[] {
     if (close < 0) continue;
     try {
       const args = JSON.parse(transcript.slice(open + 1, close)) as Record<string, unknown>;
-      calls.push({ name, args });
+      calls.push({ name, args, start: match.index ?? 0, end: close + 1, score: 0 });
     } catch {
       // Truncated calls still contribute their tool name to the generic workflow.
     }
   }
-  return calls;
+  return calls.map((call, index) => {
+    const result = transcript.slice(call.end, calls[index + 1]?.start ?? transcript.length);
+    let score = 0;
+    if (/\b(error|failed|failure)\b/i.test(result) || /"(?:count|executed)"\s*:\s*0\b/.test(result) || /"rows"\s*:\s*\[\s*\]/.test(result)) score -= 10;
+    if (/"ok"\s*:\s*true/.test(result) || /"count"\s*:\s*[1-9]\d*/.test(result) || /"rows"\s*:\s*\[\s*\{/.test(result) || /Наш[её]л|found\s+[1-9]/i.test(result)) score += 10;
+    return { ...call, score };
+  });
 }
 
 function pick(source: Record<string, unknown>, keys: string[]): Record<string, unknown> {
   return Object.fromEntries(keys.filter((key) => source[key] !== undefined).map((key) => [key, source[key]]));
 }
 
+function best(calls: CapturedCall[]): CapturedCall | undefined {
+  return calls.reduce<CapturedCall | undefined>((selected, call) =>
+    !selected || call.score >= selected.score ? call : selected, undefined);
+}
+
+function selectedFastPath(transcript: string): CapturedCall[] {
+  const calls = capturedCalls(transcript);
+  return [
+    best(calls.filter((call) => ["start", "prepare"].includes(call.name))),
+    best(calls.filter((call) => ["open", "navigate"].includes(call.name))),
+    best(calls.filter((call) => ["multi_action", "input", "click", "press"].includes(call.name))),
+    best(calls.filter((call) => ["paginate_extract", "extract"].includes(call.name))),
+  ].filter((call): call is CapturedCall => !!call && call.score >= 0);
+}
+
 function fastPath(transcript: string): string[] {
-  return capturedCalls(transcript).flatMap(({ name, args }) => {
+  return selectedFastPath(transcript).flatMap(({ name, args }) => {
     if (["start", "prepare"].includes(name)) {
       return [`clawbrowser.${name}(${JSON.stringify(pick(args, ["profile", "country", "url", "verify", "wait_for"]))})`];
     }
     if (name === "multi_action") {
       return [`clawbrowser.multi_action(${JSON.stringify(pick(args, ["actions", "stop_on_navigation", "wait_for", "state_mode"]))})`];
+    }
+    if (["open", "navigate"].includes(name)) {
+      return [`clawbrowser.${name}(${JSON.stringify(pick(args, ["url", "new_tab", "wait_for"]))})`];
     }
     if (["paginate_extract", "extract"].includes(name)) {
       return [`clawbrowser.${name}(${JSON.stringify(pick(args, ["container", "fields", "filters", "dedupe_by", "transform", "scroll", "max_pages", "limit", "initial_wait", "timeout"]))})`];
@@ -102,13 +129,24 @@ export function workflowInstructions(task: string, transcript: string): string {
   if (unique.some((tool) => ["multi_action", "input", "click", "press"].includes(tool))) {
     steps.push("Use the site's controls to apply the requested search and filters, waiting for navigation or page settlement when needed.");
   }
+  const selected = selectedFastPath(transcript);
+  const hasSearchAction = selected.some((call) => ["multi_action", "input", "click", "press"].includes(call.name));
+  const selectedURL = selected
+    .map((call) => typeof call.args.url === "string" ? call.args.url : "")
+    .find((url) => /[?&](?:q|query|search)=/i.test(url));
+  const searchTask = /\b(find|search)\b|найди|поиск/i.test(task);
+  if (searchTask && !hasSearchAction && !selectedURL) {
+    steps.push("Before extraction, apply the requested search on the site and wait until the results page is loaded; the recorded run started from browser state that was not fully self-contained.");
+  }
   if (unique.some((tool) => ["paginate_extract", "extract", "state"].includes(tool))) {
     steps.push("Extract all matching results, paginate or scroll as needed, deduplicate by canonical URL, and exclude irrelevant matches.");
   }
   steps.push("Return a concise result list with titles, URLs, and the important details requested by the user.");
   const calls = fastPath(transcript);
+  const hasElementHints = calls.some((call) => call.includes('"element_id"'));
+  const incomplete = searchTask && !hasSearchAction && !selectedURL;
   const technical = calls.length
-    ? `\n\nTechnical fast path:\nRun these operations in order. Reuse the saved arguments first; inspect the page and adapt only if an operation fails or the page structure changed.\n\n${calls.map((call, index) => `${index + 1}. ${call}`).join("\n")}\n\nTreat saved element_id values as short-lived hints. Resolve the element again by role, label, text, or selector if the id no longer matches.`
+    ? `\n\nTechnical fast path:\nRun these operations in order. Reuse the saved arguments first; inspect the page and adapt only if an operation fails or the page structure changed.\n\n${calls.map((call, index) => `${index + 1}. ${call}`).join("\n")}${incomplete ? "\n\nThis fast path is partial: reproduce the requested site search before running extraction." : ""}${hasElementHints ? "\n\nTreat saved element_id values as short-lived hints. Resolve the element again by role, label, text, or selector if the id no longer matches." : ""}`
     : "";
   return `Task pattern:\n${task || "Repeat the saved browser task on the selected website."}\n\nWorkflow:\n${steps.map((step, index) => `${index + 1}. ${step}`).join("\n")}${technical}`;
 }

--- a/src/lib/workflowDistillation.test.ts
+++ b/src/lib/workflowDistillation.test.ts
@@ -15,6 +15,14 @@ describe("workflow agent distillation", () => {
     expect(parseDistilledWorkflow(raw, fallback)?.title).toBe("Makler vehicle search");
   });
 
+  it("parses JSON surrounded by CLI output and permits generic endpoint guidance", () => {
+    const raw = `Codex CLI\n${JSON.stringify({
+      title: "Makler search", domain: "makler.md",
+      instructions: "Reuse the active endpoint only after proxy verification, then run clawbrowser.start({}) and clawbrowser.paginate_extract({}). " + "x".repeat(80),
+    })}\nDone`;
+    expect(parseDistilledWorkflow(raw, fallback)?.domain).toBe("makler.md");
+  });
+
   it("rejects invented tools, changed domains, and transient connection data", () => {
     expect(parseDistilledWorkflow(JSON.stringify({ title: "x", domain: "evil.test", instructions: "x".repeat(100) }), fallback)).toBeUndefined();
     expect(parseDistilledWorkflow(JSON.stringify({ title: "x", domain: "makler.md", instructions: `Use clawbrowser.delete_all({}). ${"x".repeat(100)}` }), fallback)).toBeUndefined();

--- a/src/lib/workflowDistillation.test.ts
+++ b/src/lib/workflowDistillation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { parseDistilledWorkflow, workflowDistillationPrompt } from "./workflowDistillation";
+
+const fallback = {
+  title: "makler.md — матизы", domain: "makler.md",
+  instructions: "Technical fast path: clawbrowser.start({}) then clawbrowser.paginate_extract({}). " + "x".repeat(100),
+};
+
+describe("workflow agent distillation", () => {
+  it("accepts a grounded structured skill", () => {
+    const raw = JSON.stringify({
+      title: "Makler vehicle search", domain: "makler.md",
+      instructions: "Prepare the proxy, apply the requested search, then run clawbrowser.start({}) and clawbrowser.paginate_extract({}) with the saved filters. " + "x".repeat(80),
+    });
+    expect(parseDistilledWorkflow(raw, fallback)?.title).toBe("Makler vehicle search");
+  });
+
+  it("rejects invented tools, changed domains, and transient connection data", () => {
+    expect(parseDistilledWorkflow(JSON.stringify({ title: "x", domain: "evil.test", instructions: "x".repeat(100) }), fallback)).toBeUndefined();
+    expect(parseDistilledWorkflow(JSON.stringify({ title: "x", domain: "makler.md", instructions: `Use clawbrowser.delete_all({}). ${"x".repeat(100)}` }), fallback)).toBeUndefined();
+    expect(parseDistilledWorkflow(JSON.stringify({ title: "x", domain: "makler.md", instructions: `endpoint http://127.0.0.1:1234 ${"x".repeat(100)}` }), fallback)).toBeUndefined();
+  });
+
+  it("forbids tool use in the authoring prompt", () => {
+    expect(workflowDistillationPrompt(fallback)).toContain("Do not call tools");
+  });
+});

--- a/src/lib/workflowDistillation.test.ts
+++ b/src/lib/workflowDistillation.test.ts
@@ -4,6 +4,7 @@ import { parseDistilledWorkflow, workflowDistillationPrompt } from "./workflowDi
 const fallback = {
   title: "makler.md — матизы", domain: "makler.md",
   instructions: "Technical fast path: clawbrowser.start({}) then clawbrowser.paginate_extract({}). " + "x".repeat(100),
+  reusable: true, reason: "Completed browser search",
 };
 
 describe("workflow agent distillation", () => {
@@ -11,6 +12,7 @@ describe("workflow agent distillation", () => {
     const raw = JSON.stringify({
       title: "Makler vehicle search", domain: "makler.md",
       instructions: "Prepare the proxy, apply the requested search, then run clawbrowser.start({}) and clawbrowser.paginate_extract({}) with the saved filters. " + "x".repeat(80),
+      reusable: true, reason: "Successful reusable extraction",
     });
     expect(parseDistilledWorkflow(raw, fallback)?.title).toBe("Makler vehicle search");
   });
@@ -19,14 +21,20 @@ describe("workflow agent distillation", () => {
     const raw = `Codex CLI\n${JSON.stringify({
       title: "Makler search", domain: "makler.md",
       instructions: "Reuse the active endpoint only after proxy verification, then run clawbrowser.start({}) and clawbrowser.paginate_extract({}). " + "x".repeat(80),
+      reusable: true, reason: "Successful reusable extraction",
     })}\nDone`;
     expect(parseDistilledWorkflow(raw, fallback)?.domain).toBe("makler.md");
   });
 
   it("rejects invented tools, changed domains, and transient connection data", () => {
-    expect(parseDistilledWorkflow(JSON.stringify({ title: "x", domain: "evil.test", instructions: "x".repeat(100) }), fallback)).toBeUndefined();
-    expect(parseDistilledWorkflow(JSON.stringify({ title: "x", domain: "makler.md", instructions: `Use clawbrowser.delete_all({}). ${"x".repeat(100)}` }), fallback)).toBeUndefined();
-    expect(parseDistilledWorkflow(JSON.stringify({ title: "x", domain: "makler.md", instructions: `endpoint http://127.0.0.1:1234 ${"x".repeat(100)}` }), fallback)).toBeUndefined();
+    expect(parseDistilledWorkflow(JSON.stringify({ title: "x", domain: "evil.test", instructions: "x".repeat(100), reusable: true, reason: "ok" }), fallback)).toBeUndefined();
+    expect(parseDistilledWorkflow(JSON.stringify({ title: "x", domain: "makler.md", instructions: `Use clawbrowser.delete_all({}). ${"x".repeat(100)}`, reusable: true, reason: "ok" }), fallback)).toBeUndefined();
+    expect(parseDistilledWorkflow(JSON.stringify({ title: "x", domain: "makler.md", instructions: `endpoint http://127.0.0.1:1234 ${"x".repeat(100)}`, reusable: true, reason: "ok" }), fallback)).toBeUndefined();
+  });
+
+  it("accepts the agent's decision that a trace is not reusable", () => {
+    const parsed = parseDistilledWorkflow(JSON.stringify({ reusable: false, reason: "The run ended before any results were extracted." }), fallback);
+    expect(parsed).toMatchObject({ reusable: false, reason: "The run ended before any results were extracted." });
   });
 
   it("forbids tool use in the authoring prompt", () => {

--- a/src/lib/workflowDistillation.ts
+++ b/src/lib/workflowDistillation.ts
@@ -2,13 +2,15 @@ export interface DistilledWorkflow {
   title: string;
   domain: string;
   instructions: string;
+  reusable: boolean;
+  reason: string;
 }
 
 export function workflowDistillationPrompt(input: DistilledWorkflow): string {
   return `You are converting an observed successful browser run into a reusable private skill.
 Do not call tools, browse, or inspect files. Use only the supplied cleaned trace.
 
-Return exactly one JSON object with string fields: title, domain, instructions.
+Return exactly one JSON object with fields: title, domain, instructions, reusable, reason.
 
 Rules:
 - Preserve the real domain and only browser tools/arguments present in the cleaned trace.
@@ -17,6 +19,8 @@ Rules:
 - Separate the proven fast path from fallback behavior.
 - Do not include results, IDs, endpoints, dashboard URLs, timestamps, tokens, or credentials.
 - Do not wrap JSON in markdown.
+- Set reusable to true only if the trace shows a completed, repeatable browser task with meaningful successful actions.
+- Set reusable to false for empty, failed, trivial, interrupted, or result-only traces. Explain why in reason.
 
 Current title: ${JSON.stringify(input.title)}
 Domain: ${JSON.stringify(input.domain)}
@@ -49,10 +53,13 @@ export function parseDistilledWorkflow(raw: string, fallback: DistilledWorkflow)
   const title = typeof record.title === "string" ? record.title.trim().slice(0, 64) : "";
   const domain = typeof record.domain === "string" ? record.domain.trim().toLowerCase() : "";
   const instructions = typeof record.instructions === "string" ? record.instructions.trim() : "";
-  if (!title || domain !== fallback.domain || instructions.length < 80 || instructions.length > 16_000) return undefined;
+  const reusable = typeof record.reusable === "boolean" ? record.reusable : undefined;
+  const reason = typeof record.reason === "string" ? record.reason.trim().slice(0, 240) : "";
+  if (reusable === false) return { ...fallback, reusable: false, reason: reason || "The browser workflow was not completed successfully." };
+  if (reusable !== true || !title || domain !== fallback.domain || instructions.length < 80 || instructions.length > 16_000) return undefined;
   if (/(?:dashboard_url\s*[:=]|rs_[a-z0-9]+|127\.0\.0\.1:\d+|localhost:\d+|api[_-]?key\s*[:=]|bearer\s+[a-z0-9._-]+)/i.test(instructions)) return undefined;
   const allowedTools = new Set([...fallback.instructions.matchAll(/clawbrowser\.([a-z_]+)/g)].map((match) => match[1]));
   const producedTools = [...instructions.matchAll(/clawbrowser\.([a-z_]+)/g)].map((match) => match[1]);
   if (producedTools.some((tool) => !allowedTools.has(tool))) return undefined;
-  return { title, domain, instructions };
+  return { title, domain, instructions, reusable: true, reason };
 }

--- a/src/lib/workflowDistillation.ts
+++ b/src/lib/workflowDistillation.ts
@@ -25,18 +25,32 @@ ${input.instructions}`;
 }
 
 export function parseDistilledWorkflow(raw: string, fallback: DistilledWorkflow): DistilledWorkflow | undefined {
-  const start = raw.indexOf("{");
-  const end = raw.lastIndexOf("}");
-  if (start < 0 || end <= start) return undefined;
   let value: unknown;
-  try { value = JSON.parse(raw.slice(start, end + 1)); } catch { return undefined; }
+  const starts = [...raw.matchAll(/\{/g)].map((match) => match.index ?? -1).filter((index) => index >= 0);
+  for (const start of starts) {
+    let depth = 0; let quoted = false; let escaped = false;
+    for (let index = start; index < raw.length; index += 1) {
+      const char = raw[index];
+      if (quoted) {
+        if (escaped) escaped = false;
+        else if (char === "\\") escaped = true;
+        else if (char === '"') quoted = false;
+      } else if (char === '"') quoted = true;
+      else if (char === "{") depth += 1;
+      else if (char === "}" && --depth === 0) {
+        try { value = JSON.parse(raw.slice(start, index + 1)); } catch { /* try the next object */ }
+        break;
+      }
+    }
+    if (value) break;
+  }
   if (!value || typeof value !== "object") return undefined;
   const record = value as Record<string, unknown>;
   const title = typeof record.title === "string" ? record.title.trim().slice(0, 64) : "";
   const domain = typeof record.domain === "string" ? record.domain.trim().toLowerCase() : "";
   const instructions = typeof record.instructions === "string" ? record.instructions.trim() : "";
   if (!title || domain !== fallback.domain || instructions.length < 80 || instructions.length > 16_000) return undefined;
-  if (/(?:dashboard_url|endpoint|rs_[a-z0-9]+|127\.0\.0\.1:\d+|localhost:\d+|api[_-]?key|bearer\s+)/i.test(instructions)) return undefined;
+  if (/(?:dashboard_url\s*[:=]|rs_[a-z0-9]+|127\.0\.0\.1:\d+|localhost:\d+|api[_-]?key\s*[:=]|bearer\s+[a-z0-9._-]+)/i.test(instructions)) return undefined;
   const allowedTools = new Set([...fallback.instructions.matchAll(/clawbrowser\.([a-z_]+)/g)].map((match) => match[1]));
   const producedTools = [...instructions.matchAll(/clawbrowser\.([a-z_]+)/g)].map((match) => match[1]);
   if (producedTools.some((tool) => !allowedTools.has(tool))) return undefined;

--- a/src/lib/workflowDistillation.ts
+++ b/src/lib/workflowDistillation.ts
@@ -1,0 +1,44 @@
+export interface DistilledWorkflow {
+  title: string;
+  domain: string;
+  instructions: string;
+}
+
+export function workflowDistillationPrompt(input: DistilledWorkflow): string {
+  return `You are converting an observed successful browser run into a reusable private skill.
+Do not call tools, browse, or inspect files. Use only the supplied cleaned trace.
+
+Return exactly one JSON object with string fields: title, domain, instructions.
+
+Rules:
+- Preserve the real domain and only browser tools/arguments present in the cleaned trace.
+- Keep the workflow self-contained from proxy/session preparation through final results.
+- Parameterize user-specific search values when useful, while retaining their current defaults.
+- Separate the proven fast path from fallback behavior.
+- Do not include results, IDs, endpoints, dashboard URLs, timestamps, tokens, or credentials.
+- Do not wrap JSON in markdown.
+
+Current title: ${JSON.stringify(input.title)}
+Domain: ${JSON.stringify(input.domain)}
+Cleaned trace and deterministic fallback:
+${input.instructions}`;
+}
+
+export function parseDistilledWorkflow(raw: string, fallback: DistilledWorkflow): DistilledWorkflow | undefined {
+  const start = raw.indexOf("{");
+  const end = raw.lastIndexOf("}");
+  if (start < 0 || end <= start) return undefined;
+  let value: unknown;
+  try { value = JSON.parse(raw.slice(start, end + 1)); } catch { return undefined; }
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  const title = typeof record.title === "string" ? record.title.trim().slice(0, 64) : "";
+  const domain = typeof record.domain === "string" ? record.domain.trim().toLowerCase() : "";
+  const instructions = typeof record.instructions === "string" ? record.instructions.trim() : "";
+  if (!title || domain !== fallback.domain || instructions.length < 80 || instructions.length > 16_000) return undefined;
+  if (/(?:dashboard_url|endpoint|rs_[a-z0-9]+|127\.0\.0\.1:\d+|localhost:\d+|api[_-]?key|bearer\s+)/i.test(instructions)) return undefined;
+  const allowedTools = new Set([...fallback.instructions.matchAll(/clawbrowser\.([a-z_]+)/g)].map((match) => match[1]));
+  const producedTools = [...instructions.matchAll(/clawbrowser\.([a-z_]+)/g)].map((match) => match[1]);
+  if (producedTools.some((tool) => !allowedTools.has(tool))) return undefined;
+  return { title, domain, instructions };
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -444,7 +444,7 @@ interface State {
   runCustomScript: (script: CustomScript) => Promise<void>;
   saveLocalSkill: (skill: BrowserWorkflowSkill) => Promise<void>;
   deleteLocalSkill: (id: string) => void;
-  runLocalSkill: (skill: BrowserWorkflowSkill) => Promise<void>;
+  runLocalSkill: (skill: BrowserWorkflowSkill, task?: string) => Promise<void>;
 
   // Internal queue/runtime helpers
   reconcileQueues: () => void;
@@ -3372,16 +3372,45 @@ export const useStore = create<State>((set, get) => {
     void invoke("delete_local_skill", { slug: `workflow-${id.slice(0, 8)}` });
   },
 
-  runLocalSkill: async (skill) => {
+  runLocalSkill: async (skill, taskOverride) => {
     if (!get().agentReady()) return;
+    const task = taskOverride?.trim() || skill.task.trim();
+    if (!task) return;
     set({ tab: "chat" });
     const cid = get().activeConversation()?.id ?? get().newChat();
+    const remoteOnly = get().conversations.find((conversation) => conversation.id === cid)?.executionTarget === "vps";
     const target = skill.domain || "the active website";
+    const chip: UserCommandChip = { kind: "skill", title: skill.title, detail: skill.domain || "Local skill" };
+    if (remoteOnly) {
+      get().enqueue(
+        `Use my local browser skill "${skill.title}" for ${target} on the selected VPS only. Do not prepare or change any local NextBrowser session.\n\nTask for this run:\n${task}\n\nWorkflow instructions:\n${skill.instructions}`,
+        chip, cid,
+      );
+      return;
+    }
+    const stepId = get().makeStepMessage(cid);
+    let prep;
+    try {
+      prep = await prepareLocalSession({
+        host: skill.domain || undefined,
+        selectedProfile: get().selectedProfile,
+        statuses: get().statuses,
+        defaultSession: get().defaultSession,
+        onStep: (step) => get().appendStep(cid, stepId, step),
+      });
+    } catch (error) {
+      get().failStep(cid, stepId, error);
+      trackEvent("session_preflight_failed", { source: "local_skill" });
+      return;
+    }
+    if (!get().agentReady()) return;
+    const note = pageReadyNote(prep.host, prep.directFallback);
     get().enqueue(
-      `Use my local browser skill "${skill.title}" for ${target}. Reuse this proven workflow, adapting selectors only when the page changed.\n\nOriginal task:\n${skill.task}\n\nWorkflow instructions:\n${skill.instructions}\n\nObserved browser actions:\n${skill.actions.map((action, index) => `${index + 1}. ${action}`).join("\n") || "No recorded action trace; follow the workflow instructions."}`,
-      { kind: "skill", title: skill.title, detail: skill.domain || "Local skill" },
+      `Use my local browser skill "${skill.title}" for ${target} in the active verified NextBrowser session.${note}\nThe app already prepared the session, verified the selected proxy, and opened the website. Do not run saved start/prepare operations again. Begin with the first task-specific action. Reuse the proven fast path, adapting selectors only if the page changed.\n\nTask for this run:\n${task}\n\nWorkflow instructions:\n${skill.instructions}\n\nObserved browser actions (reference only):\n${skill.actions.map((action, index) => `${index + 1}. ${action}`).join("\n") || "No recorded action trace; follow the workflow instructions."}`,
+      chip,
       cid,
     );
+    trackEvent("local_skill_run_queued", { has_domain: !!skill.domain, customized_task: task !== skill.task.trim() });
   },
 
   startRemoteStream: async (profile) => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -2147,6 +2147,7 @@ button, input, textarea, select { color: var(--text); }
 .workflow-save-modal { width: min(560px, calc(100vw - 48px)); }
 .workflow-save-modal .field-label { display: block; margin: 10px 0 5px; color: var(--muted); font-size: 12px; }
 .workflow-save-modal textarea { width: 100%; resize: vertical; }
+.workflow-author-status { display: flex; align-items: center; gap: 7px; min-height: 20px; margin: 8px 0 2px; }
 .msg-assistant-wrap { display: flex; flex-direction: column; align-items: flex-start; }
 .assistant-bubble {
   max-width: 85%;

--- a/src/styles.css
+++ b/src/styles.css
@@ -2145,6 +2145,7 @@ button, input, textarea, select { color: var(--text); }
 }
 .save-workflow-btn:hover { color: var(--text); }
 .workflow-save-modal { width: min(560px, calc(100vw - 48px)); }
+.workflow-quality-modal { width: min(430px, calc(100vw - 48px)); }
 .workflow-save-modal .field-label { display: block; margin: 10px 0 5px; color: var(--muted); font-size: 12px; }
 .workflow-save-modal textarea { width: 100%; resize: vertical; }
 .workflow-author-status { display: flex; align-items: center; gap: 7px; min-height: 20px; margin: 8px 0 2px; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -2146,6 +2146,9 @@ button, input, textarea, select { color: var(--text); }
 .save-workflow-btn:hover { color: var(--text); }
 .workflow-save-modal { width: min(560px, calc(100vw - 48px)); }
 .workflow-quality-modal { width: min(430px, calc(100vw - 48px)); }
+.skill-run-modal { width: min(520px, calc(100vw - 48px)); }
+.skill-run-modal .field-label { display: block; margin: 10px 0 5px; color: var(--muted); font-size: 12px; }
+.skill-run-modal textarea { width: 100%; resize: vertical; }
 .workflow-save-modal .field-label { display: block; margin: 10px 0 5px; color: var(--muted); font-size: 12px; }
 .workflow-save-modal textarea { width: 100%; resize: vertical; }
 .workflow-author-status { display: flex; align-items: center; gap: 7px; min-height: 20px; margin: 8px 0 2px; }


### PR DESCRIPTION
## Summary
- rename the action to Save as skill and preserve terminal PTY state across tabs
- capture and score real browser operations, keeping only successful reusable fast-path steps
- ask the selected agent in an isolated no-browser one-shot process to turn the cleaned trace into a semantic reusable skill
- validate agent JSON against the observed domain/tool allowlist and reject transient IDs, endpoints, or credentials
- fall back to deterministic skill generation on invalid output, failure, or timeout

## Verification
- regression tests cover makler.md transcript parsing, redundant/failed extraction removal, and agent-output validation
- npm test -- --run (171 tests)
- npm run build
- git diff --check