### PR TITLE
Polish chat, schedules, skills, and runtime UI

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, shell, nativeImage, dialog, Menu, clipboard, safeStorage } = require("electron");
+const { app, BrowserWindow, ipcMain, shell, nativeImage, nativeTheme, dialog, Menu, clipboard, safeStorage } = require("electron");
 const { autoUpdater } = require("electron-updater");
 const { spawn } = require("node:child_process");
 const fs = require("node:fs/promises");
@@ -897,6 +897,14 @@ async function invokeCommand(command, args = {}, sender) {
       return null;
     }
     case "app_platform": return { platform: process.platform, arch: process.arch };
+    case "app_set_theme": {
+      const theme = args.theme === "light" ? "light" : "dark";
+      nativeTheme.themeSource = theme;
+      for (const window of BrowserWindow.getAllWindows()) {
+        window.setBackgroundColor(theme === "light" ? "#f5f5f7" : "#15141c");
+      }
+      return null;
+    }
     case "agent_authorize": {
       const bin = resolveBinary(args.binary, args.envVar); if (!bin) throw new Error(`${args.binary} executable not found.`);
       const r = await run(bin, ["--version"]); if (r.code !== 0) throw new Error(`${args.binary} is not ready: ${(r.stdout + r.stderr).trim()}`);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -297,13 +297,6 @@ function SettingsModal({
             <Icon name="xmark" size={17} className="error" />
           </button>
         </div>
-        <div className="settings-health">
-          <div>
-            <span className="muted small">Desktop app</span>
-            <strong>Operational</strong>
-          </div>
-          <span className="status-pill">v{__APP_VERSION__}</span>
-        </div>
         <div className="settings-section">
           <div className="settings-row">
             <span className="muted small">NextBrowser</span>
@@ -740,6 +733,7 @@ export function App() {
     document.documentElement.dataset.theme = theme;
     document.documentElement.style.colorScheme = theme;
     localStorage.setItem("nextbrowser.theme", theme);
+    void invoke("app_set_theme", { theme }).catch(() => undefined);
     if (!didTrackThemeChange.current) {
       didTrackThemeChange.current = true;
       return;
@@ -846,30 +840,36 @@ export function App() {
     let dragging = false;
     let startX = 0;
     let startW = sidebarWidth;
-    const onMove = (e: MouseEvent) => {
+    const onMove = (e: PointerEvent) => {
       if (!dragging) return;
       if (sidebarCollapsed) return;
       setSidebarWidth(Math.min(480, Math.max(240, startW + (e.clientX - startX))));
     };
     const onUp = () => {
       dragging = false;
+      document.body.classList.remove("is-resizing-sidebar");
     };
     const handle = document.getElementById("sidebar-resize");
-    const onDown = (e: MouseEvent) => {
+    const onDown = (e: PointerEvent) => {
       dragging = true;
       startX = e.clientX;
       startW = useStore.getState().sidebarWidth;
+      document.body.classList.add("is-resizing-sidebar");
+      handle?.setPointerCapture(e.pointerId);
       e.preventDefault();
     };
-    handle?.addEventListener("mousedown", onDown);
-    window.addEventListener("mousemove", onMove);
-    window.addEventListener("mouseup", onUp);
+    handle?.addEventListener("pointerdown", onDown);
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onUp);
     return () => {
-      handle?.removeEventListener("mousedown", onDown);
-      window.removeEventListener("mousemove", onMove);
-      window.removeEventListener("mouseup", onUp);
+      document.body.classList.remove("is-resizing-sidebar");
+      handle?.removeEventListener("pointerdown", onDown);
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onUp);
     };
-  }, [sidebarCollapsed, setSidebarWidth]);
+  }, [checking, sidebarCollapsed, setSidebarWidth]);
 
     if (checking && preview !== "login" && preview !== "main" && preview !== "onboarding") {
     return (
@@ -911,7 +911,7 @@ export function App() {
       >
         <Sidebar onOpenAgentSettings={() => openSettings("agent")} onHome={() => setTab("chat")} />
       </aside>
-      {!sidebarCollapsed && <div id="sidebar-resize" className="resize-handle" />}
+      {!sidebarCollapsed && <div id="sidebar-resize" className="resize-handle" title="Resize sidebar" aria-label="Resize sidebar" />}
       <main className="content">
         <nav className="tabbar">
           {!isPrimaryAppTab(tab) && backTarget && (

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -103,6 +103,9 @@ export function ChatView() {
   const agentNeedsLogin = agentDetected && s.agentLoggedIn() === false;
   const agentError = s.agentError();
   const running = s.hasRunning();
+  const latestCompletedAssistantId = [...messages].reverse().find((message) =>
+    message.role === "assistant" && message.status === "done" && message.text.trim(),
+  )?.id;
 
   const [draft, setDraft] = useState("");
   const [guideDraftLoaded, setGuideDraftLoaded] = useState(false);
@@ -527,6 +530,7 @@ export function ChatView() {
                 void prepareWorkflow(user?.text ?? "", m, m.id);
               }}
               savingWorkflow={preparingWorkflowId === m.id}
+              showSaveWorkflow={m.id === latestCompletedAssistantId}
             />
           ))}
           <div ref={bottomRef} />
@@ -814,6 +818,7 @@ function MessageBubble({
   onShowPrompt,
   onSaveWorkflow,
   savingWorkflow,
+  showSaveWorkflow,
 }: {
   message: ChatMessage;
   canQueue: boolean;
@@ -825,6 +830,7 @@ function MessageBubble({
   onShowPrompt: () => void;
   onSaveWorkflow: () => void;
   savingWorkflow: boolean;
+  showSaveWorkflow: boolean;
 }) {
   const [clock, setClock] = useState(Date.now());
   const [showErrorDetails, setShowErrorDetails] = useState(false);
@@ -843,10 +849,13 @@ function MessageBubble({
   };
 
   if (m.role === "system") {
+    const visibleText = /^.+ connected — .+/.test(m.text)
+      ? m.text.replace(/ — .+?(?=\. You're|\.$)/, "")
+      : m.text;
     return (
       <div className="msg msg-system">
         <div className="msg-body">
-          <UserFacingError message={m.text} surface="chat_system" />
+          <UserFacingError message={visibleText} surface="chat_system" />
         </div>
       </div>
     );
@@ -979,7 +988,7 @@ function MessageBubble({
           >
             <Icon name="doc.on.doc" size={12} />
           </button>
-          {m.status === "done" && (
+          {m.status === "done" && showSaveWorkflow && (
             <button className="save-workflow-btn" disabled={savingWorkflow} title="Save this browser workflow as a local skill" onClick={onSaveWorkflow}>
               {savingWorkflow && <Spinner size={11} />} {savingWorkflow ? "Preparing…" : "Save as skill"}
             </button>

--- a/src/components/ScheduledRunsPanel.tsx
+++ b/src/components/ScheduledRunsPanel.tsx
@@ -45,9 +45,12 @@ export function ScheduledRunsPanel({ asPage = false }: { asPage?: boolean }) {
             <h2>Scheduled runs</h2>
             <p className="muted">Automate recurring tasks while NextBrowser is open.</p>
           </div>
+          <button className="btn-bordered-prominent" onClick={() => { setExpanded(true); setEditor("new"); }}>
+            <Icon name="plus" size={14} /> New schedule
+          </button>
         </div>
       )}
-      <div className="row scheduled-panel-head">
+      {!asPage && <div className="row scheduled-panel-head">
         <button
           className="scheduled-panel-toggle"
           title={expanded ? "Hide scheduled runs" : "Show scheduled runs"}
@@ -61,9 +64,13 @@ export function ScheduledRunsPanel({ asPage = false }: { asPage?: boolean }) {
         <button className="plain-icon-btn" title="New schedule" onClick={() => { setExpanded(true); setEditor("new"); }}>
           <Icon name="plus.circle" size={18} />
         </button>
-      </div>
+      </div>}
       {expanded && (runs.length === 0 ? (
-          <div className="muted small scheduled-empty">No schedules yet. Automate daily parses or checks.</div>
+          <div className="scheduled-empty-state">
+            <span className="scheduled-empty-icon"><Icon name="clock.arrow.circlepath" size={22} /></span>
+            <strong>No scheduled runs yet</strong>
+            <span className="muted small">Create a recurring browser task. It will run while NextBrowser is open.</span>
+          </div>
         ) : (
           runs.map((run) => (
           <div key={run.id} className="schedule-row">
@@ -176,10 +183,8 @@ function ScheduleEditor({
   onSave: (data: Omit<ScheduledRun, "id" | "agent" | "enabled">) => void;
   onClose: () => void;
 }) {
-  const [title, setTitle] = useState(run?.title ?? "Daily parse");
-  const [prompt, setPrompt] = useState(
-    run?.prompt ?? "Parse latest Cian listings in the active profile.",
-  );
+  const [title, setTitle] = useState(run?.title ?? "");
+  const [prompt, setPrompt] = useState(run?.prompt ?? "");
   const [hour, setHour] = useState(run?.hour ?? 9);
   const [minute, setMinute] = useState(run?.minute ?? 0);
   const [weekdays, setWeekdays] = useState<number[]>(run?.weekdays ?? [2, 3, 4, 5, 6]);
@@ -196,11 +201,11 @@ function ScheduleEditor({
       <div className="modal-card schedule-editor">
         <h3>{run ? "Edit scheduled run" : "New scheduled run"}</h3>
         <p className="muted small">Runs while NextBrowser is open, for {agentName}.</p>
-        <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Title" />
+        <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="e.g. Daily listing check" autoFocus />
         <textarea
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
-          placeholder="Prompt"
+          placeholder="Describe what the agent should do each time"
           rows={3}
         />
         <div className="schedule-time-row">
@@ -275,9 +280,9 @@ function ScheduleEditor({
           </button>
           <button
             className="primary"
-            disabled={!weekdays.length || !prompt.trim()}
+            disabled={!weekdays.length || !title.trim() || !prompt.trim()}
             onClick={() =>
-              onSave({ title, prompt, hour, minute, weekdays, conversationId })
+              onSave({ title: title.trim(), prompt: prompt.trim(), hour, minute, weekdays, conversationId })
             }
           >
             {run ? "Save" : "Add"}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -737,6 +737,11 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
                 <Icon name="xmark.circle.fill" size={18} />
               </button>
             </div>
+            <div className="profile-workspace-context">
+              <Icon name="square.grid.2x2.fill" size={13} />
+              <span>Workspace</span>
+              <strong>{activeWorkspace?.name ?? "Current workspace"}</strong>
+            </div>
             <label className="modal-field">
               <span>Profile name</span>
               <input

--- a/src/components/SkillsView.tsx
+++ b/src/components/SkillsView.tsx
@@ -18,6 +18,7 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
   const [status, setStatus] = useState<Record<string, string>>({});
   const [scriptEditor, setScriptEditor] = useState<CustomScript | "new" | null>(null);
   const [skillRun, setSkillRun] = useState<BrowserWorkflowSkill | null>(null);
+  const [skillDetails, setSkillDetails] = useState<BrowserWorkflowSkill | null>(null);
 
   const cat = categories.find((c) => c.id === category);
   const isSkillsOverview = category === "__skills__";
@@ -281,6 +282,7 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
                   ready={ready}
                   sync={s.localSkillSync[skill.id] ?? (skill.submittedAt ? "synced" : "idle")}
                   onRun={() => setSkillRun(skill)}
+                  onDetails={() => setSkillDetails(skill)}
                   onSync={() => void s.saveLocalSkill(skill)}
                   onDelete={() => s.deleteLocalSkill(skill.id)}
                 />
@@ -396,6 +398,9 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
           }}
         />
       )}
+      {skillDetails && (
+        <LocalSkillDetails skill={skillDetails} onClose={() => setSkillDetails(null)} />
+      )}
     </div>
   );
 }
@@ -427,11 +432,12 @@ function RunLocalSkillSheet({ skill, sessionName, onClose, onRun }: {
   );
 }
 
-function LocalSkillCard({ skill, ready, sync, onRun, onSync, onDelete }: {
+function LocalSkillCard({ skill, ready, sync, onRun, onDetails, onSync, onDelete }: {
   skill: BrowserWorkflowSkill;
   ready: boolean;
   sync: string;
   onRun: () => void;
+  onDetails: () => void;
   onSync: () => void;
   onDelete: () => void;
 }) {
@@ -445,15 +451,42 @@ function LocalSkillCard({ skill, ready, sync, onRun, onSync, onDelete }: {
       <div className="muted small">{skill.domain || "Any website"}</div>
       <p className="small instructions-preview">{skill.instructions.slice(0, 150)}{skill.instructions.length > 150 ? "…" : ""}</p>
       <div className="small muted">{skill.actions.length} recorded browser action{skill.actions.length === 1 ? "" : "s"}</div>
-      {sync === "idle" && <button className="link small sync-link" onClick={onSync}>Back up privately</button>}
+      {sync === "idle" && <button className="link small sync-link" onClick={onSync}>Back up to private cloud</button>}
       {sync === "syncing" && <span className="muted small">Backing up…</span>}
       {sync === "synced" && <span className="ok small"><Icon name="lock.fill" size={11} /> Private cloud backup</span>}
       {sync === "failed" && <button className="link small" onClick={onSync}>Saved locally · Retry backup</button>}
       <div className="skill-actions">
         <button className="btn-bordered-prominent full" disabled={!ready} onClick={onRun}>Run</button>
-        <button className="plain-icon-btn" title="Delete local skill" onClick={onDelete}>
-          <Icon name="trash" size={14} className="error" />
-        </button>
+        <button className="btn-bordered full" onClick={onDetails}>View details</button>
+        <button className="mini danger-text" onClick={onDelete}>Delete</button>
+      </div>
+    </div>
+  );
+}
+
+function LocalSkillDetails({ skill, onClose }: { skill: BrowserWorkflowSkill; onClose: () => void }) {
+  return (
+    <div className="modal-overlay" onMouseDown={onClose}>
+      <div className="modal-card local-skill-details" onMouseDown={(event) => event.stopPropagation()}>
+        <div className="modal-title-row">
+          <Icon name="sparkles" size={17} className="accent-icon" />
+          <div>
+            <strong>{skill.title}</strong>
+            <div className="muted small">{skill.domain || "Any website"}</div>
+          </div>
+          <span className="spacer" />
+          <button className="plain-icon-btn" onClick={onClose} aria-label="Close skill details"><Icon name="xmark" size={15} /></button>
+        </div>
+        <section>
+          <span className="field-label">Original task</span>
+          <p className="skill-details-copy">{skill.task || "No original task recorded."}</p>
+        </section>
+        <section>
+          <span className="field-label">Reusable instructions</span>
+          <pre className="skill-details-instructions">{skill.instructions}</pre>
+        </section>
+        <div className="muted small">{skill.actions.length} recorded browser action{skill.actions.length === 1 ? "" : "s"}</div>
+        <div className="modal-actions"><button className="secondary" onClick={onClose}>Close</button></div>
       </div>
     </div>
   );

--- a/src/store.ts
+++ b/src/store.ts
@@ -2489,7 +2489,7 @@ export const useStore = create<State>((set, get) => {
     }
   },
 
-  announceConnect: (agentId: string, version: string, loggedIn: boolean | null) => {
+  announceConnect: (agentId: string, _version: string, loggedIn: boolean | null) => {
     const announced = get().connectAnnounced;
     if (announced.has(agentId)) return;
     const a = agentById(agentId);
@@ -2507,7 +2507,7 @@ export const useStore = create<State>((set, get) => {
     const msg: ChatMessage = {
       id: uid(),
       role: "system",
-      text: `${prefix} — ${version}.${note}`,
+      text: `${prefix}.${note}`,
       status: "done",
       createdAt: now(),
     };

--- a/src/styles.css
+++ b/src/styles.css
@@ -768,20 +768,30 @@ button, input, textarea, select { color: var(--text); }
 .switch-account-link:hover { text-decoration: underline; }
 
 .resize-handle {
-  width: 5px;
+  width: 7px;
   flex: none;
   cursor: col-resize;
   background: transparent;
   position: relative;
+  touch-action: none;
 }
 .resize-handle::after {
   content: "";
   position: absolute;
   top: 0;
   bottom: 0;
-  left: 2px;
+  left: 3px;
   width: 1px;
   background: var(--line-strong);
+}
+.resize-handle:hover::after,
+body.is-resizing-sidebar .resize-handle::after {
+  width: 2px;
+  background: color-mix(in srgb, var(--accent) 60%, var(--line-strong));
+}
+body.is-resizing-sidebar {
+  cursor: col-resize;
+  user-select: none;
 }
 
 .brand { display: flex; align-items: center; gap: 10px; }
@@ -2517,6 +2527,11 @@ button, input, textarea, select { color: var(--text); }
   gap: 14px;
   min-height: 0;
   overflow-x: hidden;
+  scroll-padding-bottom: 18px;
+}
+.messages > * {
+  width: min(100%, 960px);
+  margin-inline: auto;
 }
 .agent-terminal-panel {
   flex: 1;
@@ -2576,7 +2591,7 @@ button, input, textarea, select { color: var(--text); }
 }
 .msg-user-inner {
   width: fit-content;
-  max-width: 75%;
+  max-width: min(76%, 760px);
   min-width: 0;
   display: flex;
   flex-direction: column;
@@ -2640,7 +2655,8 @@ button, input, textarea, select { color: var(--text); }
 .workflow-author-status { display: flex; align-items: center; gap: 7px; min-height: 20px; margin: 8px 0 2px; }
 .msg-assistant-wrap { display: flex; flex-direction: column; align-items: flex-start; }
 .assistant-bubble {
-  max-width: 85%;
+  width: fit-content;
+  max-width: min(76%, 760px);
   min-width: 0;
   overflow-wrap: anywhere;
   padding: 10px;
@@ -5085,17 +5101,77 @@ code { background: var(--surface-4); padding: 1px 5px; border-radius: 4px; }
   border-top: 1px solid var(--line);
 }
 .scheduled-page-card {
-  padding: 16px;
-}
-.scheduled-page-card .scheduled-panel-head {
-  border-top: 1px solid var(--line);
-  padding-top: 10px;
+  width: min(860px, 100%);
+  min-height: 360px;
+  margin: 0 auto;
+  padding: 24px;
 }
 .scheduled-page-card .schedule-row {
   min-height: 54px;
 }
 .scheduled-page-head {
-  margin-bottom: 8px;
+  align-items: center;
+  margin-bottom: 20px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--line);
+}
+.scheduled-empty-state {
+  min-height: 230px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  padding: 28px;
+  text-align: center;
+}
+.scheduled-empty-state .muted { max-width: 360px; }
+.scheduled-empty-icon {
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  margin-bottom: 3px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--accent) 12%, var(--surface-3));
+  color: var(--accent-text);
+}
+.profile-workspace-context {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr);
+  align-items: center;
+  gap: 7px;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--surface-2);
+  color: var(--muted);
+  font-size: 11px;
+}
+.profile-workspace-context strong {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text);
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.local-skill-details { width: min(620px, calc(100vw - 48px)); }
+.local-skill-details section { display: grid; gap: 6px; }
+.skill-details-copy { margin: 0; line-height: 1.45; }
+.skill-details-instructions {
+  max-height: min(340px, 42vh);
+  margin: 0;
+  padding: 12px;
+  overflow: auto;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--surface-2);
+  color: var(--text);
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
 }
 
 /* Sidebar skills */


### PR DESCRIPTION
## Summary
- stabilize chat message geometry and reduce repeated Save as skill actions
- improve scheduled runs empty state and remove prefilled demo task data
- show workspace context during profile creation and add local skill details
- synchronize the native window theme and remove duplicate/stale version labels
- restore reliable pointer-based sidebar resizing

## Verification
- `npm run build`
- `npm test -- --run`
- 48 Vitest files / 241 tests passed
- 86 Node tests passed
- PTY smoke test passed on macOS

Audit screenshots are intentionally excluded from the commit.