### PR TITLE
ci: notify Slack about GitHub issues

### DIFF
--- a/.github/workflows/slack-issue-notifications.yml
+++ b/.github/workflows/slack-issue-notifications.yml
@@ -1,0 +1,110 @@
+name: Notify Slack about GitHub issues
+
+on:
+  issues:
+    types: [opened, closed]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  notify:
+    # issue_comment also fires for pull requests; keep this workflow issue-only.
+    if: ${{ github.event_name == 'issues' || !github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send notification to Slack
+        uses: actions/github-script@v8
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+        with:
+          script: |
+            const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+
+            const { issue, repository, sender } = context.payload;
+            const isClosed = context.eventName === "issues" && context.payload.action === "closed";
+            const isComment = context.eventName === "issue_comment";
+            const actor = sender?.login ?? "GitHub user";
+            const issueUrl = issue.html_url;
+            const repositoryUrl = `https://github.com/${repository.full_name}`;
+
+            const escapeSlack = (value) => String(value ?? "")
+              .replaceAll("&", "&amp;")
+              .replaceAll("<", "&lt;")
+              .replaceAll(">", "&gt;");
+
+            const commentBody = isComment
+              ? escapeSlack(context.payload.comment?.body?.trim()).slice(0, 700)
+              : "";
+
+            async function slackApi(method, body) {
+              const response = await fetch(`https://slack.com/api/${method}`, {
+                method: "POST",
+                headers: {
+                  authorization: `Bearer ${process.env.SLACK_BOT_TOKEN}`,
+                  "content-type": "application/json; charset=utf-8",
+                },
+                body: JSON.stringify(body),
+              });
+              const result = await response.json();
+              if (!response.ok || !result.ok) {
+                throw new Error(`Slack ${method} failed: ${response.status} ${JSON.stringify(result)}`);
+              }
+              return result;
+            }
+
+            if (isClosed) {
+              if (!process.env.SLACK_BOT_TOKEN || !process.env.SLACK_CHANNEL_ID) {
+                core.setFailed("Missing repository secrets: SLACK_BOT_TOKEN and SLACK_CHANNEL_ID");
+                return;
+              }
+
+              let cursor;
+              let threadTs;
+              do {
+                const history = await slackApi("conversations.history", {
+                  channel: process.env.SLACK_CHANNEL_ID,
+                  limit: 200,
+                  ...(cursor ? { cursor } : {}),
+                });
+                const root = history.messages?.find((message) => message.text?.includes(issueUrl));
+                if (root) threadTs = root.thread_ts ?? root.ts;
+                cursor = history.response_metadata?.next_cursor || undefined;
+              } while (!threadTs && cursor);
+
+              if (!threadTs) {
+                core.setFailed(`Could not find the Slack root message for issue #${issue.number}`);
+                return;
+              }
+
+              await slackApi("chat.postMessage", {
+                channel: process.env.SLACK_CHANNEL_ID,
+                thread_ts: threadTs,
+                text: `Issue #${issue.number} closed`,
+              });
+              return;
+            }
+
+            const message = isComment
+              ? `*New Comment:* <${issueUrl}|${escapeSlack(issue.title)}>\n\n*${escapeSlack(actor)}* in <${repositoryUrl}|${escapeSlack(repository.full_name)}>\n\n${commentBody}`
+              : `*New Issue:* <${issueUrl}|${escapeSlack(issue.title)}>\n\n*${escapeSlack(actor)}* in <${repositoryUrl}|${escapeSlack(repository.full_name)}>`;
+
+            if (!webhookUrl) {
+              core.setFailed("Missing repository secret: SLACK_WEBHOOK_URL");
+              return;
+            }
+
+            const response = await fetch(webhookUrl, {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ text: message }),
+            });
+
+            if (!response.ok) {
+              throw new Error(`Slack webhook failed: ${response.status} ${await response.text()}`);
+            }


### PR DESCRIPTION
Add the same compact Slack issue notification flow used by clawbrowser/clawbrowser.

Notifications:
- New issue: compact two-paragraph message with issue and repository links.
- New issue comment: same format with comment body.
- Closed issue: `Issue #N closed` posted in the original Slack thread.

The repository name is taken from the GitHub event payload, so this will identify `nextbrowser-oss/nextbrowser-app` automatically.

Required repository secrets, using the same values as clawbrowser/clawbrowser:
- `SLACK_WEBHOOK_URL`
- `SLACK_BOT_TOKEN`
- `SLACK_CHANNEL_ID`