### PR TITLE
Test: reject an invalid skill before packaging

### DIFF
--- a/skills/invalid-fast-fail/SKILL.md
+++ b/skills/invalid-fast-fail/SKILL.md
@@ -1,0 +1,3 @@
+# Invalid fast-fail fixture
+
+This intentionally invalid skill has no YAML frontmatter.

--- a/skills/invalid-fast-fail/manifest.json
+++ b/skills/invalid-fast-fail/manifest.json
@@ -1,0 +1,14 @@
+{
+  "id": "wrong-id",
+  "name": "Invalid Fast Fail",
+  "description": "Intentionally invalid validation fixture.",
+  "author": "nextbrowser-oss",
+  "domains": [],
+  "operations": ["teleport"],
+  "category": {
+    "id": "invalid category",
+    "title": "Invalid",
+    "icon": "globe",
+    "order": 99
+  }
+}

--- a/skills/invalid-fast-fail/tests/cases.json
+++ b/skills/invalid-fast-fail/tests/cases.json
@@ -1,0 +1,6 @@
+[
+  {
+    "task": "One case is intentionally insufficient.",
+    "expects": ["fast validation failure"]
+  }
+]


### PR DESCRIPTION
## Purpose

Negative stacked validation test for #185. This PR is intentionally invalid and must not be merged.

## Expected CI behavior

1. The single `Validate repository skills` job fails with actionable schema errors.
2. macOS and Windows test/package jobs remain skipped because they depend on validation.
3. No Electron dependencies or native modules are installed.
4. Only one pull-request workflow run is created.

Close without merge after the behavior is confirmed.