### PR TITLE
Fix Windows profile launch and component update race

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -48,10 +48,19 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
   const [profileCountry, setProfileCountry] = useState("US");
   const [profileSaving, setProfileSaving] = useState(false);
   const [profileError, setProfileError] = useState<string | null>(null);
+  const [profileActionError, setProfileActionError] = useState<string | null>(null);
   const [profileGuideFocus, setProfileGuideFocus] = useState(false);
   const [logoutPending, setLogoutPending] = useState(false);
   const [logoutError, setLogoutError] = useState<string | null>(null);
   const profileCreateRequestRef = useRef<string | null>(null);
+
+  const runProfileAction = (label: string, action: () => Promise<void>) => {
+    setProfileActionError(null);
+    void action().catch((error: unknown) => {
+      const detail = error instanceof Error ? error.message.trim() : String(error ?? "").trim();
+      setProfileActionError(detail ? `${label} ${detail}` : label);
+    });
+  };
 
   const agentName = agentById(s.agentId).name;
   const ready = s.agentReady();
@@ -60,7 +69,7 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
   const defaultStatus = s.defaultSession?.status ?? "unknown";
   const defaultKnown = !!s.defaultSession?.session?.name || defaultStatus !== "unknown";
   const defaultRunning = defaultStatus === "running";
-  const defaultBusy = ["starting", "stopping", "rotating"].includes(defaultStatus);
+  const defaultBusy = s.nextctlUpdating || ["starting", "stopping", "rotating"].includes(defaultStatus);
   const defaultIdentity = s.profileIdentities.__default;
   const defaultSessionDuplicate = defaultRunning && Object.values(s.profileSessions).some((session) =>
     session.status === "running" && (
@@ -114,13 +123,15 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
       if (!profile) return;
       if (profile === "__default") {
         s.selectProfile(undefined);
-        if (!defaultRunning && !defaultBusy) void s.startDefaultSession();
+        if (!defaultRunning && !defaultBusy) {
+          runProfileAction("We couldn't start the default profile.", s.startDefaultSession);
+        }
         return;
       }
       s.selectProfile(profile);
       const status = s.statuses[profile] ?? s.profileSessions[profile]?.status ?? "unknown";
       if (status !== "running" && !["starting", "stopping", "rotating"].includes(status)) {
-        void s.startProfile(profile);
+        runProfileAction(`We couldn't start “${profile}”.`, () => s.startProfile(profile));
       }
     };
     window.addEventListener("nextbrowser:focus-profiles", focusProfiles);
@@ -443,8 +454,8 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
                 city={defaultIdentity?.city}
                 ip={defaultIdentity?.ip}
                 onSelect={() => s.selectProfile(undefined)}
-                onStart={() => s.startDefaultSession()}
-                onStop={() => s.stopDefaultSession()}
+                onStart={() => runProfileAction("We couldn't start the default profile.", s.startDefaultSession)}
+                onStop={() => runProfileAction("We couldn't stop the default profile.", s.stopDefaultSession)}
                 onLive={() => {
                   s.selectProfile(undefined);
                   s.setTab("live");
@@ -458,7 +469,7 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
             {profiles.map((p) => {
               const status = s.statuses[p.name] ?? "unknown";
               const running = status === "running";
-              const busy = ["starting", "stopping", "rotating"].includes(status);
+              const busy = s.nextctlUpdating || ["starting", "stopping", "rotating"].includes(status);
               const selected = s.selectedProfile === p.name;
               const manual = p.proxy_mode === "manual" && p.manual_proxy;
               const identity = s.profileIdentities[p.name];
@@ -478,8 +489,8 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
                   manualScheme={manual ? p.manual_proxy?.scheme : undefined}
                   manualTitle={manual ? `${p.manual_proxy?.host ?? ""}:${p.manual_proxy?.port ?? ""}` : undefined}
                   onSelect={() => s.selectProfile(selected ? undefined : p.name)}
-                  onStart={() => s.startProfile(p.name)}
-                  onStop={() => s.stopProfile(p.name)}
+                  onStart={() => runProfileAction(`We couldn't start “${p.name}”.`, () => s.startProfile(p.name))}
+                  onStop={() => runProfileAction(`We couldn't stop “${p.name}”.`, () => s.stopProfile(p.name))}
                   onLive={() => {
                     s.selectProfile(p.name);
                     s.setTab("live");
@@ -488,6 +499,9 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
                 />
               );
             })}
+            {profileActionError && (
+              <div className="error small profile-action-error" role="alert">{profileActionError}</div>
+            )}
           </div>
         </div>
       </nav>

--- a/src/store.ts
+++ b/src/store.ts
@@ -1179,9 +1179,25 @@ export const useStore = create<State>((set, get) => {
     if (!get().nextctlAvailable) return;
     if (get().nextctlUpdating) return;
     if (pendingTarget(get(), "vps")) return;
+    // `nextctl update` also refreshes the browser runtime and agent assets. Do
+    // not mutate either while a browser profile is running/transitioning or an
+    // agent turn is using them; the one-minute poll will retry once idle.
+    const browserSessionActive = [
+      get().defaultSession?.status,
+      ...Object.values(get().statuses),
+    ].some((status) => status != null && !["stopped", "unknown"].includes(status));
+    if (browserSessionActive || get().anyAgentRunning()) return;
     const state = await loadJson<NextctlUpdateState>(NEXTCTL_UPDATE_STATE_FILE, {});
     if (pendingTarget(get(), "vps")) return;
     const lastAutoCheckAt = Number(state.lastAutoCheckAt ?? 0);
+    // A fresh install has just resolved or downloaded nextctl during bootstrap.
+    // Treat that as the first successful check instead of immediately running
+    // `nextctl update`, which can race with the user's first profile launch and
+    // with Clawbrowser runtime installation (especially on Windows).
+    if (lastAutoCheckAt <= 0) {
+      await saveJson(NEXTCTL_UPDATE_STATE_FILE, { lastAutoCheckAt: now() });
+      return;
+    }
     if (lastAutoCheckAt > 0 && now() - lastAutoCheckAt < NEXTCTL_DAILY_UPDATE_MS) return;
     if (!await get().checkNextctlUpdate()) return;
     if (pendingTarget(get(), "vps")) return;
@@ -2007,6 +2023,7 @@ export const useStore = create<State>((set, get) => {
   startProfile: async (n) => {
     const startedAt = performance.now();
     trackEvent("profile_start_requested", { scope: "named" });
+    const previousStatus = get().statuses[n] ?? "stopped";
     set((s) => ({ statuses: { ...s.statuses, [n]: "starting" } }));
     try {
       await nextctlRunChecked(["start", "--profile", n, "--format", "json"]);
@@ -2015,6 +2032,11 @@ export const useStore = create<State>((set, get) => {
       if (identity) set((s) => ({ profileIdentities: { ...s.profileIdentities, [n]: identity } }));
       trackTiming("profile_start_completed", startedAt, { scope: "named", status: get().statuses[n] ?? "unknown" });
     } catch (error) {
+      // Never leave a failed launch looking active forever. Restore the last
+      // known state immediately; a later refresh can replace it with the
+      // authoritative nextctl status.
+      set((s) => ({ statuses: { ...s.statuses, [n]: previousStatus } }));
+      void get().loadProfiles();
       requestAccountSignIn(set, error);
       throw error;
     }

--- a/src/store.vps.test.ts
+++ b/src/store.vps.test.ts
@@ -399,3 +399,18 @@ describe("VPS execution target isolation", () => {
     expect(useStore.getState().activeConversation()?.vpsConnectionLabel).toBeUndefined();
   });
 });
+
+describe("local component and profile lifecycle", () => {
+  it("restores a profile status when launching it fails", async () => {
+    useStore.setState({ statuses: { work: "stopped" } });
+    bridge.invoke.mockResolvedValue({
+      code: 1,
+      stdout: "",
+      stderr: "browser runtime could not start",
+    });
+
+    await expect(useStore.getState().startProfile("work")).rejects.toThrow("browser runtime could not start");
+
+    expect(useStore.getState().statuses.work).toBe("stopped");
+  });
+});


### PR DESCRIPTION
## Summary

- avoid running a full nextctl/runtime update immediately after a fresh install
- defer background component updates while browser profiles or agent turns are active
- disable profile launch controls while a component update is running
- restore the previous profile status after a failed launch instead of leaving it stuck on `starting`
- surface the underlying profile launch error in the sidebar instead of triggering only the generic global banner

## Verification

- `npm test` — 191 tests passed
- `npm run build` — passed