### PR TITLE
Test: reject an invalid repository skill

### DIFF
--- a/skills/invalid-skill-fixture/SKILL.md
+++ b/skills/invalid-skill-fixture/SKILL.md
@@ -1,0 +1,3 @@
+# Invalid validation fixture
+
+This intentionally incomplete file has no YAML frontmatter.

--- a/skills/invalid-skill-fixture/manifest.json
+++ b/skills/invalid-skill-fixture/manifest.json
@@ -1,0 +1,14 @@
+{
+  "id": "different-id",
+  "name": "Invalid Skill Fixture",
+  "description": "An intentionally invalid skill used to verify repository validation.",
+  "author": "nextbrowser-oss",
+  "domains": [],
+  "operations": ["teleport"],
+  "category": {
+    "id": "Invalid Category",
+    "title": "Validation fixtures",
+    "icon": "globe",
+    "order": 99
+  }
+}

--- a/skills/invalid-skill-fixture/tests/cases.json
+++ b/skills/invalid-skill-fixture/tests/cases.json
@@ -1,0 +1,6 @@
+[
+  {
+    "task": "This single case should be rejected.",
+    "expects": ["validation fails"]
+  }
+]


### PR DESCRIPTION
## Purpose

This is an intentionally invalid, non-mergeable pull request used to verify that repository skill validation fails clearly in CI. **Do not merge this PR.**

## Expected validation failures

The fixture intentionally contains:

- a manifest ID that does not match the directory
- no supported domain
- an unsupported `teleport` operation
- an invalid category ID
- no YAML frontmatter in `SKILL.md`
- an undersized instruction
- only one acceptance case instead of three

## Expected result

`npm run validate:skills` and therefore both CI build jobs must fail while listing the violations above. This PR should remain red and be closed after the validation behavior is confirmed.