### PR TITLE
Save and reuse structured private browser skills

### DIFF
--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -22,6 +22,8 @@ import {
   workflowInstructions,
   workflowQuality,
   workflowTitle,
+  workflowCapability,
+  workflowRecipe,
 } from "../lib/workflowCapture";
 import {
   parseDistilledWorkflow,
@@ -253,6 +255,10 @@ export function ChatView() {
       title: workflowTitle(task, domain), domain,
       instructions: workflowInstructions(task, evidence),
       ...quality,
+      capability: workflowCapability(task, evidence),
+      parametersSchema: { type: "object", properties: { task: { type: "string", default: task } } },
+      outputSchema: { type: "object", properties: { success: { type: "boolean" }, results: { type: "array" } } },
+      recipe: workflowRecipe(task, evidence),
     };
     const authored = quality.reusable && ready ? await authorWorkflowWithAgent(agentSpec, s.workingDir, fallback) : undefined;
     const prepared = authored ?? fallback;
@@ -785,7 +791,11 @@ export function ChatView() {
           onSave={(title, domain, instructions) => {
             void s.saveLocalSkill({
               id: uid(), title, domain, task: workflowDraft.task, instructions,
-              actions: (workflowDraft.answer.toolEvents ?? []).map((event) => event.detail ?? event.name),
+              actions: workflowDraft.prepared.recipe.actions,
+              capability: workflowDraft.prepared.capability,
+              parametersSchema: workflowDraft.prepared.parametersSchema,
+              outputSchema: workflowDraft.prepared.outputSchema,
+              recipe: workflowDraft.prepared.recipe,
               createdAt: Date.now(), updatedAt: Date.now(),
             });
             setWorkflowDraft(null);

--- a/src/lib/persistence.test.ts
+++ b/src/lib/persistence.test.ts
@@ -87,7 +87,7 @@ describe("Swift-compatible persistence", () => {
     } as never);
     expect(normalized.createdAt).toBe(Date.parse("2026-08-04T10:00:00Z"));
     expect(serializeWorkflowSkills([normalized])[0]).toMatchObject({
-      domain: "999.md", actions: ["navigate", "extract"], createdAt: "2026-08-04T10:00:00Z",
+      domain: "999.md", actions: [{ tool: "navigate", arguments: {} }, { tool: "extract", arguments: {} }], createdAt: "2026-08-04T10:00:00Z",
     });
   });
 });

--- a/src/lib/persistence.ts
+++ b/src/lib/persistence.ts
@@ -128,8 +128,24 @@ export function serializeScripts(scripts: CustomScript[]) {
 }
 
 export function normalizeWorkflowSkill(skill: BrowserWorkflowSkill): BrowserWorkflowSkill {
+  const legacyActions: unknown[] = Array.isArray(skill.actions) ? skill.actions : [];
+  const actions = legacyActions.flatMap((action) => {
+    if (action && typeof action === "object" && "tool" in action && typeof action.tool === "string") {
+      const args = "arguments" in action && action.arguments && typeof action.arguments === "object" ? action.arguments as Record<string, unknown> : {};
+      return [{ tool: action.tool, arguments: args }];
+    }
+    if (typeof action !== "string") return [];
+    const match = action.match(/(?:clawbrowser\.)?([a-z_]+)\((\{.*\})\)/s);
+    try { return match ? [{ tool: match[1], arguments: JSON.parse(match[2]) as Record<string, unknown> }] : [{ tool: action.replace(/^clawbrowser\./, ""), arguments: {} }]; } catch { return []; }
+  });
+  const capability = skill.capability ?? "other";
   return {
     ...skill,
+    actions,
+    capability,
+    parametersSchema: skill.parametersSchema ?? { type: "object", properties: {} },
+    outputSchema: skill.outputSchema ?? { type: "object", properties: {} },
+    recipe: skill.recipe ?? { version: 1, capability, actions },
     createdAt: parseMillis(skill.createdAt),
     updatedAt: parseMillis(skill.updatedAt),
     submittedAt: skill.submittedAt == null ? undefined : parseMillis(skill.submittedAt),

--- a/src/lib/workflowCapture.test.ts
+++ b/src/lib/workflowCapture.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { capturedWorkflowDomain, terminalBrowserTask, workflowDomain, workflowInstructions, workflowQuality, workflowTitle } from "./workflowCapture";
+import { capturedWorkflowDomain, terminalBrowserTask, workflowDomain, workflowInstructions, workflowQuality, workflowRecipe, workflowTitle } from "./workflowCapture";
 
 const transcript = `
 │ model:     gpt-5.6-sol low   /model to change │
@@ -39,13 +39,19 @@ describe("terminal workflow capture", () => {
     const task = terminalBrowserTask(transcript);
     expect(workflowTitle(task, "makler.md")).toBe("makler.md — матизы");
     const instructions = workflowInstructions(task, transcript);
-    expect(instructions).toContain("verify the requested proxy country");
     expect(instructions).toContain("deduplicate by canonical URL");
-    expect(instructions).toContain('clawbrowser.start({"profile":"us-makler-md","country":"US","url":"https://makler.md"})');
+    expect(instructions).not.toContain("clawbrowser.start");
     expect(instructions).toContain('"element_id":6');
     expect(instructions).toContain('"dedupe_by":["url"]');
     expect(instructions).not.toContain("return_state");
     expect(instructions).not.toContain("gpt-5.6-sol");
+  });
+
+  it("stores task actions but leaves session lifecycle to the app", () => {
+    const recipe = workflowRecipe(terminalBrowserTask(transcript), transcript);
+    expect(recipe.capability).toBe("search");
+    expect(recipe.actions.map((action) => action.tool)).toEqual(["multi_action", "paginate_extract"]);
+    expect(recipe.actions.some((action) => ["start", "prepare"].includes(action.tool))).toBe(false);
   });
 
   it("keeps one successful extraction and marks a non-self-contained search", () => {

--- a/src/lib/workflowCapture.ts
+++ b/src/lib/workflowCapture.ts
@@ -1,7 +1,7 @@
 const PROMPT_MARKER = /^\s*›\s*(.+)$/gm;
 const CLAWBROWSER_CALL = /clawbrowser\.([a-z_]+)/g;
 
-interface CapturedCall {
+export interface CapturedCall {
   name: string;
   args: Record<string, unknown>;
   start: number;
@@ -51,6 +51,25 @@ function capturedCalls(transcript: string): CapturedCall[] {
   });
 }
 
+export type WorkflowCapability = "scrape" | "search" | "posting" | "form" | "navigation" | "other";
+
+export function workflowCapability(task: string, transcript: string): WorkflowCapability {
+  const tools = capturedCalls(transcript).map((call) => call.name);
+  if (/\b(post|publish|comment|reply|send)\b|опубли|отправ|коммент/i.test(task)) return "posting";
+  if (tools.some((tool) => ["paginate_extract", "extract"].includes(tool))) return /\b(find|search)\b|найди|поиск/i.test(task) ? "search" : "scrape";
+  if (tools.some((tool) => ["input", "upload"].includes(tool))) return "form";
+  if (tools.some((tool) => ["open", "navigate", "click", "press"].includes(tool))) return "navigation";
+  return "other";
+}
+
+export function workflowRecipe(task: string, transcript: string) {
+  const capability = workflowCapability(task, transcript);
+  const actions = selectedFastPath(transcript)
+    .filter(({ name }) => !["start", "prepare"].includes(name))
+    .map(({ name, args }) => ({ tool: name, arguments: args }));
+  return { version: 1 as const, capability, actions };
+}
+
 function pick(source: Record<string, unknown>, keys: string[]): Record<string, unknown> {
   return Object.fromEntries(keys.filter((key) => source[key] !== undefined).map((key) => [key, source[key]]));
 }
@@ -71,10 +90,7 @@ function selectedFastPath(transcript: string): CapturedCall[] {
 }
 
 function fastPath(transcript: string): string[] {
-  return selectedFastPath(transcript).flatMap(({ name, args }) => {
-    if (["start", "prepare"].includes(name)) {
-      return [`clawbrowser.${name}(${JSON.stringify(pick(args, ["profile", "country", "url", "verify", "wait_for"]))})`];
-    }
+  return selectedFastPath(transcript).filter(({ name }) => !["start", "prepare"].includes(name)).flatMap(({ name, args }) => {
     if (name === "multi_action") {
       return [`clawbrowser.multi_action(${JSON.stringify(pick(args, ["actions", "stop_on_navigation", "wait_for", "state_mode"]))})`];
     }
@@ -179,9 +195,6 @@ export function workflowInstructions(task: string, transcript: string): string {
   const tools = [...transcript.matchAll(CLAWBROWSER_CALL)].map((match) => match[1]);
   const unique = tools.filter((tool, index) => tools.indexOf(tool) === index);
   const steps: string[] = [];
-  if (unique.includes("start") || unique.includes("prepare")) {
-    steps.push("Start or reattach the requested Clawbrowser profile and verify the requested proxy country before interacting with the site.");
-  }
   if (unique.some((tool) => ["open", "navigate"].includes(tool))) {
     steps.push("Open the target website in the verified browser session.");
   }

--- a/src/lib/workflowDistillation.test.ts
+++ b/src/lib/workflowDistillation.test.ts
@@ -5,6 +5,10 @@ const fallback = {
   title: "makler.md — матизы", domain: "makler.md",
   instructions: "Technical fast path: clawbrowser.start({}) then clawbrowser.paginate_extract({}). " + "x".repeat(100),
   reusable: true, reason: "Completed browser search",
+  capability: "search" as const,
+  parametersSchema: { type: "object", properties: {} },
+  outputSchema: { type: "object", properties: { results: { type: "array" } } },
+  recipe: { version: 1 as const, capability: "search" as const, actions: [{ tool: "paginate_extract", arguments: {} }] },
 };
 
 describe("workflow agent distillation", () => {

--- a/src/lib/workflowDistillation.ts
+++ b/src/lib/workflowDistillation.ts
@@ -4,17 +4,21 @@ export interface DistilledWorkflow {
   instructions: string;
   reusable: boolean;
   reason: string;
+  capability: "scrape" | "search" | "posting" | "form" | "navigation" | "other";
+  parametersSchema: Record<string, unknown>;
+  outputSchema: Record<string, unknown>;
+  recipe: { version: 1; capability: DistilledWorkflow["capability"]; actions: Array<{ tool: string; arguments: Record<string, unknown> }> };
 }
 
 export function workflowDistillationPrompt(input: DistilledWorkflow): string {
   return `You are converting an observed successful browser run into a reusable private skill.
 Do not call tools, browse, or inspect files. Use only the supplied cleaned trace.
 
-Return exactly one JSON object with fields: title, domain, instructions, reusable, reason.
+Return exactly one JSON object with fields: title, domain, instructions, reusable, reason, capability, parameters_schema, output_schema.
 
 Rules:
 - Preserve the real domain and only browser tools/arguments present in the cleaned trace.
-- Keep the workflow self-contained from proxy/session preparation through final results.
+- Keep only task-specific website actions through final results. NextBrowser prepares profiles, proxy, and sessions; omit start/prepare lifecycle steps.
 - Parameterize user-specific search values when useful, while retaining their current defaults.
 - Separate the proven fast path from fallback behavior.
 - Do not include results, IDs, endpoints, dashboard URLs, timestamps, tokens, or credentials.
@@ -61,5 +65,9 @@ export function parseDistilledWorkflow(raw: string, fallback: DistilledWorkflow)
   const allowedTools = new Set([...fallback.instructions.matchAll(/clawbrowser\.([a-z_]+)/g)].map((match) => match[1]));
   const producedTools = [...instructions.matchAll(/clawbrowser\.([a-z_]+)/g)].map((match) => match[1]);
   if (producedTools.some((tool) => !allowedTools.has(tool))) return undefined;
-  return { title, domain, instructions, reusable: true, reason };
+  const allowedCapabilities = new Set(["scrape", "search", "posting", "form", "navigation", "other"]);
+  const capability = typeof record.capability === "string" && allowedCapabilities.has(record.capability) ? record.capability as DistilledWorkflow["capability"] : fallback.capability;
+  const parametersSchema = record.parameters_schema && typeof record.parameters_schema === "object" && !Array.isArray(record.parameters_schema) ? record.parameters_schema as Record<string, unknown> : fallback.parametersSchema;
+  const outputSchema = record.output_schema && typeof record.output_schema === "object" && !Array.isArray(record.output_schema) ? record.output_schema as Record<string, unknown> : fallback.outputSchema;
+  return { title, domain, instructions, reusable: true, reason, capability, parametersSchema, outputSchema, recipe: { ...fallback.recipe, capability } };
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -79,6 +79,19 @@ interface QueuedItem {
   executionTarget: ExecutionTarget;
 }
 
+function privateSkillContext(skills: BrowserWorkflowSkill[], text: string): string {
+  const lower = text.toLowerCase();
+  const intent = /\b(post|publish|comment|reply|send)\b|опубли|отправ|коммент/i.test(text) ? "posting"
+    : /\b(find|search)\b|найди|поиск/i.test(text) ? "search"
+      : /\b(scrape|extract|parse)\b|скрейп|парс/i.test(text) ? "scrape"
+        : /\b(fill|upload|form)\b|заполни|загруз/i.test(text) ? "form" : "other";
+  const match = skills
+    .filter((skill) => skill.domain && lower.includes(skill.domain.toLowerCase()))
+    .sort((a, b) => Number(b.capability === intent) - Number(a.capability === intent) || b.updatedAt - a.updatedAt)[0];
+  if (!match || (match.capability !== intent && intent !== "other")) return "";
+  return `\n\nA private skill owned by this user matches the domain and intent. Execute its structured recipe first; fall back to its prose workflow only if the page changed. Do not repeat start/prepare because NextBrowser owns session setup.\nPrivate skill: ${match.title}\nRecipe: ${JSON.stringify(match.recipe)}\nFallback: ${match.instructions}`;
+}
+
 export interface ManualProxyProfileInput {
   name: string;
   scheme: "http" | "socks5";
@@ -443,7 +456,7 @@ interface State {
   deleteCustomScript: (id: string) => void;
   runCustomScript: (script: CustomScript) => Promise<void>;
   saveLocalSkill: (skill: BrowserWorkflowSkill) => Promise<void>;
-  deleteLocalSkill: (id: string) => void;
+  deleteLocalSkill: (id: string) => Promise<void>;
   runLocalSkill: (skill: BrowserWorkflowSkill, task?: string) => Promise<void>;
 
   // Internal queue/runtime helpers
@@ -1409,7 +1422,7 @@ export const useStore = create<State>((set, get) => {
       get().conversations,
       item.conversationId,
       item.replyId,
-      item.rawText,
+      item.rawText + privateSkillContext(get().localSkills, item.rawText),
       get().selectedProfile,
       { nextctlAvailable: get().nextctlAvailable, executionTarget: item.executionTarget },
     );
@@ -3353,16 +3366,21 @@ export const useStore = create<State>((set, get) => {
     persistLocalSkills(localSkills);
     set({ localSkills });
     const slug = `workflow-${skill.id.slice(0, 8)}`;
-    const body = `---\nname: ${skill.title}\ndescription: Reusable browser workflow${skill.domain ? ` for ${skill.domain}` : ""}.\n---\n\n# ${skill.title}\n\n## When to use\n\n${skill.task}\n\n## Workflow\n\n${skill.instructions}\n\n## Recorded browser actions\n\n${skill.actions.map((action, index) => `${index + 1}. ${action}`).join("\n") || "No action trace was captured."}\n`;
+    const description = `Reusable private ${skill.capability} browser workflow${skill.domain ? ` for ${skill.domain}` : ""}.`;
+    const body = `---\nname: ${JSON.stringify(skill.title)}\ndescription: ${JSON.stringify(description)}\n---\n\n# ${skill.title}\n\n## Workflow\n\n${skill.instructions}\n\n## Inputs\n\n\`\`\`json\n${JSON.stringify(skill.parametersSchema, null, 2)}\n\`\`\`\n\n## Output\n\n\`\`\`json\n${JSON.stringify(skill.outputSchema, null, 2)}\n\`\`\`\n\n## Recipe\n\nExecute these task-specific actions first. The app prepares the browser session separately. If a selector is stale, resolve it again and continue.\n\n\`\`\`json\n${JSON.stringify(skill.recipe, null, 2)}\n\`\`\`\n`;
     await invoke<string>("write_local_skill", { slug, content: body });
     set((state) => ({ localSkillSync: { ...state.localSkillSync, [skill.id]: "syncing" } }));
     let tempPath: string | undefined;
     try {
       tempPath = await invoke<string>("write_temp_skill", { slug, content: body });
       const { env, res } = await nextctlEnvelope<SkillRef>([
-        "skill", "add", "--domain", `${slug}.script`, "--private", "--slug", slug,
+        "skill", "add", "--domain", skill.domain, "--private", "--slug", slug,
         "--title", skill.title, "--description", `Private browser skill${skill.domain ? ` for ${skill.domain}` : ""}.`,
         "--category", "my-skills", "--category-title", "My skills", "--category-icon", "person.crop.circle",
+        "--capability", skill.capability,
+        "--parameters-json", JSON.stringify(skill.parametersSchema),
+        "--output-json", JSON.stringify(skill.outputSchema),
+        "--recipe-json", JSON.stringify(skill.recipe),
         "--file", tempPath,
       ]);
       if (res.code !== 0 || env.ok === false) throw new Error(nextctlErrorMessage(res));
@@ -3379,7 +3397,12 @@ export const useStore = create<State>((set, get) => {
     }
   },
 
-  deleteLocalSkill: (id) => {
+  deleteLocalSkill: async (id) => {
+    const skill = get().localSkills.find((item) => item.id === id);
+    if (skill?.serverSlug) {
+      const { res } = await nextctlEnvelope(["skill", "delete", skill.serverSlug]);
+      if (res.code !== 0) throw new Error(nextctlErrorMessage(res));
+    }
     const localSkills = get().localSkills.filter((skill) => skill.id !== id);
     persistLocalSkills(localSkills);
     set({ localSkills });
@@ -3420,7 +3443,7 @@ export const useStore = create<State>((set, get) => {
     if (!get().agentReady()) return;
     const note = pageReadyNote(prep.host, prep.directFallback);
     get().enqueue(
-      `Use my local browser skill "${skill.title}" for ${target} in the active verified NextBrowser session.${note}\nThe app already prepared the session, verified the selected proxy, and opened the website. Do not run saved start/prepare operations again. Begin with the first task-specific action. Reuse the proven fast path, adapting selectors only if the page changed.\n\nTask for this run:\n${task}\n\nWorkflow instructions:\n${skill.instructions}\n\nObserved browser actions (reference only):\n${skill.actions.map((action, index) => `${index + 1}. ${action}`).join("\n") || "No recorded action trace; follow the workflow instructions."}`,
+      `Use my local browser skill "${skill.title}" for ${target} in the active verified NextBrowser session.${note}\nThe app already prepared the session, verified the selected proxy, and opened the website. Do not run saved start/prepare operations again. Begin with the first task-specific action. Reuse the proven recipe, adapting selectors only if the page changed.\n\nTask for this run:\n${task}\n\nStructured recipe (execute first):\n${JSON.stringify(skill.recipe, null, 2)}\n\nWorkflow fallback:\n${skill.instructions}`,
       chip,
       cid,
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -185,12 +185,20 @@ export interface BrowserWorkflowSkill {
   domain: string;
   task: string;
   instructions: string;
-  actions: string[];
+  actions: BrowserWorkflowAction[];
+  capability: BrowserSkillCapability;
+  parametersSchema: Record<string, unknown>;
+  outputSchema: Record<string, unknown>;
+  recipe: BrowserWorkflowRecipe;
   createdAt: number;
   updatedAt: number;
   serverSlug?: string;
   submittedAt?: number;
 }
+
+export type BrowserSkillCapability = "scrape" | "search" | "posting" | "form" | "navigation" | "other";
+export interface BrowserWorkflowAction { tool: string; arguments: Record<string, unknown>; }
+export interface BrowserWorkflowRecipe { version: 1; capability: BrowserSkillCapability; actions: BrowserWorkflowAction[]; }
 
 export function customPrivateSlug(script: CustomScript): string {
   return script.serverSlug ?? `custom-${script.id.slice(0, 8).toLowerCase()}`;


### PR DESCRIPTION
## Summary
- save skills against the real website domain and inferred capability
- distill inputs, outputs, and a structured task recipe
- keep browser session lifecycle outside saved recipes
- automatically match private skills by domain and intent
- execute the recipe first with prose fallback
- delete synced skills from private cloud storage
- safely quote generated SKILL.md frontmatter and migrate legacy local skills

## Depends on
- nextbrowser-oss/nextctl private skill lifecycle support
- clawbrowser/next-browser-api executable skill metadata

## Test plan
- npm test
- npm run build