### PR TITLE
Add repository-contributed browser skills

### DIFF
--- a/.github/ISSUE_TEMPLATE/05-skill-contribution.yml
+++ b/.github/ISSUE_TEMPLATE/05-skill-contribution.yml
@@ -1,0 +1,54 @@
+name: Browser skill contribution
+description: Propose or claim a public browser skill to contribute through a pull request
+title: "[Skill]: "
+labels: ["skill"]
+body:
+  - type: input
+    id: website
+    attributes:
+      label: Website
+      description: The primary hostname this skill will support.
+      placeholder: example.com
+    validations:
+      required: true
+  - type: dropdown
+    id: operation
+    attributes:
+      label: Primary operation
+      options:
+        - Search and scraping
+        - Pagination
+        - Posting or commenting
+        - Messaging
+        - Form completion
+    validations:
+      required: true
+  - type: textarea
+    id: workflows
+    attributes:
+      label: Required workflows
+      description: List the concrete user tasks the skill must complete.
+      placeholder: |
+        - Search using the requested filters
+        - Traverse all result pages
+        - Return deduplicated canonical URLs
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance tasks
+      description: Provide at least three distinct tasks that will be tested from a fresh agent chat.
+    validations:
+      required: true
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution agreement
+      options:
+        - label: I will contribute this skill under `skills/<skill-id>/` through a focused pull request.
+          required: true
+        - label: I will include no credentials, cookies, or private user data.
+          required: true
+        - label: I will include evidence of successful runs for every acceptance task.
+          required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,19 +48,227 @@ The managed browser runtime is an external dependency. Do not copy its implement
 
 ## Contributing a browser skill
 
-Repository skills ship in the NextBrowser catalog and must be contributed through GitHub rather than created with the in-app **Save as skill** flow. Claim or open an issue for one website and one coherent workflow, then add a single directory under `skills/<kebab-case-id>/` containing:
+Repository skills are public, reviewed browser workflows that ship in the NextBrowser catalog. They are source-controlled so improvements remain attributable to their GitHub contributors. Do not use the in-app **Save as skill** flow for repository contributions; that flow is for a user's private or local workflows.
 
-- `SKILL.md` with matching YAML frontmatter and resilient browser instructions;
-- `manifest.json` with the author, domains, operations, and UI category;
-- `tests/cases.json` with at least three distinct acceptance tasks.
+### 1. Choose and claim a workflow
 
-Run the repository validator before opening a pull request:
+Open a **Browser skill contribution** issue before starting substantial work. Specify one primary website, the concrete workflows you intend to support, and at least three acceptance tasks. This prevents two contributors from unknowingly working on the same skill.
 
-```bash
-npm run validate:skills
+A skill should solve one coherent, repeatable job. Good scopes include:
+
+- searching and extracting vehicle listings from one marketplace;
+- publishing a draft listing on one classifieds site;
+- collecting product data across paginated search results;
+- posting or replying through a specific site's composer.
+
+Avoid vague scopes such as “use example.com,” and avoid combining unrelated operations merely because they share a domain. Multiple skills may support the same domain when they represent distinct jobs, for example:
+
+```text
+skills/
+├── example-product-search/
+├── example-product-posting/
+└── example-order-status/
 ```
 
-Test the skill from a fresh agent chat. The pull request must include the tested tasks, outcomes, and a terminal transcript, screenshot, or short recording. Instructions must verify requested proxy state before interaction, avoid relying on short-lived element IDs, cover pagination when relevant, deduplicate results, and state recovery behavior. Never include credentials, cookies, private user data, or generated results in a skill.
+Before implementing a second skill for a domain, confirm that extending an existing skill would not be clearer for users.
+
+### 2. Create the skill directory
+
+Create one lowercase kebab-case directory under `skills/`:
+
+```text
+skills/<skill-id>/
+├── SKILL.md
+├── manifest.json
+└── tests/
+    └── cases.json
+```
+
+The directory name, manifest `id`, and YAML frontmatter `name` must be identical. Do not add generated output, screenshots, recordings, credentials, cookies, or captured website data to this directory.
+
+Use [`skills/999-car-search/`](skills/999-car-search/) as a complete working example.
+
+### 3. Write `SKILL.md`
+
+`SKILL.md` is the instruction that the selected agent receives. Begin with YAML frontmatter:
+
+```markdown
+---
+name: example-product-search
+description: Search, filter, and extract product listings from example.com.
+---
+
+# Example product search
+```
+
+The instructions should tell the agent when to use the skill and how to complete the task efficiently. Include only behavior that is specific or especially useful for this workflow. Cover the following when relevant:
+
+1. Start or reattach one named browser profile instead of creating duplicate sessions.
+2. If the user requested a proxy country, verify that country successfully before interacting with the website.
+3. Navigate to the correct search, form, or content surface.
+4. Apply the requested filters and wait for navigation or page settlement when necessary.
+5. Extract the requested fields and canonical URLs.
+6. Traverse pagination or infinite scrolling to the required stopping condition.
+7. Deduplicate results and reject irrelevant matches.
+8. Recover from stale elements, navigation, detached tabs, or changed page structure.
+9. Return a concise result or request confirmation before a consequential publishing action.
+
+Prefer semantic targets such as roles, labels, text, and stable selectors. Treat browser `element_id` values as short-lived hints; never design a workflow that depends on an element ID captured in an earlier session. Reuse a proven fast path where it remains valid, but require the agent to inspect and adapt when the page changes.
+
+For posting, commenting, messaging, purchases, deletion, or other user-visible actions, distinguish preparation from final submission. Do not silently broaden the user's request or publish unintended content.
+
+Never include:
+
+- API keys, passwords, bearer tokens, cookies, or session data;
+- personal information or private URLs;
+- captured search results that will become stale;
+- instructions to bypass access controls or conceal consequential actions;
+- claims about a website that were not verified during testing.
+
+### 4. Add `manifest.json`
+
+The manifest supplies catalog metadata and determines where the skill appears in the UI:
+
+```json
+{
+  "id": "example-product-search",
+  "name": "Example Product Search",
+  "description": "Search, filter, paginate, and deduplicate products on example.com.",
+  "author": "your-github-username",
+  "domains": ["example.com"],
+  "operations": ["search", "scrape", "paginate"],
+  "category": {
+    "id": "marketplaces",
+    "title": "Marketplaces",
+    "icon": "globe",
+    "order": 30
+  }
+}
+```
+
+Fields:
+
+- `id` — the exact lowercase kebab-case directory name;
+- `name` — concise user-facing catalog name;
+- `description` — one sentence explaining the practical outcome;
+- `author` — the contributor's GitHub username or organization;
+- `domains` — one or more hostnames the workflow directly supports;
+- `operations` — one or more supported operation identifiers;
+- `category.id` — lowercase kebab-case category identifier;
+- `category.title` — user-facing category name;
+- `category.icon` — an icon name already supported by the app;
+- `category.order` — integer controlling category order in the catalog.
+
+Allowed operation identifiers are:
+
+```text
+search, scrape, paginate, post, comment, message, form
+```
+
+Reuse an existing category when it fits. Do not create nearly identical categories solely to give one skill a custom heading.
+
+### 5. Add acceptance cases
+
+`tests/cases.json` must contain at least three distinct, realistic tasks:
+
+```json
+[
+  {
+    "task": "Find every matching product and include its price and canonical URL.",
+    "expects": [
+      "applies the requested filters",
+      "paginates to the end",
+      "deduplicates canonical URLs"
+    ]
+  },
+  {
+    "task": "Run the same search through a US proxy.",
+    "expects": [
+      "verifies the US proxy before search",
+      "does not restart a verified profile"
+    ]
+  },
+  {
+    "task": "Recover when the saved selector no longer matches.",
+    "expects": [
+      "resolves the control semantically",
+      "completes without using a stale element id"
+    ]
+  }
+]
+```
+
+Cases are reviewable acceptance criteria, not a substitute for running the browser. Include meaningful variation: filters, pagination, proxy use, recovery, or confirmation behavior as applicable. Do not submit three cosmetic rewrites of the same task.
+
+### 6. Validate and test locally
+
+Install the locked dependencies and run all required checks from the repository root:
+
+```bash
+npm ci
+npm run validate:skills
+npm test
+npm run build
+```
+
+Then test every acceptance task from a fresh agent chat so the result does not depend on hidden conversation context. For each task, record:
+
+- operating system and NextBrowser version or commit;
+- agent used;
+- task text exactly as submitted;
+- requested browser profile and proxy country, if any;
+- pass or fail outcome;
+- relevant result count or final state;
+- unexpected retries, duplicate tabs, permission prompts, or recovery steps;
+- elapsed time when performance is part of the skill's value.
+
+Scraping skills should be checked for pagination, canonical URL deduplication, irrelevant-result rejection, and a clear stopping condition. Posting skills should be checked for correct field mapping, draft preservation, explicit final submission behavior, and recovery after navigation or validation errors.
+
+Attach a redacted terminal transcript, screenshot, or short recording to the pull request as evidence. Evidence belongs in the pull request, not in the skill directory.
+
+### 7. Open the pull request
+
+Fork the repository, branch from the latest `main`, commit the skill, and push your branch:
+
+```bash
+git switch main
+git pull --ff-only
+git switch -c skill/example-product-search
+git add skills/example-product-search
+git commit -m "Add example product search skill"
+git push -u origin skill/example-product-search
+```
+
+Open a focused pull request containing only one coherent skill or one clearly related improvement to an existing skill. Link the contribution issue and include:
+
+- the supported website and workflow;
+- why a separate skill is appropriate;
+- all acceptance tasks and their outcomes;
+- the exact validation, test, and build commands run;
+- redacted evidence of successful browser runs;
+- known limitations, regional behavior, or fragile website areas.
+
+CI validates the directory, manifest, frontmatter, acceptance-case structure, and build on macOS and Windows. A green CI run does not replace browser review.
+
+### 8. Review and release
+
+Reviewers may request changes when a skill is too broad, duplicates an existing skill, relies on transient selectors, omits pagination or recovery, exposes sensitive data, or has not been demonstrated from a fresh chat. Keep review fixes in the same pull request.
+
+After merge, the repository loader includes the skill in the NextBrowser catalog. Users can run it but cannot modify the public repository copy from the app. Subsequent improvements should be submitted as another focused pull request so history and authorship remain visible.
+
+#### Contributor completion checklist
+
+- [ ] The contribution issue identifies one website and coherent workflow.
+- [ ] Directory name, manifest `id`, and frontmatter `name` match.
+- [ ] Instructions verify a requested proxy before website interaction.
+- [ ] Instructions avoid persistent reliance on captured element IDs.
+- [ ] Pagination, deduplication, stopping conditions, and recovery are covered where relevant.
+- [ ] Consequential posting actions require the intended user confirmation behavior.
+- [ ] `tests/cases.json` contains at least three genuinely distinct tasks.
+- [ ] Every acceptance task was run from a fresh agent chat.
+- [ ] Evidence is redacted and attached to the pull request.
+- [ ] `npm run validate:skills`, `npm test`, and `npm run build` pass.
+- [ ] No secrets, private data, generated output, or unrelated changes are committed.
 
 ## Making changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,11 +39,28 @@ npm run dev
 
 - `src/` — React renderer, product UI, state, and renderer tests.
 - `electron/` — Electron main process, preload bridge, and native integration.
+- `skills/` — public browser skills contributed through focused pull requests.
 - `scripts/` — build and maintenance helpers.
 - `public/` and `build/` — application assets and packaging resources.
 - `docs/` — product documentation and README translations.
 
 The managed browser runtime is an external dependency. Do not copy its implementation into this repository or describe its behavior as native NextBrowser behavior without a verified source.
+
+## Contributing a browser skill
+
+Repository skills ship in the NextBrowser catalog and must be contributed through GitHub rather than created with the in-app **Save as skill** flow. Claim or open an issue for one website and one coherent workflow, then add a single directory under `skills/<kebab-case-id>/` containing:
+
+- `SKILL.md` with matching YAML frontmatter and resilient browser instructions;
+- `manifest.json` with the author, domains, operations, and UI category;
+- `tests/cases.json` with at least three distinct acceptance tasks.
+
+Run the repository validator before opening a pull request:
+
+```bash
+npm run validate:skills
+```
+
+Test the skill from a fresh agent chat. The pull request must include the tested tasks, outcomes, and a terminal transcript, screenshot, or short recording. Instructions must verify requested proxy state before interaction, avoid relying on short-lived element IDs, cover pagination when relevant, deduplicate results, and state recovery behavior. Never include credentials, cookies, private user data, or generated results in a skill.
 
 ## Making changes
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "electron/main.cjs",
   "scripts": {
     "dev": "concurrently -k \"vite --port 1421\" \"wait-on tcp:1421 && cross-env VITE_DEV_SERVER_URL=http://localhost:1421 electron .\"",
-    "build": "tsc && vite build",
+    "build": "npm run validate:skills && tsc && vite build",
     "postinstall": "electron-builder install-app-deps",
     "test": "vitest run --exclude electron/agent-workspace.test.cjs --exclude electron/binary-resolver.test.cjs --exclude electron/browser-runtime.test.cjs --exclude electron/runtime-config.test.cjs --exclude electron/workspace-instructions.test.cjs --exclude electron/github-stars.test.cjs --exclude electron/command-runner.test.cjs --exclude electron/ssh-config.test.cjs --exclude electron/proxy-traffic.test.cjs && node --test electron/agent-workspace.test.cjs electron/binary-resolver.test.cjs electron/browser-runtime.test.cjs electron/runtime-config.test.cjs electron/workspace-instructions.test.cjs electron/github-stars.test.cjs electron/command-runner.test.cjs electron/ssh-config.test.cjs electron/proxy-traffic.test.cjs && node scripts/verify-pty.cjs",
     "start": "electron .",
@@ -18,7 +18,8 @@
     "dist:publish": "npm run build && electron-builder --publish always",
     "dist:mac": "npm run build && electron-builder --mac dmg zip --publish never",
     "dist:win": "npm run build && electron-builder --win nsis --publish never",
-    "icons": "node scripts/generate-icons.mjs"
+    "icons": "node scripts/generate-icons.mjs",
+    "validate:skills": "node scripts/validate-skills.mjs"
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.11.0",

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -1,0 +1,56 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = path.resolve("skills");
+const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const allowedOperations = new Set(["search", "scrape", "paginate", "post", "comment", "message", "form"]);
+const failures = [];
+
+for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue;
+  const dir = path.join(root, entry.name);
+  if (!slugPattern.test(entry.name)) failures.push(`${entry.name}: directory must be a lowercase kebab-case slug`);
+  for (const required of ["SKILL.md", "manifest.json", "tests/cases.json"]) {
+    if (!fs.existsSync(path.join(dir, required))) failures.push(`${entry.name}: missing ${required}`);
+  }
+  if (!fs.existsSync(path.join(dir, "manifest.json"))) continue;
+  let manifest;
+  try { manifest = JSON.parse(fs.readFileSync(path.join(dir, "manifest.json"), "utf8")); }
+  catch { failures.push(`${entry.name}: manifest.json is not valid JSON`); continue; }
+  if (manifest.id !== entry.name) failures.push(`${entry.name}: manifest id must match its directory`);
+  for (const field of ["name", "description", "author"]) {
+    if (typeof manifest[field] !== "string" || !manifest[field].trim()) failures.push(`${entry.name}: ${field} is required`);
+  }
+  if (!Array.isArray(manifest.domains) || !manifest.domains.length || manifest.domains.some((domain) => typeof domain !== "string" || !domain.includes("."))) {
+    failures.push(`${entry.name}: domains must contain at least one hostname`);
+  }
+  if (!Array.isArray(manifest.operations) || !manifest.operations.length || manifest.operations.some((operation) => !allowedOperations.has(operation))) {
+    failures.push(`${entry.name}: operations contains an unsupported value`);
+  }
+  if (!manifest.category || !slugPattern.test(manifest.category.id ?? "") || typeof manifest.category.title !== "string" || typeof manifest.category.icon !== "string" || !Number.isInteger(manifest.category.order)) {
+    failures.push(`${entry.name}: category must include id, title, icon, and integer order`);
+  }
+  const skillPath = path.join(dir, "SKILL.md");
+  if (fs.existsSync(skillPath)) {
+    const skill = fs.readFileSync(skillPath, "utf8");
+    if (!skill.startsWith("---\n")) failures.push(`${entry.name}: SKILL.md must start with YAML frontmatter`);
+    if (!skill.includes(`name: ${entry.name}`)) failures.push(`${entry.name}: SKILL.md frontmatter name must match the manifest id`);
+    if (skill.length < 400) failures.push(`${entry.name}: SKILL.md is too short to be useful`);
+    if (/api[_ -]?key|password\s*[:=]|bearer\s+[a-z0-9]/i.test(skill)) failures.push(`${entry.name}: SKILL.md may contain credentials`);
+  }
+  const casesPath = path.join(dir, "tests", "cases.json");
+  if (fs.existsSync(casesPath)) {
+    try {
+      const cases = JSON.parse(fs.readFileSync(casesPath, "utf8"));
+      if (!Array.isArray(cases) || cases.length < 3 || cases.some((testCase) => typeof testCase?.task !== "string" || !Array.isArray(testCase?.expects))) {
+        failures.push(`${entry.name}: tests/cases.json must contain at least three task/expects cases`);
+      }
+    } catch { failures.push(`${entry.name}: tests/cases.json is not valid JSON`); }
+  }
+}
+
+if (failures.length) {
+  console.error(failures.map((failure) => `- ${failure}`).join("\n"));
+  process.exit(1);
+}
+console.log(`Validated ${fs.readdirSync(root, { withFileTypes: true }).filter((entry) => entry.isDirectory()).length} repository skill(s).`);

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -32,7 +32,10 @@ for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
   }
   const skillPath = path.join(dir, "SKILL.md");
   if (fs.existsSync(skillPath)) {
-    const skill = fs.readFileSync(skillPath, "utf8");
+    // Git commonly checks text files out with CRLF on Windows. Normalize the
+    // contents before validating Markdown structure so CI behaves identically
+    // on macOS, Linux, and Windows. Strip a possible UTF-8 BOM as well.
+    const skill = fs.readFileSync(skillPath, "utf8").replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
     if (!skill.startsWith("---\n")) failures.push(`${entry.name}: SKILL.md must start with YAML frontmatter`);
     if (!skill.includes(`name: ${entry.name}`)) failures.push(`${entry.name}: SKILL.md frontmatter name must match the manifest id`);
     if (skill.length < 400) failures.push(`${entry.name}: SKILL.md is too short to be useful`);

--- a/skills/999-car-search/SKILL.md
+++ b/skills/999-car-search/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: 999-car-search
+description: Search and extract relevant vehicle listings from 999.md with pagination and deduplication.
+---
+
+# 999.md car search
+
+Use this skill when a user asks to find cars or compare vehicle listings on `999.md`.
+
+## Workflow
+
+1. Start or reattach one named Clawbrowser profile. If the user requested a proxy country, verify that country before interacting with the site. Never start the same profile repeatedly after a successful start.
+2. Open the car listings section and apply the user's make, model, year, mileage, price, fuel, and location criteria using the site's controls or query parameters.
+3. Confirm the visible filters before extraction. Search terms can match parts and dismantling listings, so do not treat the raw result count as a count of cars.
+4. Extract title, canonical URL, price, year, mileage, location, and the short description when available.
+5. Traverse every available result page or scroll boundary requested by the user. Prefer one structured pagination/extraction operation over repeatedly inspecting the full page.
+6. Deduplicate by canonical listing URL. Exclude parts, rentals, wanted ads, and dismantling listings unless the user requested them.
+7. Return a concise list and state how many pages were inspected, how many raw rows were seen, and how many relevant unique listings remained.
+
+## Recovery
+
+- Treat saved element identifiers as short-lived hints. Resolve controls again by role, label, visible text, or selector after navigation.
+- If navigation changes the page target, list tabs once and continue with the matching `999.md` result tab. Do not call start again merely because a target id changed.
+- If structured extraction returns no rows, inspect a compact page state once, correct the container or fields, and retry.
+- Stop and report the actual blocker if proxy verification, authentication, or the site itself fails twice.
+
+## Output
+
+For each matching car include: title, price, year, mileage, location, and URL. Never claim that all listings were collected unless pagination reached a confirmed end.

--- a/skills/999-car-search/manifest.json
+++ b/skills/999-car-search/manifest.json
@@ -1,0 +1,14 @@
+{
+  "id": "999-car-search",
+  "name": "999.md Car Search",
+  "description": "Search, filter, paginate, and deduplicate car listings on 999.md.",
+  "author": "nextbrowser-oss",
+  "domains": ["999.md"],
+  "operations": ["search", "scrape", "paginate"],
+  "category": {
+    "id": "marketplaces",
+    "title": "Marketplaces",
+    "icon": "globe",
+    "order": 30
+  }
+}

--- a/skills/999-car-search/tests/cases.json
+++ b/skills/999-car-search/tests/cases.json
@@ -1,0 +1,14 @@
+[
+  {
+    "task": "Find all Daewoo Matiz listings and include price, year, and URL.",
+    "expects": ["uses car listings", "paginates to the end", "deduplicates canonical URLs", "excludes parts"]
+  },
+  {
+    "task": "Find Mitsubishi Space Star cars from 2006 or earlier with an American proxy.",
+    "expects": ["verifies US proxy first", "applies year filter", "reports pages inspected"]
+  },
+  {
+    "task": "Compare BMW E60 cars under 5000 EUR and ignore dismantling listings.",
+    "expects": ["filters price", "rejects dismantling results", "returns structured listing details"]
+  }
+]

--- a/src/components/SkillsView.tsx
+++ b/src/components/SkillsView.tsx
@@ -174,6 +174,7 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
             const st = applyState(e.id);
             const applyError = s.skillApplyError(e.id);
             const publishedScript = e.selector.kind === "script" && !e.js;
+            const repositorySkill = e.source === "repository";
             return (
               <div key={e.id} className="skill-card claw-card">
                 <div className="skill-card-head">
@@ -181,10 +182,11 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
                   <div className="skill-title">{e.title}</div>
                   <span className={"mode-badge" + (e.js ? " instant" : " agent")}>
                     <Icon name={e.js ? "bolt.fill" : publishedScript ? "scroll.fill" : "sparkles"} size={10} />
-                    {e.js ? "Instant" : publishedScript ? "Script" : "Agent"}
+                    {e.js ? "Instant" : publishedScript ? "Script" : repositorySkill ? "Repository" : "Agent"}
                   </span>
                 </div>
                 <div className="muted small">{e.subtitle}</div>
+                {repositorySkill && e.author && <div className="small muted skill-author">by @{e.author}</div>}
                 <div className="target-line small muted">
                   <Icon
                     name={selectorTargetHost(e.selector) ? "arrow.right.circle" : "play.circle"}
@@ -202,7 +204,8 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
                     Added to script menu
                   </div>
                 )}
-                {!publishedScript && (
+                {repositorySkill && <div className="small ok skill-status"><Icon name="checkmark.seal.fill" size={12} /> Included with NextBrowser</div>}
+                {!publishedScript && !repositorySkill && (
                   <>
                     {st === "idle" && <div className="small muted skill-status">Not installed</div>}
                     {st === "applying" && <div className="small muted skill-status">Pulling from API…</div>}
@@ -225,7 +228,11 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
                   </>
                 )}
                 <div className="skill-actions">
-                  {e.js ? (
+                  {repositorySkill ? (
+                    <button className="btn-bordered-prominent full" disabled={!ready} title={`Run ${e.title} in chat`} onClick={() => void s.useSkillInChat(e)}>
+                      <Icon name="play.fill" size={13} /> Run
+                    </button>
+                  ) : e.js ? (
                     <button className="btn-bordered-prominent full" title={`Run ${e.title}`} onClick={() => s.runScript(e)}>
                       <Icon name="bolt.fill" size={14} />
                       Run

--- a/src/repositorySkills.test.ts
+++ b/src/repositorySkills.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { mergeSkillCategories, repositorySkillCategories } from "./repositorySkills";
+
+describe("repository skills", () => {
+  it("loads validated skills into the application catalog", () => {
+    const categories = repositorySkillCategories();
+    const skill = categories.flatMap((category) => category.entries)
+      .find((entry) => entry.id === "repository:999-car-search");
+    expect(skill?.source).toBe("repository");
+    expect(skill?.selector).toEqual({ kind: "domain", value: "999.md" });
+    expect(skill?.instructions).toContain("# 999.md car search");
+  });
+
+  it("merges repository and backend skills in the same category", () => {
+    const merged = mergeSkillCategories([{
+      id: "marketplaces",
+      title: "Marketplaces",
+      blurb: "Backend skills",
+      icon: "globe",
+      entries: [{
+        id: "backend",
+        title: "Backend skill",
+        subtitle: "From API",
+        selector: { kind: "domain", value: "example.com" },
+        category: "marketplaces",
+        categoryTitle: "Marketplaces",
+        categoryIcon: "globe",
+        categoryOrder: 30,
+      }],
+    }]);
+    expect(merged.find((category) => category.id === "marketplaces")?.entries.map((entry) => entry.id))
+      .toEqual(["backend", "repository:999-car-search"]);
+  });
+});

--- a/src/repositorySkills.ts
+++ b/src/repositorySkills.ts
@@ -1,0 +1,72 @@
+import type { SkillCategory, SkillEntry } from "./skillsCatalog";
+
+interface RepositorySkillManifest {
+  id: string;
+  name: string;
+  description: string;
+  author: string;
+  domains: string[];
+  operations: string[];
+  category: { id: string; title: string; icon: string; order: number };
+}
+
+const manifests = import.meta.glob<RepositorySkillManifest>("../skills/*/manifest.json", {
+  eager: true,
+  import: "default",
+});
+const instructions = import.meta.glob<string>("../skills/*/SKILL.md", {
+  eager: true,
+  query: "?raw",
+  import: "default",
+});
+
+function directory(path: string): string {
+  return path.split("/").at(-2) ?? "";
+}
+
+export function repositorySkillCategories(): SkillCategory[] {
+  const grouped = new Map<string, SkillCategory>();
+  for (const [manifestPath, manifest] of Object.entries(manifests)) {
+    const slug = directory(manifestPath);
+    const skillInstructions = Object.entries(instructions)
+      .find(([skillPath]) => directory(skillPath) === slug)?.[1];
+    if (!skillInstructions) continue;
+    const category = grouped.get(manifest.category.id) ?? {
+      id: manifest.category.id,
+      title: manifest.category.title,
+      icon: manifest.category.icon,
+      blurb: "Community-maintained skills shipped with NextBrowser.",
+      entries: [],
+    };
+    const entry: SkillEntry = {
+      id: `repository:${manifest.id}`,
+      title: manifest.name,
+      subtitle: manifest.description,
+      description: manifest.description,
+      category: manifest.category.id,
+      categoryTitle: manifest.category.title,
+      categoryIcon: manifest.category.icon,
+      categoryOrder: manifest.category.order,
+      selector: { kind: "domain", value: manifest.domains[0] },
+      source: "repository",
+      instructions: skillInstructions,
+      author: manifest.author,
+    };
+    category.entries.push(entry);
+    grouped.set(manifest.category.id, category);
+  }
+  return [...grouped.values()].sort((a, b) =>
+    (a.entries[0]?.categoryOrder ?? 0) - (b.entries[0]?.categoryOrder ?? 0));
+}
+
+export const REPOSITORY_SKILL_CATEGORIES = repositorySkillCategories();
+
+export function mergeSkillCategories(remote: SkillCategory[], repository = REPOSITORY_SKILL_CATEGORIES): SkillCategory[] {
+  const merged = new Map(remote.map((category) => [category.id, { ...category, entries: [...category.entries] }]));
+  for (const category of repository) {
+    const existing = merged.get(category.id);
+    if (existing) existing.entries.push(...category.entries);
+    else merged.set(category.id, { ...category, entries: [...category.entries] });
+  }
+  return [...merged.values()];
+}

--- a/src/skillsCatalog.ts
+++ b/src/skillsCatalog.ts
@@ -14,6 +14,9 @@ export interface SkillEntry {
   categoryIcon: string;
   categoryOrder: number;
   js?: string;
+  source?: "backend" | "repository";
+  instructions?: string;
+  author?: string;
 }
 
 export interface SkillCategory {

--- a/src/store.ts
+++ b/src/store.ts
@@ -23,6 +23,7 @@ import {
   selectorFlags,
   selectorTargetHost,
 } from "./skillsCatalog";
+import { REPOSITORY_SKILL_CATEGORIES, mergeSkillCategories } from "./repositorySkills";
 import { activityFromText, extractToolEvents } from "./lib/activityParser";
 import { composePrompt } from "./lib/composePrompt";
 import { executionTargetForTurn, type ExecutionTarget } from "./lib/executionTarget";
@@ -901,7 +902,7 @@ export const useStore = create<State>((set, get) => {
   activeConvId: {},
   tab: "chat",
   skillState: {},
-  skillCategories: [],
+  skillCategories: REPOSITORY_SKILL_CATEGORIES,
   scheduledRuns: [],
   customScripts: [],
   localSkills: [],
@@ -1896,7 +1897,10 @@ export const useStore = create<State>((set, get) => {
   },
 
   loadSkillCatalog: async () => {
-    if (!get().nextctlSupportsSkill) return;
+    if (!get().nextctlSupportsSkill) {
+      set({ skillCategories: REPOSITORY_SKILL_CATEGORIES });
+      return;
+    }
     try {
       const catalog = await nextctlJson<{ categories: Array<{ id: string; title: string; icon: string; order: number; skills: SkillRef[] }> }>(["skill", "list"]);
       const backendScripts: SkillEntry[] = [];
@@ -1911,6 +1915,7 @@ export const useStore = create<State>((set, get) => {
               category: category.id, categoryTitle: category.title,
               categoryIcon: category.icon, categoryOrder: category.order,
               selector: { kind: ref.kind === "domain" && ref.selector!.endsWith(".script") ? "script" : ref.kind!, value: ref.selector! },
+              source: "backend",
             }))
             .filter((entry) => {
               if (category.id === "my-skills") {
@@ -1924,7 +1929,7 @@ export const useStore = create<State>((set, get) => {
         })).filter((category) => category.id !== "my-skills");
       const localApplied = get().appliedScripts.filter((entry) => !entry.id.startsWith("catalog:"));
       set({
-        skillCategories,
+        skillCategories: mergeSkillCategories(skillCategories),
         privateCloudSkills,
         appliedScripts: [...localApplied, ...backendScripts.map((entry) => ({ ...entry, id: `catalog:${entry.id}` }))],
       });
@@ -1933,7 +1938,7 @@ export const useStore = create<State>((set, get) => {
         skill_count: catalog.categories.reduce((total, category) => total + category.skills.length, 0),
       });
     } catch {
-      set({ skillCategories: [] });
+      set({ skillCategories: REPOSITORY_SKILL_CATEGORIES });
       trackEvent("skill_catalog_failed");
     }
   },
@@ -2833,6 +2838,25 @@ export const useStore = create<State>((set, get) => {
       category: entry.category,
       selector_kind: entry.selector.kind,
     });
+    if (entry.source === "repository" && entry.instructions) {
+      set((s) => ({
+        skillState: {
+          ...s.skillState,
+          [skillKey(s.agentId, entry.id)]: "installed",
+        },
+      }));
+      trackTiming("skill_apply_completed", startedAt, {
+        category: entry.category,
+        source: "repository",
+      });
+      return {
+        found: true,
+        slug: entry.id.replace(/^repository:/, ""),
+        title: entry.title,
+        kind: "domain",
+        selector: entry.selector.value,
+      };
+    }
     if (entry.selector.kind === "script") {
       const existing = get().appliedScripts.some((script) => script.id === entry.id);
       const appliedScripts = existing ? get().appliedScripts : [...get().appliedScripts, entry];
@@ -2964,7 +2988,9 @@ export const useStore = create<State>((set, get) => {
     const remoteOnly = get().conversations.find((conversation) => conversation.id === cid)?.executionTarget === "vps";
     if (remoteOnly) {
       const chip: UserCommandChip = { kind: "skill", title: entry.title, detail: target };
-      const prompt = `Use the "${entry.title}" skill for ${target} on the selected VPS only. Do not prepare, open, inspect, or change any local NextBrowser session. Use only skill instructions and browser tooling that are already available on the VPS; if the skill is missing there, report that without installing it.${entry.description ? `\n\nSkill description: ${entry.description}` : ""}`;
+      const prompt = entry.instructions
+        ? `Use the "${entry.title}" repository skill for ${target} on the selected VPS only. Do not prepare, open, inspect, or change any local NextBrowser session. Follow this SKILL.md exactly:\n\n${entry.instructions}`
+        : `Use the "${entry.title}" skill for ${target} on the selected VPS only. Do not prepare, open, inspect, or change any local NextBrowser session. Use only skill instructions and browser tooling that are already available on the VPS; if the skill is missing there, report that without installing it.${entry.description ? `\n\nSkill description: ${entry.description}` : ""}`;
       get().enqueue(prompt, chip, cid);
       return;
     }
@@ -3007,7 +3033,7 @@ export const useStore = create<State>((set, get) => {
       return;
     }
 
-    const md = await installedSkillMarkdown(ref);
+    const md = entry.instructions ?? await installedSkillMarkdown(ref);
 
     const chip: UserCommandChip = { kind: "skill", title: entry.title, detail: target };
     const prompt = skillAgentPrompt(


### PR DESCRIPTION
## Summary
- load public browser skills directly from `skills/` into the application catalog
- add a strict contribution manifest and acceptance-case validator
- add a GitHub issue form and contributor documentation
- include `999.md Car Search` as an end-to-end example
- merge repository skills with the existing backend catalog

## Contributor flow
1. Claim a skill issue.
2. Add `skills/<id>/SKILL.md`, `manifest.json`, and `tests/cases.json`.
3. Run `npm run validate:skills`.
4. Open a focused PR with test evidence.
5. Once merged and released, the skill appears in NextBrowser automatically.

## Verification
- `npm run validate:skills`
- `npm run build`
- `npm test` (243 tests)
- visually verified repository skill/category rendering in the local app

## Notes
The skill-creator quick validator could not run in this workspace because its Python environment lacks PyYAML; the repository validator covers the required frontmatter, naming, manifest, cases, and credential checks.