### PR TITLE
Polish runtime setup and chat recovery UX

### DIFF
--- a/electron/dasbrowser-runtime.cjs
+++ b/electron/dasbrowser-runtime.cjs
@@ -57,9 +57,22 @@ function adaptDasbrowserArgs(args, executable) {
   return adapted;
 }
 
+function dasbrowserAppCopyOptions() {
+  return {
+    recursive: true,
+    preserveTimestamps: true,
+    // Chromium app bundles use relative framework symlinks. Node resolves
+    // symlink targets by default while copying, which would permanently point
+    // the installed app at the temporary mounted DMG and break its signature
+    // as soon as the image is detached.
+    verbatimSymlinks: true,
+  };
+}
+
 module.exports = {
   DASBROWSER_DOWNLOADS,
   adaptDasbrowserArgs,
+  dasbrowserAppCopyOptions,
   dasbrowserRuntimeCandidates,
   requestedBrowserRuntime,
   resolveDasbrowserRuntime,

--- a/electron/dasbrowser-runtime.test.cjs
+++ b/electron/dasbrowser-runtime.test.cjs
@@ -5,6 +5,7 @@ const path = require("node:path");
 const test = require("node:test");
 const {
   adaptDasbrowserArgs,
+  dasbrowserAppCopyOptions,
   requestedBrowserRuntime,
   resolveDasbrowserRuntime,
 } = require("./dasbrowser-runtime.cjs");
@@ -25,4 +26,20 @@ test("adapts the app toolset to nextctl's chromium CDP runtime", () => {
   assert.deepEqual(adaptDasbrowserArgs(args, "/browser"), [
     "start", "--profile", "work", "--runtime", "chromium", "--format", "json", "--runtime-bin", "/browser",
   ]);
+});
+
+test("copies macOS app bundles without resolving their relative framework symlinks", async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "nextbrowser-dasbrowser-copy-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const source = path.join(root, "source", "Dasbrowser.app", "Contents", "Frameworks", "Browser.framework");
+  const target = path.join(root, "target", "Dasbrowser.app");
+  fs.mkdirSync(path.join(source, "Versions", "1"), { recursive: true });
+  fs.symlinkSync("1", path.join(source, "Versions", "Current"));
+
+  await fs.promises.cp(path.join(root, "source", "Dasbrowser.app"), target, dasbrowserAppCopyOptions());
+
+  assert.equal(
+    fs.readlinkSync(path.join(target, "Contents", "Frameworks", "Browser.framework", "Versions", "Current")),
+    "1",
+  );
 });

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -32,6 +32,7 @@ const { browserInstallArgs, requiresBrowserRuntime, resolveBrowserRuntime } = re
 const {
   DASBROWSER_DOWNLOADS,
   adaptDasbrowserArgs,
+  dasbrowserAppCopyOptions,
   requestedBrowserRuntime,
   resolveDasbrowserRuntime,
 } = require("./dasbrowser-runtime.cjs");
@@ -58,6 +59,7 @@ const DEEP_LINK_PROTOCOL = "nextbrowser";
 let appUpdateStatus = { status: "idle" };
 let appUpdateTimer = null;
 let nextctlInstallStatus = { status: "idle" };
+let browserRuntimeInstallStatus = { status: "idle" };
 let nextctlInstallPromise = null;
 let browserInstallPromise = null;
 let dasbrowserInstallPromise = null;
@@ -227,6 +229,10 @@ async function nextctlHasSkill(binary) {
 function setNextctlInstallStatus(status, patch = {}) {
   nextctlInstallStatus = { status, ...patch, updatedAt: Date.now() };
   emit("nextctl:install", nextctlInstallStatus);
+}
+function setBrowserRuntimeInstallStatus(runtime, status, patch = {}) {
+  browserRuntimeInstallStatus = { runtime, status, ...patch, updatedAt: Date.now() };
+  emit("browser-runtime:install", browserRuntimeInstallStatus);
 }
 function legacyManagedNextctlRoot() { return path.join(app.getPath("userData"), "managed-nextctl"); }
 function managedNextctlRoot() {
@@ -422,6 +428,7 @@ async function ensureClawbrowserRuntime(nextctlBin) {
   if (browserInstallPromise) return browserInstallPromise;
 
   browserInstallPromise = (async () => {
+    setBrowserRuntimeInstallStatus("clawbrowser", "downloading");
     const runtimeRoot = nextbrowserRuntimeRoot();
     await Promise.all([
       "data", "cache", "installer-bin", "agent-plugins",
@@ -432,8 +439,12 @@ async function ensureClawbrowserRuntime(nextctlBin) {
       const detail = (result.stderr || result.stdout || "Clawbrowser installation failed").trim();
       throw new Error(detail);
     }
+    setBrowserRuntimeInstallStatus("clawbrowser", "ready");
     return installed;
-  })().finally(() => {
+  })().catch((error) => {
+    setBrowserRuntimeInstallStatus("clawbrowser", "failed");
+    throw error;
+  }).finally(() => {
     browserInstallPromise = null;
   });
   return browserInstallPromise;
@@ -477,11 +488,13 @@ async function ensureDasbrowserRuntime() {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "nextbrowser-dasbrowser-"));
     try {
       const url = await officialDasbrowserDownloadUrl();
+      setBrowserRuntimeInstallStatus("dasbrowser", "downloading");
       if (process.platform === "darwin") {
         const image = path.join(tempDir, "dasbrowser.dmg");
         const mount = path.join(tempDir, "mount");
         await fs.mkdir(mount, { recursive: true });
         await downloadFile(url, image);
+        setBrowserRuntimeInstallStatus("dasbrowser", "installing");
         const attached = await run("hdiutil", ["attach", "-readonly", "-nobrowse", "-mountpoint", mount, image], {}, { timeoutMs: 120_000 });
         if (attached.code !== 0) throw new Error((attached.stderr || attached.stdout || "Could not mount DasBrowser installer.").trim());
         try {
@@ -489,13 +502,19 @@ async function ensureDasbrowserRuntime() {
           const target = path.join(nextbrowserRuntimeRoot(), "data", "Dasbrowser.app");
           await fs.mkdir(path.dirname(target), { recursive: true });
           await fs.rm(target, { recursive: true, force: true });
-          await fs.cp(source, target, { recursive: true, preserveTimestamps: true });
+          await fs.cp(source, target, dasbrowserAppCopyOptions());
+          const signature = await run("codesign", ["--verify", "--deep", "--strict", target], {}, { timeoutMs: 120_000 });
+          if (signature.code !== 0) {
+            await fs.rm(target, { recursive: true, force: true });
+            throw new Error("The downloaded DasBrowser app failed macOS signature verification.");
+          }
         } finally {
           await run("hdiutil", ["detach", mount, "-force"], {}, { timeoutMs: 30_000 }).catch(() => undefined);
         }
       } else {
         const installer = path.join(tempDir, "DasbrowserSetup.exe");
         await downloadFile(url, installer);
+        setBrowserRuntimeInstallStatus("dasbrowser", "installing");
         const installed = await run(installer, ["--silent", "--install"], {}, { timeoutMs: 10 * 60 * 1000 });
         if (installed.code !== 0) throw new Error((installed.stderr || installed.stdout || "DasBrowser installation failed.").trim());
         for (let attempt = 0; attempt < 30 && !resolveDasbrowserRuntime(options); attempt += 1) {
@@ -504,11 +523,15 @@ async function ensureDasbrowserRuntime() {
       }
       const executable = resolveDasbrowserRuntime(options);
       if (!executable) throw new Error("DasBrowser installed, but its browser executable could not be found.");
+      setBrowserRuntimeInstallStatus("dasbrowser", "ready");
       return executable;
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
     }
-  })().finally(() => {
+  })().catch((error) => {
+    setBrowserRuntimeInstallStatus("dasbrowser", "failed");
+    throw error;
+  }).finally(() => {
     dasbrowserInstallPromise = null;
   });
   return dasbrowserInstallPromise;
@@ -702,6 +725,7 @@ async function invokeCommand(command, args = {}, sender) {
     }
     case "nextctl_resolve": return await resolveOrInstallNextctl();
     case "nextctl_install_status": return nextctlInstallStatus;
+    case "browser_runtime_install_status": return browserRuntimeInstallStatus;
     case "nextctl_run": {
       return executeNextctl(args.args || [], {
         extraEnv: args.extraEnv || {},

--- a/electron/project-sync.cjs
+++ b/electron/project-sync.cjs
@@ -3,7 +3,7 @@ const { loadBackendConfig } = require("./proxy-traffic.cjs");
 const REQUEST_TIMEOUT_MS = 30_000;
 // Workspaces and projects live in the same service as the cloud skill registry.
 // Keep the same override and default used by nextctl's skill commands.
-const DEFAULT_SKILL_SERVICE_URL = "https://51-15-201-29.sslip.io";
+const DEFAULT_SKILL_SERVICE_URL = "https://core.nextbrowser.com";
 
 function entityBackendURL(env = process.env) {
   const raw = String(env.CLAWCTL_SKILL_SERVICE || DEFAULT_SKILL_SERVICE_URL).trim();

--- a/electron/project-sync.test.cjs
+++ b/electron/project-sync.test.cjs
@@ -28,5 +28,5 @@ test("syncs projects with the private backend key", async (t) => {
 });
 
 test("uses the same default backend as cloud skills", () => {
-  assert.equal(entityBackendURL({}), "https://51-15-201-29.sslip.io");
+  assert.equal(entityBackendURL({}), "https://core.nextbrowser.com");
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "nextbrowser",
       "version": "0.1.13",
+      "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",
@@ -71,9 +72,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -273,9 +274,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1672,16 +1673,16 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-from": {
@@ -2005,15 +2006,15 @@
       "license": "MIT"
     },
     "node_modules/concurrently": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.3.tgz",
-      "integrity": "sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.4.tgz",
+      "integrity": "sha512-TZ0CEhyzvFjgtAvHTusDMgj7wNdihCh7LLLrzdUOXIhdlnL2JBBGA9eJxR24rtqgmdjh3OA3hrN1rCHj6HM8qA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.4",
+        "shell-quote": "1.9.0",
         "supports-color": "8.1.1",
         "tree-kill": "1.2.2",
         "yargs": "17.7.2"
@@ -2268,9 +2269,9 @@
       "license": "MIT"
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2719,9 +2720,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -2771,9 +2772,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2972,9 +2973,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3461,9 +3462,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -4884,9 +4885,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -5016,9 +5017,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5282,9 +5283,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -5302,7 +5303,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5846,9 +5847,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6071,9 +6072,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
-      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -6289,9 +6290,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "optional": true,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ import {
   previousAppTab,
   recordPreviousAppTab,
 } from "./lib/appNavigation";
-import { errorReference, internalError } from "./lib/userFacingError";
+import { errorReference } from "./lib/userFacingError";
 import { invoke, listen } from "./electronBridge";
 import { agentById } from "./agents";
 import { releaseDownloadUrl } from "./lib/releaseDownload";
@@ -48,6 +48,35 @@ interface AppUpdateStatus {
   message?: string;
 }
 
+interface BrowserRuntimeInstallStatus {
+  runtime?: "clawbrowser" | "dasbrowser";
+  status?: "idle" | "downloading" | "installing" | "ready" | "failed";
+}
+
+const APP_UPDATE_ERROR = "We couldn't update NextBrowser. Please retry again.";
+
+function BrowserRuntimeInstallModal({ status }: { status: BrowserRuntimeInstallStatus }) {
+  const name = status.runtime === "dasbrowser" ? "DasBrowser" : "ClawBrowser";
+  const installing = status.status === "installing";
+  return (
+    <div className="browser-install-overlay" role="status" aria-live="polite">
+      <div className="modal-card browser-install-modal" aria-labelledby="browser-install-title">
+        <div className="browser-install-mark"><Spinner size={22} /></div>
+        <div className="browser-install-copy">
+          <strong id="browser-install-title">{installing ? `Installing ${name}` : `Downloading ${name}`}</strong>
+          <p className="muted small">
+            {installing
+              ? "Finishing the browser setup. This may take a moment."
+              : `Preparing ${name} for its first profile. The download time depends on your connection.`}
+          </p>
+        </div>
+        <div className="browser-install-progress" aria-hidden="true"><span /></div>
+        <p className="muted browser-install-note">Keep NextBrowser open until setup is complete.</p>
+      </div>
+    </div>
+  );
+}
+
 // macOS in-place auto-update needs a signed + notarized build (Squirrel.Mac
 // rejects unsigned updates). Until signing lands we still detect and surface
 // the new version, but send users to the release page to update manually.
@@ -66,7 +95,7 @@ function updateLabel(status?: AppUpdateStatus | null): string {
   if (status.status === "not-available") return "Up to date";
   if (status.status === "checking") return "Checking...";
   if (status.status === "disabled") return "Updates unavailable in this build";
-  if (status.status === "error") return internalError("We couldn't update NextBrowser.", "APP_UPDATE_FAILED");
+  if (status.status === "error") return APP_UPDATE_ERROR;
   return "Check for updates";
 }
 
@@ -230,8 +259,6 @@ function SettingsModal({
   const authorizeAgent = useStore((s) => s.authorizeAgent);
   const loginAgent = useStore((s) => s.loginAgent);
   const logoutAgent = useStore((s) => s.logoutAgent);
-  const terminalChat = useStore((s) => s.terminalChat);
-  const setTerminalChat = useStore((s) => s.setTerminalChat);
   const profiles = useStore((s) => {
     const defaultKnown = !!s.defaultSession?.session?.name || (s.defaultSession?.status ?? "unknown") !== "unknown";
     const hasListedDefault = s.profiles.some((profile) => profile.name === "default");
@@ -387,25 +414,6 @@ function SettingsModal({
               </div>
             )}
           </div>
-          <div className="settings-experiment-row">
-            <span className="settings-feature-icon">
-              <Icon name="terminal" size={17} />
-            </span>
-            <span className="settings-feature-copy">
-              <strong>Terminal chat <span className="experimental-pill">Experimental</span></strong>
-              <span className="muted small">Switch between the regular UI and a persistent agent terminal, automatically continuing with recent context.</span>
-            </span>
-            <button
-              type="button"
-              className={"settings-switch" + (terminalChat ? " is-on" : "")}
-              role="switch"
-              aria-checked={terminalChat}
-              aria-label="Terminal chat"
-              onClick={() => setTerminalChat(!terminalChat)}
-            >
-              <span />
-            </button>
-          </div>
           <button
             className="settings-feature-link"
             onClick={() => {
@@ -519,6 +527,7 @@ export function App() {
   const [appUpdate, setAppUpdate] = useState<AppUpdateStatus>({ status: "idle" });
   const [updatePromptDismissed, setUpdatePromptDismissed] = useState(false);
   const [unexpectedError, setUnexpectedError] = useState<{ reference: string; detail: string }>();
+  const [browserRuntimeInstall, setBrowserRuntimeInstall] = useState<BrowserRuntimeInstallStatus>();
   const preview = getPreviewMode();
   const checking = useStore((s) => s.checking);
   const tab = useStore((s) => s.tab);
@@ -565,6 +574,22 @@ export function App() {
   }, []);
 
   useEffect(() => {
+    const applyStatus = (status: BrowserRuntimeInstallStatus) => {
+      if (status.status === "downloading" || status.status === "installing") {
+        setBrowserRuntimeInstall(status);
+      } else {
+        setBrowserRuntimeInstall((current) => current?.runtime === status.runtime ? undefined : current);
+      }
+    };
+    void invoke<BrowserRuntimeInstallStatus>("browser_runtime_install_status").then(applyStatus).catch(() => undefined);
+    let cleanup: (() => void) | undefined;
+    void listen<BrowserRuntimeInstallStatus>("browser-runtime:install", (event) => applyStatus(event.payload))
+      .then((off) => { cleanup = off; })
+      .catch(() => undefined);
+    return () => cleanup?.();
+  }, []);
+
+  useEffect(() => {
     if (!unexpectedError) return;
     const timer = window.setTimeout(() => setUnexpectedError(undefined), 8_000);
     return () => window.clearTimeout(timer);
@@ -572,17 +597,17 @@ export function App() {
 
   const checkAppUpdate = () => {
     void invoke<AppUpdateStatus>("app_check_for_update").then(setAppUpdate).catch(() => {
-      setAppUpdate({ status: "error", message: internalError("We couldn't check for updates.", "APP_UPDATE_CHECK_FAILED") });
+      setAppUpdate({ status: "error", message: APP_UPDATE_ERROR });
     });
   };
   const downloadAppUpdate = () => {
     void invoke<AppUpdateStatus>("app_download_update").then(setAppUpdate).catch(() => {
-      setAppUpdate({ status: "error", message: internalError("We couldn't download the update.", "APP_UPDATE_DOWNLOAD_FAILED") });
+      setAppUpdate({ status: "error", message: APP_UPDATE_ERROR });
     });
   };
   const installAppUpdate = () => {
     void invoke<boolean>("app_install_update").catch(() => {
-      setAppUpdate({ status: "error", message: internalError("We couldn't install the update.", "APP_UPDATE_INSTALL_FAILED") });
+      setAppUpdate({ status: "error", message: APP_UPDATE_ERROR });
     });
   };
   const openLatestRelease = async () => {
@@ -956,6 +981,7 @@ export function App() {
       {!checking && !agentReady && <AgentConnectionGate />}
       {showOnboarding && agentReady && !workspaceSetupRequired && <OnboardingView />}
       {!checking && agentReady && workspaceSetupRequired && <WorkspaceSetupGate />}
+      {browserRuntimeInstall && <BrowserRuntimeInstallModal status={browserRuntimeInstall} />}
       {unexpectedError && <GlobalErrorNotice error={unexpectedError} onClose={() => setUnexpectedError(undefined)} />}
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,7 @@ import { WorkspaceSetupGate } from "./components/WorkspaceSetupGate";
 import { AgentInstallLink } from "./components/AgentInstallLink";
 
 const TABS: { id: AppTab; label: string; icon?: string }[] = [
-  { id: "chat", label: "Project" },
+  { id: "chat", label: "Project", icon: "bubble.left.and.bubble.right.fill" },
   { id: "live", label: "Live", icon: "video.fill" },
 ];
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -821,7 +821,8 @@ export function App() {
     const onDown = (e: MouseEvent) => {
       dragging = true;
       startX = e.clientX;
-      startW = sidebarWidth;
+      startW = useStore.getState().sidebarWidth;
+      e.preventDefault();
     };
     handle?.addEventListener("mousedown", onDown);
     window.addEventListener("mousemove", onMove);
@@ -831,7 +832,7 @@ export function App() {
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
     };
-  }, [sidebarCollapsed, sidebarWidth, setSidebarWidth]);
+  }, [sidebarCollapsed, setSidebarWidth]);
 
     if (checking && preview !== "login" && preview !== "main" && preview !== "onboarding") {
     return (

--- a/src/components/AgentTerminal.tsx
+++ b/src/components/AgentTerminal.tsx
@@ -4,6 +4,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
 import { invoke, listen } from "../electronBridge";
 import { Icon, Spinner } from "./Icon";
+import { terminalInputWithDeferredContext } from "../lib/contextHandoff";
 
 interface AgentTerminalProps {
   agentId: string;
@@ -98,11 +99,14 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
   const onProfileStartedRef = useRef(onProfileStarted);
   const onProfileStoppedRef = useRef(onProfileStopped);
   const lastTerminalHandoffRef = useRef("");
+  const pendingHandoffRef = useRef(pendingHandoff);
+  const userInputSinceChatHandoffRef = useRef(false);
   onContinueInChatRef.current = onContinueInChat;
   onHandoffConsumedRef.current = onHandoffConsumed;
   onChatHandoffConsumedRef.current = onChatHandoffConsumed;
   onProfileStartedRef.current = onProfileStarted;
   onProfileStoppedRef.current = onProfileStopped;
+  pendingHandoffRef.current = pendingHandoff;
 
   const transcript = () => {
     const terminal = terminalRef.current;
@@ -126,6 +130,7 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
     setStatus("starting");
     setError(undefined);
     lastTerminalHandoffRef.current = "";
+    userInputSinceChatHandoffRef.current = false;
     let disposed = false;
     let removeData: (() => void) | undefined;
     let removeExit: (() => void) | undefined;
@@ -208,7 +213,18 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
     });
     const input = terminal.onData((data) => {
       const id = terminalIdRef.current;
-      if (id) void invoke("terminal_input", { id, data });
+      if (!id) return;
+      const pending = pendingHandoffRef.current;
+      const deferred = terminalInputWithDeferredContext(pending?.text, data);
+      if (pending && deferred.consumed) {
+        pendingHandoffRef.current = undefined;
+        userInputSinceChatHandoffRef.current = true;
+        onHandoffConsumedRef.current(pending.id);
+        void invoke("terminal_input", { id, data: deferred.data });
+        return;
+      }
+      if (deferred.userInput) userInputSinceChatHandoffRef.current = true;
+      void invoke("terminal_input", { id, data });
     });
 
     void (async () => {
@@ -276,23 +292,18 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
   }, [agentId, conversationId, workingDir, restartNonce]);
 
   useEffect(() => {
-    const id = terminalIdRef.current;
-    if (!pendingHandoff || !id || status !== "running") return;
-    // Paste the complete multiline handoff, then submit it once so switching
-    // the Settings toggle continues the task without another user action.
-    void invoke("terminal_input", { id, data: `\x1b[200~${pendingHandoff.text}\x1b[201~\r` });
-    terminalRef.current?.focus();
-    onHandoffConsumedRef.current(pendingHandoff.id);
-  }, [pendingHandoff?.id, status]);
-
-  useEffect(() => {
     if (!handoffToChatRequest || status !== "running") return;
+    if (!userInputSinceChatHandoffRef.current) {
+      onChatHandoffConsumedRef.current(handoffToChatRequest);
+      return;
+    }
     const value = transcript();
     const fingerprint = handoffFingerprint(value);
     if (value && fingerprint !== lastTerminalHandoffRef.current) {
       lastTerminalHandoffRef.current = fingerprint;
       onContinueInChatRef.current(value);
     }
+    userInputSinceChatHandoffRef.current = false;
     onChatHandoffConsumedRef.current(handoffToChatRequest);
   }, [handoffToChatRequest, status]);
 

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -29,7 +29,7 @@ import {
   workflowDistillationPrompt,
   type DistilledWorkflow,
 } from "../lib/workflowDistillation";
-import { chatToTerminalHandoff, terminalToChatHandoff } from "../lib/contextHandoff";
+import { chatPromptWithDeferredContext, chatToTerminalHandoff, terminalToChatHandoff } from "../lib/contextHandoff";
 import { browserProfileContext } from "../lib/browserProfileContext";
 
 async function authorWorkflowWithAgent(agent: AgentSpec, workingDir: string, fallback: DistilledWorkflow): Promise<DistilledWorkflow | undefined> {
@@ -114,6 +114,7 @@ export function ChatView() {
   const [terminalMounted, setTerminalMounted] = useState(s.terminalChat);
   const [terminalHandoff, setTerminalHandoff] = useState<{ id: string; text: string }>();
   const [terminalToChatRequest, setTerminalToChatRequest] = useState<string>();
+  const [pendingTerminalContext, setPendingTerminalContext] = useState<{ conversationId: string; text: string }>();
 
   useEffect(() => {
     const openProjectCreator = () => {
@@ -128,19 +129,24 @@ export function ChatView() {
   const chatMessagesSharedWithTerminal = useRef(new Map<string, number>());
   const bottomRef = useRef<HTMLDivElement>(null);
   const composerRef = useRef<HTMLTextAreaElement>(null);
+  const conversationKey = `${agentId}:${conv?.id ?? "new"}`;
+
+  useEffect(() => {
+    setTerminalHandoff(undefined);
+    setTerminalToChatRequest(undefined);
+    setPendingTerminalContext(undefined);
+  }, [conv?.id]);
 
   useEffect(() => {
     const wasTerminalChat = previousTerminalChat.current;
     previousTerminalChat.current = s.terminalChat;
     if (s.terminalChat) {
       setTerminalMounted(true);
-      const conversationKey = `${agentId}:${conv?.id ?? "new"}`;
       const sharedCount = chatMessagesSharedWithTerminal.current.get(conversationKey) ?? 0;
       if (!wasTerminalChat && messages.length > sharedCount) {
         // Only send messages created since the previous handoff. Replaying the
         // whole conversation can make an agent execute an already-finished task.
         setTerminalHandoff({ id: uid(), text: chatToTerminalHandoff(messages.slice(sharedCount), s.selectedProfile) });
-        chatMessagesSharedWithTerminal.current.set(conversationKey, messages.length);
       }
       return;
     }
@@ -172,9 +178,15 @@ export function ChatView() {
   const send = () => {
     const t = draft.trim();
     if (!t && attachments.length === 0) return;
+    const visiblePrompt = t || "Please inspect the attached file(s).";
+    const deferredContext = pendingTerminalContext && pendingTerminalContext.conversationId === conv?.id
+      ? pendingTerminalContext.text
+      : undefined;
+    const agentPrompt = chatPromptWithDeferredContext(deferredContext, visiblePrompt);
     setDraft("");
     setGuideDraftLoaded(false);
-    s.enqueue(t || "Please inspect the attached file(s).", undefined, undefined, attachments);
+    setPendingTerminalContext(undefined);
+    s.enqueue(visiblePrompt, undefined, undefined, attachments, agentPrompt);
     setAttachments([]);
   };
 
@@ -365,13 +377,14 @@ export function ChatView() {
               savingWorkflow={preparingWorkflowId === "terminal"}
               pendingHandoff={terminalHandoff}
               handoffToChatRequest={terminalToChatRequest}
-              onHandoffConsumed={(id) => setTerminalHandoff((current) => current?.id === id ? undefined : current)}
+              onHandoffConsumed={(id) => {
+                setTerminalHandoff((current) => current?.id === id ? undefined : current);
+                chatMessagesSharedWithTerminal.current.set(conversationKey, messages.length);
+              }}
               onChatHandoffConsumed={(id) => setTerminalToChatRequest((current) => current === id ? undefined : current)}
               onContinueInChat={(transcript) => {
                 const handoff = terminalToChatHandoff(transcript, s.selectedProfile);
-                setDraft("");
-                setGuideDraftLoaded(false);
-                s.enqueue(handoff);
+                if (conv?.id) setPendingTerminalContext({ conversationId: conv.id, text: handoff });
               }}
               onSaveWorkflow={(transcript) => {
                 const answer = {

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -303,15 +303,6 @@ export function ChatView() {
           )}
           <div className="chat-mode-toggle" role="group" aria-label="Project chat mode">
             <button
-              className={!s.terminalChat ? "active" : ""}
-              aria-pressed={!s.terminalChat}
-              title="Open regular chat"
-              onClick={() => s.setTerminalChat(false)}
-            >
-              <Icon name="bubble.left.and.bubble.right.fill" size={12} />
-              Chat
-            </button>
-            <button
               className={s.terminalChat ? "active" : ""}
               aria-pressed={s.terminalChat}
               title="Open terminal chat"
@@ -319,6 +310,15 @@ export function ChatView() {
             >
               <Icon name="terminal" size={12} />
               Terminal
+            </button>
+            <button
+              className={!s.terminalChat ? "active" : ""}
+              aria-pressed={!s.terminalChat}
+              title="Open regular chat"
+              onClick={() => s.setTerminalChat(false)}
+            >
+              <Icon name="bubble.left.and.bubble.right.fill" size={12} />
+              Chat
             </button>
           </div>
           {!remoteOnly && s.selectedProfile && (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -60,8 +60,9 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
   const [workspaceName, setWorkspaceName] = useState("");
   const [workspaceSaving, setWorkspaceSaving] = useState(false);
   const [workspaceError, setWorkspaceError] = useState<string | null>(null);
-  const [chatsOpen, setChatsOpen] = useState(true);
-  const [profilesOpen, setProfilesOpen] = useState(true);
+  const [openWorkspaceSection, setOpenWorkspaceSection] = useState<"projects" | "profiles">("projects");
+  const chatsOpen = openWorkspaceSection === "projects";
+  const profilesOpen = openWorkspaceSection === "profiles";
   const [dragOverProfileName, setDragOverProfileName] = useState<string | null>(null);
   const [profileGuideFocus, setProfileGuideFocus] = useState(false);
   const [logoutPending, setLogoutPending] = useState(false);
@@ -527,10 +528,10 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
           <div className="profile-list workspace-content">
             <section className="workspace-section workspace-chats">
               <div className="workspace-section-head">
-                <button className="workspace-section-toggle" onClick={() => setChatsOpen((open) => !open)} aria-expanded={chatsOpen} aria-label={chatsOpen ? "Collapse chats" : "Expand chats"}>
+                <button className="workspace-section-toggle" onClick={() => setOpenWorkspaceSection(chatsOpen ? "profiles" : "projects")} aria-expanded={chatsOpen} aria-label={chatsOpen ? "Collapse projects" : "Expand projects"}>
                   <Icon name="chevron.right" size={10} className={chatsOpen ? "section-chevron open" : "section-chevron"} />
                   <Icon name="bubble.left.and.bubble.right.fill" size={12} />
-                  <span>Chats</span>
+                  <span>Projects</span>
                   <span className="workspace-count">{projects.length}</span>
                 </button>
                 <span className="spacer" />
@@ -575,7 +576,7 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
 
             <section className="workspace-section workspace-profiles">
               <div className="workspace-section-head">
-                <button className="workspace-section-toggle" onClick={() => setProfilesOpen((open) => !open)} aria-expanded={profilesOpen} aria-label={profilesOpen ? "Collapse profiles" : "Expand profiles"}>
+                <button className="workspace-section-toggle" onClick={() => setOpenWorkspaceSection(profilesOpen ? "projects" : "profiles")} aria-expanded={profilesOpen} aria-label={profilesOpen ? "Collapse profiles" : "Expand profiles"}>
                   <Icon name="chevron.right" size={10} className={profilesOpen ? "section-chevron open" : "section-chevron"} />
                   <Icon name="folder.fill" size={12} />
                   <span>Profiles</span>
@@ -784,21 +785,27 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
                 <span><strong>DasBrowser</strong><small>Private multi-account browser</small></span>
               </label>
             </fieldset>
-            <button
-              type="button"
-              className="profile-vps-option"
-              onClick={() => {
-                setCreateProfileOpen(false);
-                setVPSSetupOpen(true);
-              }}
-            >
-              <Icon name="terminal" size={15} />
-              <span>
-                <strong>Use VPS</strong>
-                <small>Set up this project on a remote server instead</small>
-              </span>
-              <Icon name="chevron.right" size={12} className="muted" />
-            </button>
+            <section className="profile-remote-section" aria-label="Remote execution">
+              <div className="profile-remote-heading">
+                <span>Remote execution</span>
+                <small>Optional</small>
+              </div>
+              <button
+                type="button"
+                className="profile-vps-option"
+                onClick={() => {
+                  setCreateProfileOpen(false);
+                  setVPSSetupOpen(true);
+                }}
+              >
+                <span className="profile-vps-icon"><Icon name="terminal" size={15} /></span>
+                <span>
+                  <strong>Use VPS</strong>
+                  <small>Set up this project on a remote server</small>
+                </span>
+                <Icon name="chevron.right" size={12} className="muted" />
+              </button>
+            </section>
             {profileError && <div className="error small profile-create-error">{profileError}</div>}
             <div className="modal-actions">
               <button type="button" className="secondary" onClick={closeProfileCreator}>

--- a/src/lib/contextHandoff.test.ts
+++ b/src/lib/contextHandoff.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { chatToTerminalHandoff, terminalToChatHandoff } from "./contextHandoff";
+import {
+  chatPromptWithDeferredContext,
+  chatToTerminalHandoff,
+  terminalInputWithDeferredContext,
+  terminalToChatHandoff,
+} from "./contextHandoff";
 
 describe("chat context handoff", () => {
   it("keeps recent terminal context and active profile", () => {
@@ -48,5 +53,29 @@ describe("chat context handoff", () => {
     expect(result).toContain("Find Matiz under 3000 EUR");
     expect(result).not.toContain("Technical fast path");
     expect(result).not.toContain("Use my local browser skill");
+  });
+
+  it("attaches terminal context only when a new chat message is sent", () => {
+    expect(chatPromptWithDeferredContext(undefined, "Continue")).toBeUndefined();
+    expect(chatPromptWithDeferredContext("Recent terminal context", "Continue")).toBe(
+      "Recent terminal context\n\nNew user message:\nContinue",
+    );
+  });
+
+  it("does not inject chat context on terminal navigation keys", () => {
+    expect(terminalInputWithDeferredContext("Recent chat context", "\u001b[A")).toEqual({
+      data: "\u001b[A",
+      consumed: false,
+      userInput: false,
+    });
+  });
+
+  it("prepends chat context to the first terminal message without submitting it", () => {
+    const result = terminalInputWithDeferredContext("Recent chat context", "H");
+    expect(result).toMatchObject({ consumed: true, userInput: true });
+    expect(result.data).toContain("Recent chat context");
+    expect(result.data).toContain("New user message:\n");
+    expect(result.data.endsWith("H")).toBe(true);
+    expect(result.data.endsWith("\r")).toBe(false);
   });
 });

--- a/src/lib/contextHandoff.ts
+++ b/src/lib/contextHandoff.ts
@@ -61,3 +61,22 @@ ${profile ? `Active browser profile: ${profile}.\n` : ""}Use the existing browse
 Recent chat context:
 ${conversation}`.slice(0, MAX_HANDOFF_CHARS);
 }
+
+export function chatPromptWithDeferredContext(context: string | undefined, message: string): string | undefined {
+  if (!context) return undefined;
+  return `${context}\n\nNew user message:\n${message}`;
+}
+
+export function terminalInputWithDeferredContext(
+  context: string | undefined,
+  data: string,
+): { data: string; consumed: boolean; userInput: boolean } {
+  const textInput = data.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
+  const userInput = /[^\x00-\x1f\x7f]/.test(textInput);
+  if (!context || !userInput) return { data, consumed: false, userInput };
+  return {
+    data: `\x1b[200~${context}\n\nNew user message:\n\x1b[201~${data}`,
+    consumed: true,
+    userInput: true,
+  };
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -466,7 +466,7 @@ interface State {
   deleteConversation: (id: string) => void;
   forkConversation: (atMessageId?: string) => void;
   clearChat: () => void;
-  enqueue: (text: string, chip?: UserCommandChip, into?: string, attachments?: ChatAttachment[]) => void;
+  enqueue: (text: string, chip?: UserCommandChip, into?: string, attachments?: ChatAttachment[], agentPrompt?: string) => void;
   stopRunning: () => void;
   cancelQueuedReply: (replyId: string) => boolean;
   editQueuedReply: (replyId: string, newText: string) => boolean;
@@ -857,9 +857,12 @@ export const useStore = create<State>((set, get) => {
     into?: string,
     attachments: ChatAttachment[] = [],
     privilegedTarget?: ExecutionTarget,
+    agentPrompt?: string,
   ) => {
     const prompt = text.trim();
     if (!prompt) return;
+    const rawPrompt = (agentPrompt ?? text).trim();
+    if (!rawPrompt) return;
     if (prompt === "/login" || prompt.startsWith("/login ")) {
       void get().loginAgent();
       return;
@@ -916,7 +919,7 @@ export const useStore = create<State>((set, get) => {
             ...state.runtime[agentId].queue,
             {
               conversationId: cid,
-              rawText: promptWithAttachments(prompt, attachments),
+              rawText: promptWithAttachments(rawPrompt, attachments),
               replyId,
               executionTarget,
             },
@@ -3104,9 +3107,9 @@ export const useStore = create<State>((set, get) => {
     });
   },
 
-  enqueue: (text, chip, into, attachments = []) => {
+  enqueue: (text, chip, into, attachments = [], agentPrompt) => {
     if (hasVPSPromptMarker(text)) return;
-    enqueueWithTarget(text, chip, into, attachments);
+    enqueueWithTarget(text, chip, into, attachments, undefined, agentPrompt);
   },
 
   stopRunning: () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -188,7 +188,10 @@ const PROXY_REFRESH_MS = 120_000;
 const SCHEDULE_TICK_MS = 30_000;
 const NEXTCTL_DAILY_UPDATE_MS = 20 * 60 * 1000;
 const NEXTCTL_DAILY_UPDATE_POLL_MS = 60 * 1000;
+const NEXTCTL_UPDATE_RETRY_MS = 5 * 60 * 1000;
+const NEXTCTL_UPDATE_MAX_RETRIES = 2;
 const NEXTCTL_UPDATE_STATE_FILE = "nextctl-update.json";
+const NEXTCTL_UPDATE_ERROR = "We couldn't update NextBrowser. Please retry again.";
 
 function nextBrowserInstallPrompt(agentAdapter: string): string {
   return `NextBrowser needs to finish installing its local browser components before browser work can start.
@@ -433,7 +436,7 @@ interface State {
   resumeOnboardingAfterSetup: () => void;
   finishOnboarding: () => void;
   showOnboardingAgain: () => void;
-  checkNextctlUpdate: () => Promise<boolean>;
+  checkNextctlUpdate: (retryAttempt?: number) => Promise<boolean>;
   syncProjects: () => Promise<void>;
   createWorkspace: (name: string) => Promise<string>;
   selectWorkspace: (id: string) => void;
@@ -516,6 +519,7 @@ let scheduleTimer: ReturnType<typeof setInterval> | null = null;
 let sessionPollTimer: ReturnType<typeof setInterval> | null = null;
 let sessionPollInFlight = false;
 let nextctlDailyUpdateTimer: ReturnType<typeof setInterval> | null = null;
+let nextctlUpdateRetryTimer: ReturnType<typeof setTimeout> | null = null;
 let vpsSetupReservations = 0;
 let localNextctlOperations = 0;
 // Guard bootstrap against re-entry. React StrictMode invokes effects twice in
@@ -1214,6 +1218,10 @@ export const useStore = create<State>((set, get) => {
         refreshWorkspace,
         get().authorizeAgent({ deferMissingNextctlPrompt: true }),
       ]);
+      // Cloud project state may contain a reply that was streaming when the
+      // previous app process exited. Reconcile once more after cloud sync so
+      // that stale remote state cannot resurrect an hours-old running badge.
+      get().reconcileQueues();
       if (!hasCompletedCurrentOnboarding(localStorage)) {
         set({ showOnboarding: true });
       }
@@ -1370,13 +1378,17 @@ export const useStore = create<State>((set, get) => {
       const restored: QueuedItem[] = [];
       conversations = conversations.map((conv) => {
         if (conv.agent !== agent.id) return conv;
+        let conversationChanged = false;
         const msgs = conv.messages.map((m, i, arr) => {
           if (m.role !== "assistant") return m;
           if (m.status === "streaming" && r.runningReplyId !== m.id) {
+            conversationChanged = true;
+            const partial = m.text.trim();
             return {
               ...m,
-              status: "failed" as const,
-              text: m.text.trim() || "Interrupted before the reply finished.",
+              status: "cancelled" as const,
+              text: partial ? `${partial}\n[stopped]` : "[stopped]",
+              stalled: false,
             };
           }
           if (m.status === "queued") {
@@ -1392,6 +1404,7 @@ export const useStore = create<State>((set, get) => {
               });
               return m;
             }
+            conversationChanged = true;
             return {
               ...m,
               status: "failed" as const,
@@ -1400,7 +1413,7 @@ export const useStore = create<State>((set, get) => {
           }
           return m;
         });
-        return { ...conv, messages: msgs };
+        return conversationChanged ? { ...conv, messages: msgs, updatedAt: now() } : { ...conv, messages: msgs };
       });
       for (const item of restored) {
         if (!r.queue.some((q) => q.replyId === item.replyId)) r.queue.push(item);
@@ -1833,6 +1846,8 @@ export const useStore = create<State>((set, get) => {
     if (proxyTimer) clearInterval(proxyTimer);
     if (scheduleTimer) clearInterval(scheduleTimer);
     if (sessionPollTimer) clearInterval(sessionPollTimer);
+    if (nextctlUpdateRetryTimer) clearTimeout(nextctlUpdateRetryTimer);
+    nextctlUpdateRetryTimer = null;
     proxyTimer = scheduleTimer = sessionPollTimer = null;
     set({
       authed: false,
@@ -2626,8 +2641,23 @@ export const useStore = create<State>((set, get) => {
     onboardingReturnPending: false,
   }),
 
-  checkNextctlUpdate: async () => {
-    if (pendingTarget(get(), "vps")) return false;
+  checkNextctlUpdate: async (retryAttempt = 0) => {
+    const scheduleRetry = (attempt: number) => {
+      if (attempt > NEXTCTL_UPDATE_MAX_RETRIES) return;
+      if (nextctlUpdateRetryTimer) clearTimeout(nextctlUpdateRetryTimer);
+      nextctlUpdateRetryTimer = setTimeout(() => {
+        nextctlUpdateRetryTimer = null;
+        void get().checkNextctlUpdate(attempt);
+      }, NEXTCTL_UPDATE_RETRY_MS);
+    };
+    if (retryAttempt === 0 && nextctlUpdateRetryTimer) {
+      clearTimeout(nextctlUpdateRetryTimer);
+      nextctlUpdateRetryTimer = null;
+    }
+    if (pendingTarget(get(), "vps") || get().nextctlUpdating) {
+      if (retryAttempt > 0) scheduleRetry(retryAttempt);
+      return false;
+    }
     const startedAt = performance.now();
     trackEvent("nextctl_update_started");
     set({ nextctlUpdating: true, nextctlUpdateStatus: undefined });
@@ -2652,8 +2682,10 @@ export const useStore = create<State>((set, get) => {
         set({ nextctlUpdateStatus: undefined });
         trackEvent("nextctl_update_not_available");
       } else {
-        set({ nextctlUpdateStatus: internalError("We couldn't update the NextBrowser component.", "NEXTCTL_UPDATE_FAILED") });
+        set({ nextctlUpdateStatus: NEXTCTL_UPDATE_ERROR });
         trackEvent("nextctl_update_failed", { exit_code: res.code });
+        scheduleRetry(retryAttempt + 1);
+        return false;
       }
       if (pendingTarget(get(), "vps")) return true;
       const ver = await invoke<string>("nextctl_version");
@@ -2663,13 +2695,15 @@ export const useStore = create<State>((set, get) => {
       set({ nextctlVersion: normalizeNextctlVersion(ver), nextctlSupportsSkill: supportsSkill, nextctlAvailable: true });
       trackTiming("nextctl_update_completed", startedAt, { supports_skill: supportsSkill });
       return true;
-    } catch {
+    } catch (error) {
+      console.error("[NEXTCTL_UPDATE_FAILED] nextctl update failed:", error);
       set({
-        nextctlUpdateStatus: internalError("We couldn't update the NextBrowser component.", "NEXTCTL_UPDATE_FAILED"),
+        nextctlUpdateStatus: NEXTCTL_UPDATE_ERROR,
         nextctlAvailable: false,
       });
       trackTiming("nextctl_update_failed", startedAt);
-      return true;
+      scheduleRetry(retryAttempt + 1);
+      return false;
     } finally {
       set({ nextctlUpdating: false });
       for (const [agentId, runtime] of Object.entries(get().runtime)) {

--- a/src/store.vps.test.ts
+++ b/src/store.vps.test.ts
@@ -455,3 +455,23 @@ describe("local component and profile lifecycle", () => {
     expect(useStore.getState().statuses.work).toBe("stopped");
   });
 });
+
+describe("deferred chat context", () => {
+  it("shows only the new message while sending the expanded prompt to the agent", () => {
+    const local = conversation("local", "local");
+    useStore.setState({ conversations: [local], activeConvId: { codex: local.id } });
+
+    useStore.getState().enqueue(
+      "Did pagination finish?",
+      undefined,
+      undefined,
+      [],
+      "Recent terminal context\n\nNew user message:\nDid pagination finish?",
+    );
+
+    const state = useStore.getState();
+    expect(state.conversations[0].messages[0].text).toBe("Did pagination finish?");
+    expect(state.runtime.codex.queue[0].rawText).toContain("Recent terminal context");
+    expect(state.runtime.codex.queue[0].rawText).toContain("Did pagination finish?");
+  });
+});

--- a/src/store.vps.test.ts
+++ b/src/store.vps.test.ts
@@ -442,6 +442,45 @@ describe("browser profile creation", () => {
 });
 
 describe("local component and profile lifecycle", () => {
+  it("stops a persisted streaming reply when no agent process owns it", () => {
+    const stale = conversation("stale", "local", [
+      message("user", "user", "Hello"),
+      { ...message("reply", "assistant", ""), status: "streaming", runStartedAt: Date.now() - 60 * 60 * 1000 },
+    ]);
+    const previousUpdatedAt = stale.updatedAt;
+    useStore.setState({ conversations: [stale], activeConvId: { codex: stale.id } });
+
+    useStore.getState().reconcileQueues();
+
+    const restored = useStore.getState().conversations[0];
+    expect(restored.messages[1]).toMatchObject({ status: "cancelled", text: "[stopped]", stalled: false });
+    expect(restored.updatedAt).toBeGreaterThan(previousUpdatedAt);
+  });
+
+  it("retries a failed nextctl update twice at five-minute intervals", async () => {
+    vi.useFakeTimers();
+    try {
+      useStore.setState({ nextctlAvailable: true });
+      bridge.invoke.mockImplementation((command) => {
+        if (command === "nextctl_run") return Promise.resolve({ code: 1, stdout: "", stderr: "offline" });
+        return Promise.resolve(null);
+      });
+
+      await expect(useStore.getState().checkNextctlUpdate()).resolves.toBe(false);
+      expect(localNextctlCalls()).toHaveLength(1);
+      expect(useStore.getState().nextctlUpdateStatus).toBe("We couldn't update NextBrowser. Please retry again.");
+
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+      expect(localNextctlCalls()).toHaveLength(2);
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+      expect(localNextctlCalls()).toHaveLength(3);
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+      expect(localNextctlCalls()).toHaveLength(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("restores a profile status when launching it fails", async () => {
     useStore.setState({ statuses: { work: "stopped" } });
     bridge.invoke.mockResolvedValue({

--- a/src/styles.css
+++ b/src/styles.css
@@ -1809,8 +1809,8 @@ button, input, textarea, select { color: var(--text); }
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 4px;
-  min-width: 68px;
+  gap: 5px;
+  min-width: 0;
   flex: 0 0 auto;
 }
 .dot { width: 8px; height: 8px; border-radius: 50%; flex: none; }
@@ -1818,17 +1818,20 @@ button, input, textarea, select { color: var(--text); }
 .dot.orange { background: var(--warn); }
 .dot.gray { background: var(--surface-8); }
 .profile-actions {
-  width: 72px;
-  flex: 0 0 72px;
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 4px;
+  gap: 5px;
+  margin-left: 3px;
+  padding-left: 7px;
+  border-left: 1px solid var(--line);
 }
 .profile-actions .plain-icon-btn {
-  min-width: 24px;
+  width: 28px;
+  min-width: 28px;
   min-height: 28px;
-  padding: 4px;
+  padding: 3px;
 }
 .profile-actions .plain-icon-btn[data-tooltip] {
   position: relative;
@@ -2958,6 +2961,75 @@ code { background: var(--surface-4); padding: 1px 5px; border-radius: 4px; }
   border-color: rgba(255, 255, 255, 0.10);
   box-shadow: 0 24px 80px rgba(0, 0, 0, 0.52), 0 1px 0 rgba(255, 255, 255, 0.04) inset;
 }
+.browser-install-overlay {
+  position: fixed;
+  top: 74px;
+  right: 18px;
+  z-index: 1000;
+  width: min(380px, calc(100vw - 36px));
+  pointer-events: none;
+  animation: browser-install-enter 180ms ease-out both;
+}
+.browser-install-modal {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 12px 14px;
+  width: 100%;
+  min-width: 0;
+  padding: 14px;
+  overflow: hidden;
+  box-shadow: 0 14px 42px color-mix(in srgb, var(--shadow) 65%, transparent);
+}
+.browser-install-mark {
+  display: grid;
+  width: 44px;
+  height: 44px;
+  place-items: center;
+  border-radius: 12px;
+  background: var(--accent-soft);
+  color: var(--accent-text);
+}
+.browser-install-copy { min-width: 0; }
+.browser-install-copy strong { font-size: 16px; }
+.browser-install-copy p { margin: 4px 0 0; line-height: 1.4; }
+.browser-install-progress {
+  grid-column: 1 / -1;
+  height: 4px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--surface-4);
+}
+.browser-install-progress span {
+  display: block;
+  width: 42%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--accent);
+  animation: browser-install-progress 1.25s ease-in-out infinite;
+}
+.browser-install-note {
+  grid-column: 1 / -1;
+  margin: -2px 0 0;
+  font-size: 11px;
+  text-align: center;
+}
+@keyframes browser-install-progress {
+  from { transform: translateX(-120%); }
+  to { transform: translateX(340%); }
+}
+@keyframes browser-install-enter {
+  from { opacity: 0; transform: translateX(14px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+@media (max-width: 560px) {
+  .browser-install-overlay {
+    top: auto;
+    right: 12px;
+    bottom: 12px;
+    width: calc(100vw - 24px);
+  }
+}
 .settings-modal {
   width: min(420px, calc(100vw - 32px));
 }
@@ -3320,6 +3392,40 @@ code { background: var(--surface-4); padding: 1px 5px; border-radius: 4px; }
 .profile-vps-option:hover { border-color: var(--line-strong); background: var(--surface-3); }
 .profile-vps-option span { display: flex; min-width: 0; flex-direction: column; gap: 2px; }
 .profile-vps-option small { color: var(--muted); font-size: 10px; font-weight: 450; }
+.profile-remote-section {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  margin-top: 16px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--surface-2) 58%, transparent);
+}
+.profile-remote-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 650;
+}
+.profile-remote-heading small {
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: var(--surface-4);
+  color: var(--muted);
+  font-size: 9px;
+  font-weight: 600;
+}
+.profile-vps-icon {
+  display: inline-grid !important;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  background: var(--surface-4);
+}
 .vps-target-pill {
   display: inline-flex;
   align-items: center;
@@ -5270,6 +5376,39 @@ code { background: var(--surface-4); padding: 1px 5px; border-radius: 4px; }
 .project-mode-option span { display: flex; flex-direction: column; gap: 2px; }
 .project-mode-option small { color: var(--muted); }
 .profile-toolset-field { margin-top: 2px; }
+
+/* Keep profile creation choices visually grouped instead of presenting one
+   uninterrupted stack of controls. */
+.create-profile-modal {
+  width: min(380px, 100%);
+}
+.create-profile-modal > .profile-menu-head {
+  margin-bottom: 4px;
+}
+.create-profile-modal > .modal-field {
+  margin-top: 8px;
+}
+.create-profile-modal .profile-connection-field {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--line);
+}
+.create-profile-modal .profile-connection-field + .modal-field {
+  margin-top: 10px;
+}
+.create-profile-modal .profile-toolset-field {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--line);
+}
+.create-profile-modal .profile-remote-section + .profile-create-error,
+.create-profile-modal .profile-remote-section + .modal-actions {
+  margin-top: 14px;
+}
+.create-profile-modal .modal-actions {
+  padding-top: 14px;
+  border-top: 1px solid var(--line);
+}
 
 .agent-gate-overlay {
   position: fixed;


### PR DESCRIPTION
## Summary

- separate VPS setup from browser toolset selection and remove the redundant Terminal chat setting
- improve profile action spacing and preserve the resizable sidebar layout
- keep Chat/Terminal context handoff lazy and restore the project tab icon/order
- show non-blocking ClawBrowser/DasBrowser download and install progress
- preserve macOS DasBrowser bundle symlinks and verify its code signature after installation
- stop stale streaming replies from returning after restart or cloud sync
- retry failed nextctl updates and use `core.nextbrowser.com` for project/workspace sync
- update vulnerable transitive dependencies

## Verification

- `npm run build`
- `npm test` (209 frontend + 66 Electron/system tests)
- `npm audit --omit=dev --audit-level=high` (0 vulnerabilities)
- `go test ./cmd/nbc` in nextctl
- verified HTTPS connectivity and expected authenticated behavior on `core.nextbrowser.com`

## Notes

The existing Vite large-chunk warning remains non-blocking and is unchanged functionally.