### PR TITLE
Fix Terminal Chat MCP startup on macOS

### DIFF
--- a/electron/agent-workspace.test.cjs
+++ b/electron/agent-workspace.test.cjs
@@ -30,11 +30,14 @@ test("terminal Codex keeps workspace isolation while allowing Clawbrowser networ
   assert.match(main, /const nextctlBin = await resolveOrInstallNextctl\(\)/);
   assert.match(main, /mcp_servers\.clawbrowser\.command=/);
   assert.match(main, /mcp_servers\.clawbrowser\.args=/);
+  assert.match(main, /mcp_servers\.clawbrowser\.env=/);
+  assert.match(main, /plugins\."clawbrowser@clawctl-local"\.mcp_servers\.clawbrowser\.enabled=false/);
   assert.match(main, /mcp_servers\.clawbrowser\.default_tools_approval_mode=approve/);
   assert.match(main, /"--add-dir", dir/);
   assert.match(main, /\.cache", "clawbrowser"/);
   assert.match(main, /\.local", "share", "clawbrowser"/);
   assert.match(main, /\.local", "state", "clawbrowser"/);
+  assert.match(main, /path\.join\(home\(\), "\.nextbrowser", "runtime"\)/);
   assert.doesNotMatch(main, /dangerously-bypass-approvals-and-sandbox/);
 });
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -15,7 +15,7 @@ const {
   resolveBinary,
   searchDirs,
 } = require("./binary-resolver.cjs");
-const { applyLegacyRuntimeMigration, clearRuntimeCredential } = require("./runtime-config.cjs");
+const { applyLegacyRuntimeMigration, applyRuntimeRootMigration, clearRuntimeCredential } = require("./runtime-config.cjs");
 const { fetchGitHubStars } = require("./github-stars.cjs");
 const { ensureWorkspaceInstructions } = require("./workspace-instructions.cjs");
 const pty = require("node-pty");
@@ -47,17 +47,31 @@ const CODEX_TERMINAL_PROFILE_CONTENT = `[plugins."browser@openai-bundled"]
 enabled = false
 
 [plugins."clawbrowser@clawctl-local".mcp_servers.clawbrowser]
+enabled = false
 default_tools_approval_mode = "approve"
 `;
 
 function codexClawbrowserArgs(nextctlBin) {
+  const runtimeEnv = childEnv();
+  const mcpEnvKeys = [
+    "NEXTBROWSER_CONFIG_DIR",
+    "CLAWBROWSER_CACHE_DIR",
+    "CLAWBROWSER_DATA_DIR",
+    "CLAWBROWSER_STATE_ROOT",
+    "CLAWBROWSER_SESSION_ROOT",
+    "NBC_PROFILE_ROOT",
+    "CLAWBROWSER_API_BASE_URL",
+  ];
+  const mcpEnv = `{${mcpEnvKeys.map((key) => `${key}=${JSON.stringify(runtimeEnv[key])}`).join(",")}}`;
   return [
     "--profile", CODEX_TERMINAL_PROFILE,
     "--ask-for-approval", "never",
     "--sandbox", "workspace-write",
     "-c", "sandbox_workspace_write.network_access=true",
+    "-c", 'plugins."clawbrowser@clawctl-local".mcp_servers.clawbrowser.enabled=false',
     "-c", `mcp_servers.clawbrowser.command=${JSON.stringify(nextctlBin)}`,
     "-c", `mcp_servers.clawbrowser.args=${JSON.stringify(["mcp"])}`,
+    "-c", `mcp_servers.clawbrowser.env=${mcpEnv}`,
     "-c", "mcp_servers.clawbrowser.startup_timeout_sec=30",
     "-c", "mcp_servers.clawbrowser.default_tools_approval_mode=approve",
   ];
@@ -79,6 +93,7 @@ function clawbrowserWritableDirs() {
     return [path.join(localAppData, "Clawbrowser")];
   }
   return [
+    nextbrowserRuntimeRoot(),
     path.join(home(), ".cache", "clawbrowser"),
     path.join(home(), ".config", "clawbrowser"),
     path.join(home(), ".local", "share", "clawbrowser"),
@@ -123,7 +138,12 @@ const TERMINAL_AGENTS = {
 };
 
 function home() { return os.homedir(); }
-function nextbrowserRuntimeRoot() { return path.join(app.getPath("userData"), "runtime"); }
+function legacyAppRuntimeRoot() { return path.join(app.getPath("userData"), "runtime"); }
+function nextbrowserRuntimeRoot() {
+  return process.platform === "darwin"
+    ? path.join(home(), ".nextbrowser", "runtime")
+    : legacyAppRuntimeRoot();
+}
 function childEnv(extra = {}) {
   const runtimeRoot = nextbrowserRuntimeRoot();
   return {
@@ -168,8 +188,11 @@ function setNextctlInstallStatus(status, patch = {}) {
   nextctlInstallStatus = { status, ...patch, updatedAt: Date.now() };
   emit("nextctl:install", nextctlInstallStatus);
 }
+function legacyManagedNextctlRoot() { return path.join(app.getPath("userData"), "managed-nextctl"); }
 function managedNextctlRoot() {
-  return path.join(app.getPath("userData"), "managed-nextctl");
+  return process.platform === "darwin"
+    ? path.join(home(), ".nextbrowser", "managed-nextctl")
+    : legacyManagedNextctlRoot();
 }
 function managedNextctlBin() {
   return process.platform === "win32"
@@ -282,6 +305,14 @@ async function migrateLegacyData() {
 // users keep their session (proxy stays on) and see all their profiles without
 // signing in again. Best-effort and idempotent; see runtime-config.cjs.
 async function migrateLegacyRuntimeConfig() {
+  await applyRuntimeRootMigration({
+    fromRoot: legacyAppRuntimeRoot(),
+    toRoot: nextbrowserRuntimeRoot(),
+  });
+  await applyRuntimeRootMigration({
+    fromRoot: legacyManagedNextctlRoot(),
+    toRoot: managedNextctlRoot(),
+  });
   await applyLegacyRuntimeMigration({ runtimeRoot: nextbrowserRuntimeRoot() });
 }
 function safeName(name) {

--- a/electron/runtime-config.cjs
+++ b/electron/runtime-config.cjs
@@ -103,6 +103,22 @@ async function applyLegacyRuntimeMigration({
   return steps;
 }
 
+// macOS treats ~/Library/Application Support as a protected location for
+// sandboxed terminal agents. Move the app-owned runtime to ~/.nextbrowser and
+// seed it once from the former userData/runtime directory. Copying (rather than
+// renaming) keeps rollback to an older app build possible.
+async function applyRuntimeRootMigration({ fromRoot, toRoot } = {}) {
+  if (!fromRoot || !toRoot || path.resolve(fromRoot) === path.resolve(toRoot)) return false;
+  if (!fsSync.existsSync(fromRoot) || fsSync.existsSync(toRoot)) return false;
+  try {
+    await fs.mkdir(path.dirname(toRoot), { recursive: true, mode: 0o700 });
+    await fs.cp(fromRoot, toRoot, { recursive: true, force: false, errorOnExist: false });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 async function clearRuntimeCredential({ runtimeRoot }) {
   const configDir = path.join(runtimeRoot, "config");
   const configPath = path.join(configDir, "config.json");
@@ -128,5 +144,6 @@ module.exports = {
   legacyStateRoot,
   planRuntimeMigration,
   applyLegacyRuntimeMigration,
+  applyRuntimeRootMigration,
   clearRuntimeCredential,
 };

--- a/electron/runtime-config.test.cjs
+++ b/electron/runtime-config.test.cjs
@@ -9,6 +9,7 @@ const {
   legacyStateRoot,
   planRuntimeMigration,
   applyLegacyRuntimeMigration,
+  applyRuntimeRootMigration,
   clearRuntimeCredential,
 } = require("./runtime-config.cjs");
 
@@ -161,4 +162,17 @@ test("clearRuntimeCredential rejects malformed config without overwriting it", a
 
   await assert.rejects(clearRuntimeCredential({ runtimeRoot: root }), SyntaxError);
   assert.equal(await fs.readFile(configPath, "utf8"), "{broken");
+});
+
+test("copies an existing app runtime to a terminal-safe root once", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "nb-runtime-root-"));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  const fromRoot = path.join(root, "Library", "Application Support", "nextbrowser", "runtime");
+  const toRoot = path.join(root, ".nextbrowser", "runtime");
+  await fs.mkdir(path.join(fromRoot, "state"), { recursive: true });
+  await fs.writeFile(path.join(fromRoot, "state", "session.json"), "{}");
+
+  assert.equal(await applyRuntimeRootMigration({ fromRoot, toRoot }), true);
+  assert.equal(await fs.readFile(path.join(toRoot, "state", "session.json"), "utf8"), "{}");
+  assert.equal(await applyRuntimeRootMigration({ fromRoot, toRoot }), false);
 });


### PR DESCRIPTION
## Summary
- move the macOS agent runtime and managed nextctl out of protected Application Support
- migrate existing runtime state without deleting the old copy
- pass the isolated NextBrowser runtime environment explicitly to the Codex MCP process
- disable the duplicate plugin-provided MCP while keeping the Clawbrowser plugin skills enabled

## Root cause
Codex strips inherited environment variables from MCP children. The direct Clawbrowser MCP therefore started without the app's config/state paths, while the plugin also registered a second MCP. macOS then denied sandbox access to the fallback Application Support state directory and the server closed before initialize.

## Verification
- production build passes
- 183 frontend tests and 49 Node tests pass
- node-pty smoke test passes on macOS
- real Codex -> nextctl MCP initialization completes without startup warnings