### PR TITLE
Stabilize terminal handoff and chat controls

### DIFF
--- a/src/components/AgentTerminal.tsx
+++ b/src/components/AgentTerminal.tsx
@@ -80,6 +80,12 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
   const [status, setStatus] = useState<"starting" | "running" | "exited" | "failed">("starting");
   const [error, setError] = useState<string>();
   const [restartNonce, setRestartNonce] = useState(0);
+  const onContinueInChatRef = useRef(onContinueInChat);
+  const onHandoffConsumedRef = useRef(onHandoffConsumed);
+  const onChatHandoffConsumedRef = useRef(onChatHandoffConsumed);
+  onContinueInChatRef.current = onContinueInChat;
+  onHandoffConsumedRef.current = onHandoffConsumed;
+  onChatHandoffConsumedRef.current = onChatHandoffConsumed;
 
   const transcript = () => {
     const terminal = terminalRef.current;
@@ -239,15 +245,15 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
     // the Settings toggle continues the task without another user action.
     void invoke("terminal_input", { id, data: `\x1b[200~${pendingHandoff.text}\x1b[201~\r` });
     terminalRef.current?.focus();
-    onHandoffConsumed(pendingHandoff.id);
-  }, [pendingHandoff?.id, status, onHandoffConsumed]);
+    onHandoffConsumedRef.current(pendingHandoff.id);
+  }, [pendingHandoff?.id, status]);
 
   useEffect(() => {
     if (!handoffToChatRequest || status !== "running") return;
     const value = transcript();
-    if (value) onContinueInChat(value);
-    onChatHandoffConsumed(handoffToChatRequest);
-  }, [handoffToChatRequest, status, onContinueInChat, onChatHandoffConsumed]);
+    if (value) onContinueInChatRef.current(value);
+    onChatHandoffConsumedRef.current(handoffToChatRequest);
+  }, [handoffToChatRequest, status]);
 
   return (
     <section className="agent-terminal-panel" aria-label={`${agentName} terminal`}>

--- a/src/components/AgentTerminal.tsx
+++ b/src/components/AgentTerminal.tsx
@@ -73,6 +73,14 @@ function activeTerminalTheme() {
     : DARK_TERMINAL_THEME;
 }
 
+function handoffFingerprint(value: string): string {
+  return value
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "")
+    .replace(/\b(?:working|worked for)\s*\([^)]*\)/gi, "working")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
 export function AgentTerminal({ agentId, agentName, conversationId, workingDir, savingWorkflow, pendingHandoff, handoffToChatRequest, onSaveWorkflow, onContinueInChat, onHandoffConsumed, onChatHandoffConsumed }: AgentTerminalProps) {
   const hostRef = useRef<HTMLDivElement>(null);
   const terminalIdRef = useRef<string>();
@@ -83,6 +91,7 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
   const onContinueInChatRef = useRef(onContinueInChat);
   const onHandoffConsumedRef = useRef(onHandoffConsumed);
   const onChatHandoffConsumedRef = useRef(onChatHandoffConsumed);
+  const lastTerminalHandoffRef = useRef("");
   onContinueInChatRef.current = onContinueInChat;
   onHandoffConsumedRef.current = onHandoffConsumed;
   onChatHandoffConsumedRef.current = onChatHandoffConsumed;
@@ -108,6 +117,7 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
     if (!host) return;
     setStatus("starting");
     setError(undefined);
+    lastTerminalHandoffRef.current = "";
     let disposed = false;
     let removeData: (() => void) | undefined;
     let removeExit: (() => void) | undefined;
@@ -251,7 +261,11 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
   useEffect(() => {
     if (!handoffToChatRequest || status !== "running") return;
     const value = transcript();
-    if (value) onContinueInChatRef.current(value);
+    const fingerprint = handoffFingerprint(value);
+    if (value && fingerprint !== lastTerminalHandoffRef.current) {
+      lastTerminalHandoffRef.current = fingerprint;
+      onContinueInChatRef.current(value);
+    }
     onChatHandoffConsumedRef.current(handoffToChatRequest);
   }, [handoffToChatRequest, status]);
 

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -119,6 +119,7 @@ export function ChatView() {
   const [terminalHandoff, setTerminalHandoff] = useState<{ id: string; text: string }>();
   const [terminalToChatRequest, setTerminalToChatRequest] = useState<string>();
   const previousTerminalChat = useRef(s.terminalChat);
+  const chatMessagesSharedWithTerminal = useRef(new Map<string, number>());
   const bottomRef = useRef<HTMLDivElement>(null);
   const composerRef = useRef<HTMLTextAreaElement>(null);
 
@@ -127,13 +128,18 @@ export function ChatView() {
     previousTerminalChat.current = s.terminalChat;
     if (s.terminalChat) {
       setTerminalMounted(true);
-      if (!wasTerminalChat && messages.length > 0) {
-        setTerminalHandoff({ id: uid(), text: chatToTerminalHandoff(messages, s.selectedProfile) });
+      const conversationKey = `${agentId}:${conv?.id ?? "new"}`;
+      const sharedCount = chatMessagesSharedWithTerminal.current.get(conversationKey) ?? 0;
+      if (!wasTerminalChat && messages.length > sharedCount) {
+        // Only send messages created since the previous handoff. Replaying the
+        // whole conversation can make an agent execute an already-finished task.
+        setTerminalHandoff({ id: uid(), text: chatToTerminalHandoff(messages.slice(sharedCount), s.selectedProfile) });
+        chatMessagesSharedWithTerminal.current.set(conversationKey, messages.length);
       }
       return;
     }
     if (wasTerminalChat && terminalMounted) setTerminalToChatRequest(uid());
-  }, [s.terminalChat, terminalMounted]);
+  }, [s.terminalChat, terminalMounted, agentId, conv?.id, messages.length, s.selectedProfile]);
 
   useEffect(() => {
     const stageDraft = (value: string) => {

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -281,9 +281,6 @@ export function ChatView() {
         <aside className="conv-sidebar thin-material">
           <div className="conv-sidebar-head">
             <span className="conv-sidebar-label">{agentName} chats</span>
-            <button className="plain-icon-btn" onClick={() => s.newChat()} title="New chat">
-              <Icon name="square.and.pencil" size={16} />
-            </button>
           </div>
           <hr className="divider" />
           <div className="conv-sidebar-list">
@@ -329,11 +326,9 @@ export function ChatView() {
           >
             <Icon name={collapsed ? "sidebar.left" : "sidebar.leading"} size={16} />
           </button>
-          {collapsed && (
-            <button className="plain-icon-btn" onClick={() => s.newChat()} title="New chat">
-              <Icon name="square.and.pencil" size={16} />
-            </button>
-          )}
+          <button className="plain-icon-btn" onClick={() => s.newChat()} title="New chat">
+            <Icon name="square.and.pencil" size={16} />
+          </button>
           <div className="chat-title-stack">
             <strong className="chat-title">{conv?.title ?? agentName}</strong>
             <span className="muted small">{agentName}</span>


### PR DESCRIPTION
## Summary
- prevent the Terminal → Chat handoff render loop that caused a white screen
- avoid replaying completed tasks across Chat/Terminal switches
- keep Hide chats and New chat controls in a stable order

## Verification
- `npm run build`
- `npm test` (241 tests)