### PR TITLE
Test: accept a valid repository skill

### DIFF
--- a/skills/example-product-search/SKILL.md
+++ b/skills/example-product-search/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: example-product-search
+description: Search and extract product listings from example.com with optional proxy verification, pagination, filtering, and canonical URL deduplication.
+---
+
+# Example product search
+
+Use Clawbrowser to search the product catalog on `example.com` and return complete, relevant results.
+
+1. Start or reattach one named profile. Verify any proxy country requested by the user before interacting with the website; do not restart a successfully verified profile.
+2. Resolve search and filter controls from the current page by role, label, text, or stable selector. Treat captured element IDs as short-lived hints.
+3. Apply the requested query and filters, then confirm the visible page reflects them before extraction.
+4. Extract title, canonical URL, price, availability, and any fields requested by the user.
+5. Traverse pagination or infinite scrolling until the final reachable page, requested limit, or a clearly reported blocker.
+6. Normalize URLs, remove tracking parameters where possible, deduplicate by canonical URL, and exclude irrelevant matches.
+7. If navigation makes an element stale, take a new page state and resolve it semantically. If the tab detaches, continue in the matching current tab instead of starting another profile.
+8. Return concise results with source URLs, pages inspected, unique match count, and any limitation that prevented completeness.

--- a/skills/example-product-search/manifest.json
+++ b/skills/example-product-search/manifest.json
@@ -1,0 +1,14 @@
+{
+  "id": "example-product-search",
+  "name": "Example Product Search",
+  "description": "Search, filter, paginate, and deduplicate products on example.com.",
+  "author": "nextbrowser-oss",
+  "domains": ["example.com"],
+  "operations": ["search", "scrape", "paginate"],
+  "category": {
+    "id": "marketplaces",
+    "title": "Marketplaces",
+    "icon": "globe",
+    "order": 30
+  }
+}

--- a/skills/example-product-search/tests/cases.json
+++ b/skills/example-product-search/tests/cases.json
@@ -1,0 +1,14 @@
+[
+  {
+    "task": "Find every matching product with its price and canonical URL.",
+    "expects": ["applies filters", "paginates to the end", "deduplicates canonical URLs"]
+  },
+  {
+    "task": "Run the product search through a verified US proxy.",
+    "expects": ["verifies the US proxy before interaction", "does not restart the verified profile"]
+  },
+  {
+    "task": "Recover when the previous result selector no longer matches.",
+    "expects": ["resolves controls semantically", "returns unique relevant products"]
+  }
+]


### PR DESCRIPTION
## Purpose

Positive stacked validation test for #185. This PR is not intended for merge.

## Expected CI behavior

1. `Validate repository skills` passes first.
2. macOS and Windows test/package jobs start only after validation.
3. The application catalog tests pass with a second repository skill.
4. Only one pull-request workflow run is created.

Close without merge after the behavior is confirmed.