### PR TITLE
Fix terminal contrast and runtime status fallbacks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -123,6 +123,10 @@ function formatStars(count?: number | null): string {
   return `${rounded}k`;
 }
 
+// GitHub's API is unavailable in some regions. Prefer a slightly stale count
+// over rendering a broken-looking dash; a successful request replaces it.
+const GITHUB_STARS_FALLBACK = 11;
+
 function GithubStarButton({ stars }: { stars?: number | null }) {
   const label = "Star NextBrowser on GitHub";
   return (
@@ -155,7 +159,7 @@ function DiscordButton() {
 }
 
 function SocialButtons() {
-  const [stars, setStars] = useState<number | null>(null);
+  const [stars, setStars] = useState<number>(GITHUB_STARS_FALLBACK);
 
   useEffect(() => {
     let cancelled = false;

--- a/src/components/AgentTerminal.tsx
+++ b/src/components/AgentTerminal.tsx
@@ -110,6 +110,9 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
     const terminal = new Terminal({
       cursorBlink: true,
       convertEol: true,
+      // Agent CLIs emit their own ANSI colors. Keep even explicit black/dark
+      // foreground sequences readable when the app switches theme.
+      minimumContrastRatio: 7,
       fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
       fontSize: 12,
       lineHeight: 1.25,

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,3 +1,3 @@
 export function normalizeNextctlVersion(version: string): string {
-  return version.trim().replace(/^nextctl\s+/i, "");
+  return version.trim().replace(/^(?:nextctl|nbc)\s+/i, "");
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -2482,7 +2482,10 @@ export const useStore = create<State>((set, get) => {
     set({ nextctlUpdating: true, nextctlUpdateStatus: undefined });
     try {
       if (pendingTarget(get(), "vps")) return false;
-      const res = await nextctlRun(["update"]);
+      // Updating also refreshes Clawbrowser and agent assets. On slower or
+      // filtered networks that can legitimately take longer than the normal
+      // one-minute command timeout.
+      const res = await nextctlRun(["update"], undefined, { timeoutMs: 10 * 60_000 });
       const text = res.stdout + res.stderr;
       const line = text.split("\n").find((l) => l.includes("nextctl updated:"));
       if (line) {

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -10,6 +10,7 @@ const conversation = (messages: Conversation["messages"]): Conversation => ({
 describe("Swift-compatible model helpers", () => {
   it("normalizes nextctl version output for the footer", () => {
     expect(normalizeNextctlVersion("nextctl 1.2.0\n")).toBe("1.2.0");
+    expect(normalizeNextctlVersion("nbc 1.0.1\n")).toBe("1.0.1");
     expect(normalizeNextctlVersion("1.2.0")).toBe("1.2.0");
   });
   it("prefers the last non-system command chip in conversation previews", () => {


### PR DESCRIPTION
## Summary
- keep ANSI-colored terminal input readable across light and dark themes
- normalize `nbc` version output and allow component updates to finish on slow networks
- show a numeric GitHub stars fallback when the API is unavailable

## Verification
- `npm run build`
- `npm test` (241 tests)