### PR TITLE
fix: make cjs path tests OS-agnostic so Windows CI passes

### DIFF
--- a/electron/binary-resolver.test.cjs
+++ b/electron/binary-resolver.test.cjs
@@ -70,5 +70,5 @@ test("reports whether a binary can be launched", (t) => {
 });
 
 test("expands a home-relative binary override", () => {
-  assert.equal(expand("~/bin/nbc", "/tmp/demo-home"), "/tmp/demo-home/bin/nbc");
+  assert.equal(expand("~/bin/nbc", "/tmp/demo-home"), path.join("/tmp/demo-home", "bin/nbc"));
 });

--- a/electron/runtime-config.test.cjs
+++ b/electron/runtime-config.test.cjs
@@ -14,9 +14,12 @@ const {
 const homeDir = "/home/u";
 const runtimeRoot = "/data/NextBrowser/runtime";
 const isolatedConfig = path.join(runtimeRoot, "config", "config.json");
-const legacyConfig = "/home/u/.config/clawbrowser/config.json";
-const legacyProfiles = "/home/u/.local/state/clawbrowser/profiles";
-const legacyProxies = "/home/u/.local/state/clawbrowser/profile-proxies";
+// Build legacy paths through the module's own resolvers so expectations match
+// the code's path.join output on every OS (Windows uses backslashes).
+const legacyConfig = legacyConfigPath({ homeDir, platform: "linux", env: {} });
+const legacyStateDir = legacyStateRoot({ homeDir, env: {} });
+const legacyProfiles = path.join(legacyStateDir, "profiles");
+const legacyProxies = path.join(legacyStateDir, "profile-proxies");
 
 function plan(files) {
   return planRuntimeMigration({
@@ -101,7 +104,10 @@ test("applies the migration against a real filesystem, then is a no-op", async (
   );
   assert.ok(fsSync.existsSync(path.join(runtimeRoot, "profiles", "profiles", "work.json")));
   assert.ok(fsSync.existsSync(path.join(runtimeRoot, "profiles", "profile-proxies", "work.json")));
-  assert.equal((await fs.stat(migratedConfig)).mode & 0o777, 0o600);
+  if (process.platform !== "win32") {
+    // Windows does not honor POSIX permission bits.
+    assert.equal((await fs.stat(migratedConfig)).mode & 0o777, 0o600);
+  }
 
   // Second run: isolated config now exists -> nothing to do.
   const second = await applyLegacyRuntimeMigration(opts);
@@ -109,11 +115,11 @@ test("applies the migration against a real filesystem, then is a no-op", async (
 });
 
 test("legacyConfigPath and legacyStateRoot match nbc defaults", () => {
-  assert.equal(legacyConfigPath({ homeDir, platform: "linux", env: {} }), legacyConfig);
+  assert.equal(legacyConfigPath({ homeDir, platform: "linux", env: {} }), path.join(homeDir, ".config", "clawbrowser", "config.json"));
   assert.equal(
     legacyConfigPath({ homeDir: "C:\\Users\\u", platform: "win32", env: { LOCALAPPDATA: "C:\\Users\\u\\AppData\\Local" } }),
     path.join("C:\\Users\\u\\AppData\\Local", "Clawbrowser", "config.json"),
   );
-  assert.equal(legacyStateRoot({ homeDir, env: {} }), "/home/u/.local/state/clawbrowser");
-  assert.equal(legacyStateRoot({ homeDir, env: { XDG_STATE_HOME: "/xdg/state" } }), "/xdg/state/clawbrowser");
+  assert.equal(legacyStateRoot({ homeDir, env: {} }), path.join(homeDir, ".local", "state", "clawbrowser"));
+  assert.equal(legacyStateRoot({ homeDir, env: { XDG_STATE_HOME: "/xdg/state" } }), path.join("/xdg/state", "clawbrowser"));
 });


### PR DESCRIPTION
## Problem
`main` CI (`Run npm test`) fails on **windows-latest** (macOS passes). Six assertions in the `node:test` suites hardcoded POSIX forward-slash path literals as expected values, while the code builds paths with `path.join` — which emits backslashes on Windows.

Failing tests:
- `binary-resolver.test.cjs` — expands a home-relative binary override
- `runtime-config.test.cjs` — migrates config + profile metadata; migrates only the config; never overwrites an already-migrated profile dir; applies against a real filesystem; legacyConfigPath/legacyStateRoot match nbc defaults

## Fix (tests only — app code unchanged)
- Build legacy/expected paths through `path.join` and the module's own `legacyConfigPath`/`legacyStateRoot` resolvers, so expectations match the code's output on every OS.
- Guard the POSIX `0o600` mode assertion behind a non-`win32` check (Windows doesn't honor POSIX permission bits).

Verified: `npm test` green locally (179 tests); the two fixed files pass 14/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)