### PR TITLE
Support multiple repository skills in catalog tests

### DIFF
--- a/src/repositorySkills.test.ts
+++ b/src/repositorySkills.test.ts
@@ -28,7 +28,9 @@ describe("repository skills", () => {
         categoryOrder: 30,
       }],
     }]);
-    expect(merged.find((category) => category.id === "marketplaces")?.entries.map((entry) => entry.id))
-      .toEqual(["backend", "repository:999-car-search"]);
+    const marketplaceIds = merged.find((category) => category.id === "marketplaces")?.entries.map((entry) => entry.id);
+    const repositoryIds = repositorySkillCategories()
+      .find((category) => category.id === "marketplaces")?.entries.map((entry) => entry.id);
+    expect(marketplaceIds).toEqual(["backend", ...repositoryIds ?? []]);
   });
 });


### PR DESCRIPTION
## Summary

Removes the catalog test assumption that exactly one repository skill exists. The positive stacked validation PR exposed this when a second valid skill was added.

The assertion now compares merged repository entries dynamically, so future valid skill contributions do not require editing a hardcoded ID list.

## Validation

- confirmed by stacked positive PR #186 with two repository skills
- `npm test -- --run` passed

No test skills or fixtures are included.