### PR TITLE
Add Makler car search skill

### DIFF
--- a/skills/makler-car-search/SKILL.md
+++ b/skills/makler-car-search/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: makler-car-search
+description: Search and extract relevant vehicle listings from makler.md with proxy verification, pagination, filtering, and canonical URL deduplication.
+---
+
+# Makler car search
+
+Use Clawbrowser to find vehicle listings on `makler.md` and return complete, relevant results.
+
+## Workflow
+
+1. Choose one descriptive profile name and start or reattach it. If the user requests a proxy country, pass the country during profile start and confirm verification succeeded before interacting with Makler. Do not repeatedly start an already verified profile.
+2. Open `https://makler.md` and resolve the vehicle search from the current page by role, label, visible text, or a stable selector. Treat captured `element_id` values as valid only for the current page state.
+3. Search for the requested make and model. Apply requested year, price, location, mileage, fuel, transmission, or other filters through the site's controls when available.
+4. Confirm the resulting page and active filters reflect the request before extraction. Wait for navigation or page settlement only when the page is still changing.
+5. Extract listing title, canonical URL, price, year, location, and any other fields the user requested. Prefer result-card containers; use matching listing anchors as a fallback when the card structure changes.
+6. Traverse result pagination or infinite scrolling until the final reachable results page, the requested limit, or a clearly reported blocker. Do not assume the first page is complete.
+7. Normalize relative links against `https://makler.md`, remove tracking parameters when possible, and deduplicate by canonical listing URL.
+8. Exclude parts, dismantling, wanted ads, rentals, and unrelated models unless the user explicitly asks for them. Open ambiguous listings when the result card is insufficient to classify them.
+9. Return a concise list with the requested fields and URLs. State how many result pages were inspected, how many unique listings matched, and any limitation that prevented a complete search.
+
+## Recovery
+
+- If an element is stale after navigation, take a new page state and resolve it again semantically; never retry an old element ID in a loop.
+- If the active tab detaches, list current tabs and continue in the Makler results tab instead of starting another profile.
+- If extraction returns no rows, verify the search URL and visible results, then retry once with a broader stable container such as listing links.
+- If proxy verification fails, stop before website interaction and ask whether to retry or continue without the requested proxy.

--- a/skills/makler-car-search/manifest.json
+++ b/skills/makler-car-search/manifest.json
@@ -1,0 +1,14 @@
+{
+  "id": "makler-car-search",
+  "name": "Makler Car Search",
+  "description": "Search, filter, paginate, and deduplicate vehicle listings on makler.md.",
+  "author": "nextbrowser-oss",
+  "domains": ["makler.md"],
+  "operations": ["search", "scrape", "paginate"],
+  "category": {
+    "id": "marketplaces",
+    "title": "Marketplaces",
+    "icon": "globe",
+    "order": 30
+  }
+}

--- a/skills/makler-car-search/tests/cases.json
+++ b/skills/makler-car-search/tests/cases.json
@@ -1,0 +1,14 @@
+[
+  {
+    "task": "Find every Daewoo Matiz car for sale on makler.md and include price, year, location, and URL.",
+    "expects": ["uses vehicle listings", "paginates to the end", "deduplicates canonical URLs", "excludes parts and wanted ads"]
+  },
+  {
+    "task": "Using a US proxy, find Mitsubishi Space Star cars from 2006 or earlier on makler.md.",
+    "expects": ["verifies the US proxy before interaction", "applies the year constraint", "reports pages inspected"]
+  },
+  {
+    "task": "Find BMW E60 cars below 5000 EUR on makler.md and recover if the saved result selector has changed.",
+    "expects": ["applies the price constraint", "resolves changed elements semantically", "returns unique relevant listings"]
+  }
+]

--- a/src/repositorySkills.test.ts
+++ b/src/repositorySkills.test.ts
@@ -4,11 +4,15 @@ import { mergeSkillCategories, repositorySkillCategories } from "./repositorySki
 describe("repository skills", () => {
   it("loads validated skills into the application catalog", () => {
     const categories = repositorySkillCategories();
-    const skill = categories.flatMap((category) => category.entries)
+    const entries = categories.flatMap((category) => category.entries);
+    const skill = entries
       .find((entry) => entry.id === "repository:999-car-search");
     expect(skill?.source).toBe("repository");
     expect(skill?.selector).toEqual({ kind: "domain", value: "999.md" });
     expect(skill?.instructions).toContain("# 999.md car search");
+    const makler = entries.find((entry) => entry.id === "repository:makler-car-search");
+    expect(makler?.selector).toEqual({ kind: "domain", value: "makler.md" });
+    expect(makler?.instructions).toContain("# Makler car search");
   });
 
   it("merges repository and backend skills in the same category", () => {
@@ -28,7 +32,9 @@ describe("repository skills", () => {
         categoryOrder: 30,
       }],
     }]);
-    expect(merged.find((category) => category.id === "marketplaces")?.entries.map((entry) => entry.id))
-      .toEqual(["backend", "repository:999-car-search"]);
+    const marketplaceIds = merged.find((category) => category.id === "marketplaces")?.entries.map((entry) => entry.id);
+    const repositoryIds = repositorySkillCategories()
+      .find((category) => category.id === "marketplaces")?.entries.map((entry) => entry.id);
+    expect(marketplaceIds).toEqual(["backend", ...repositoryIds ?? []]);
   });
 });


### PR DESCRIPTION
## Summary

Adds a repository-maintained browser skill for complete vehicle searches on makler.md. It covers proxy verification, resilient search controls, pagination, canonical URL deduplication, irrelevant-result filtering, and recovery from stale page state.

Also makes the repository catalog test scale beyond a single bundled skill.

## Acceptance cases

- Daewoo Matiz search with price, year, location, pagination, and deduplication
- Mitsubishi Space Star through a verified US proxy with a year constraint
- BMW E60 price-filtered search with stale-selector recovery

## Checks

- `npm run validate:skills` — passed (2 skills)
- `npm test -- --run` — passed (246 tests: 190 Vitest + 56 Node)
- `npm run build` — passed

## Notes

This PR is the positive validation fixture: it is expected to pass CI and is suitable for review and merge.