### PR TITLE
feat: add file attachments to Terminal Mode

### DIFF
--- a/electron/agent-workspace.test.cjs
+++ b/electron/agent-workspace.test.cjs
@@ -61,3 +61,18 @@ test("terminal chat is isolated by conversation", () => {
   assert.match(chat, /conversationId=\{conv\?\.id\}/);
   assert.match(terminal, /terminal_context_menu/);
 });
+
+test("terminal attachments are staged inside the sandboxed workspace", () => {
+  const main = fs.readFileSync(path.join(__dirname, "main.cjs"), "utf8");
+  const terminal = fs.readFileSync(path.join(__dirname, "..", "src", "components", "AgentTerminal.tsx"), "utf8");
+  assert.match(main, /case "select_terminal_files"/);
+  assert.match(main, /agentWorkspaceDir\(home\(\)\), "\.attachments", conversation/);
+  assert.match(main, /stat\.size > 30 \* 1024 \* 1024/);
+  assert.match(main, /totalSize > 600 \* 1024 \* 1024/);
+  assert.match(main, /COPYFILE_FICLONE/);
+  assert.match(main, /case "remove_terminal_file"/);
+  assert.match(terminal, /terminalAttachmentContext\(attachmentsRef\.current\)/);
+  assert.match(terminal, /select_terminal_files/);
+  assert.match(terminal, /setAttachmentError/);
+  assert.match(terminal, /Please inspect the attached file\(s\)\./);
+});

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1067,6 +1067,51 @@ async function invokeCommand(command, args = {}, sender) {
         return { name: path.basename(file), path: file, size: stat.size };
       }));
     }
+    case "select_terminal_files": {
+      const owner = BrowserWindow.getFocusedWindow() || BrowserWindow.getAllWindows()[0];
+      const result = await dialog.showOpenDialog(owner, {
+        title: "Attach files to terminal",
+        properties: ["openFile", "multiSelections"],
+      });
+      if (result.canceled) return [];
+      const conversation = String(args.conversationId || "terminal")
+        .replace(/[^A-Za-z0-9_-]/g, "-")
+        .replace(/-+/g, "-")
+        .replace(/^-|-$/g, "")
+        .slice(0, 96) || "terminal";
+      const attachmentDir = path.join(agentWorkspaceDir(home()), ".attachments", conversation);
+      await fs.mkdir(attachmentDir, { recursive: true, mode: 0o700 });
+      const files = [];
+      let totalSize = 0;
+      for (const selected of result.filePaths.slice(0, 20)) {
+        const source = await fs.realpath(selected);
+        const stat = await fs.stat(source);
+        if (!stat.isFile()) throw new Error(`${path.basename(source)} is not a regular file.`);
+        if (stat.size > 30 * 1024 * 1024) throw new Error(`${path.basename(source)} is larger than 30 MB.`);
+        totalSize += stat.size;
+        if (totalSize > 600 * 1024 * 1024) throw new Error("Terminal attachments are limited to 600 MB per selection.");
+        const safeName = path.basename(source).replace(/[\\/:*?"<>|\x00-\x1f]/g, "-").slice(0, 180) || "file";
+        const target = path.join(attachmentDir, `${randomUUID()}-${safeName}`);
+        // Prefer copy-on-write cloning where the filesystem supports it. This
+        // keeps large explicit attachments sandbox-readable without doubling
+        // their disk usage; Node falls back to a regular copy when unavailable.
+        await fs.copyFile(source, target, fsSync.constants.COPYFILE_FICLONE);
+        if (process.platform !== "win32") await fs.chmod(target, 0o600);
+        files.push({ name: path.basename(source), path: target, size: stat.size });
+      }
+      return files;
+    }
+    case "remove_terminal_file": {
+      const workspace = agentWorkspaceDir(home());
+      const attachmentRoot = path.resolve(workspace, ".attachments");
+      const target = path.resolve(String(args.path || ""));
+      const relative = path.relative(attachmentRoot, target);
+      if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+        throw new Error("Refusing to remove a file outside the terminal attachment directory.");
+      }
+      await fs.rm(target, { force: true });
+      return null;
+    }
     case "open_path": {
       const error = await shell.openPath(path.resolve(String(args.path || "")));
       if (error) throw new Error(error);

--- a/src/components/AgentTerminal.tsx
+++ b/src/components/AgentTerminal.tsx
@@ -4,6 +4,8 @@ import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
 import { invoke, listen } from "../electronBridge";
 import { Icon, Spinner } from "./Icon";
+import type { ChatAttachment } from "../types";
+import { terminalAttachmentContext } from "../lib/chatAttachments";
 import { terminalBrowserScopeContext, terminalInputWithDeferredContext, terminalLineBufferAfter } from "../lib/contextHandoff";
 import { terminalActivityPreview, terminalAgentReady, terminalInputShouldQueueBeforeReady } from "../lib/terminalReadiness";
 import { terminalBrowserSession } from "../lib/terminalBrowserSession";
@@ -97,6 +99,8 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
   const [status, setStatus] = useState<"starting" | "running" | "exited" | "failed">("starting");
   const [error, setError] = useState<string>();
   const [restartNonce, setRestartNonce] = useState(0);
+  const [attachments, setAttachments] = useState<ChatAttachment[]>([]);
+  const [attachmentError, setAttachmentError] = useState<string>();
   const onContinueInChatRef = useRef(onContinueInChat);
   const onHandoffConsumedRef = useRef(onHandoffConsumed);
   const onChatHandoffConsumedRef = useRef(onChatHandoffConsumed);
@@ -113,6 +117,7 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
   const currentLineInputRef = useRef("");
   const lastBrowserContextRef = useRef(browserContext || "");
   const onPreviewChangeRef = useRef(onPreviewChange);
+  const attachmentsRef = useRef(attachments);
   onContinueInChatRef.current = onContinueInChat;
   onHandoffConsumedRef.current = onHandoffConsumed;
   onChatHandoffConsumedRef.current = onChatHandoffConsumed;
@@ -120,6 +125,7 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
   onProfileStoppedRef.current = onProfileStopped;
   onProfilesRefreshRef.current = onProfilesRefresh;
   onPreviewChangeRef.current = onPreviewChange;
+  attachmentsRef.current = attachments;
   pendingHandoffRef.current = pendingHandoff;
   browserProfilesRef.current = browserProfiles;
 
@@ -250,16 +256,21 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
       if (!id) return;
       const pending = pendingHandoffRef.current;
       const bufferedMessage = currentLineInputRef.current.trimStart();
+      const attachmentContext = terminalAttachmentContext(attachmentsRef.current);
       const scopeContext = bufferedMessage.startsWith("/")
         ? undefined
         : terminalBrowserScopeContext(browserProfilesRef.current ?? []);
-      const combinedContext = [scopeContext, pending?.text].filter(Boolean).join("\n\n") || undefined;
-      const deferred = terminalInputWithDeferredContext(combinedContext, data, currentLineInputRef.current);
+      const combinedContext = [scopeContext, pending?.text, attachmentContext].filter(Boolean).join("\n\n") || undefined;
+      const attachmentOnlyMessage = attachmentContext && data.includes("\r") && !currentLineInputRef.current
+        ? "Please inspect the attached file(s)."
+        : currentLineInputRef.current;
+      const deferred = terminalInputWithDeferredContext(combinedContext, data, attachmentOnlyMessage);
       if (pending && deferred.consumed) {
         pendingHandoffRef.current = undefined;
         userInputSinceChatHandoffRef.current = true;
         onHandoffConsumedRef.current(pending.id);
       }
+      if (attachmentContext && deferred.consumed) setAttachments([]);
       if (deferred.userInput) userInputSinceChatHandoffRef.current = true;
       currentLineInputRef.current = deferred.consumed ? "" : terminalLineBufferAfter(currentLineInputRef.current, data);
       writeInput(id, deferred.data);
@@ -401,6 +412,31 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
     onChatHandoffConsumedRef.current(handoffToChatRequest);
   }, [handoffToChatRequest, status]);
 
+  const attachFiles = async () => {
+    setAttachmentError(undefined);
+    try {
+      const selected = await invoke<ChatAttachment[]>("select_terminal_files", {
+        conversationId: conversationId || "terminal",
+      });
+      setAttachments((current) => {
+        const byPath = new Map(current.map((file) => [file.path, file]));
+        for (const file of selected) byPath.set(file.path, file);
+        return [...byPath.values()];
+      });
+    } catch (reason) {
+      const message = reason instanceof Error ? reason.message : String(reason);
+      setAttachmentError(message.replace(/^Error invoking remote method '[^']+': Error:\s*/, ""));
+    } finally {
+      requestAnimationFrame(() => terminalRef.current?.focus());
+    }
+  };
+
+  const removeAttachment = async (file: ChatAttachment) => {
+    await invoke("remove_terminal_file", { path: file.path });
+    setAttachments((current) => current.filter((item) => item.path !== file.path));
+    requestAnimationFrame(() => terminalRef.current?.focus());
+  };
+
   return (
     <section className="agent-terminal-panel" aria-label={`${agentName} terminal`}>
       <header className="agent-terminal-header">
@@ -412,6 +448,15 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
         {status === "running" && <span className="terminal-status-dot" title="Running" />}
         {status === "exited" && <span className="muted small">Exited</span>}
         {status === "failed" && <span className="error small" title={error}>Failed</span>}
+        <button
+          className="mini terminal-attach-file"
+          disabled={status !== "running"}
+          onClick={() => void attachFiles()}
+          title="Attach local files to the next terminal prompt"
+          aria-label="Attach local files to the next terminal prompt"
+        >
+          <Icon name="paperclip" size={13} />
+        </button>
         {(status === "exited" || status === "failed") && (
           <button
             className="mini"
@@ -433,6 +478,26 @@ export function AgentTerminal({ agentId, agentName, conversationId, workingDir, 
           {savingWorkflow && <Spinner size={11} />} {savingWorkflow ? "Preparing…" : "Save as skill"}
         </button>
       </header>
+      {attachments.length > 0 && (
+        <div className="terminal-attachments" aria-label="Files attached to the next terminal prompt">
+          {attachments.map((file) => (
+            <span className="attachment-chip" key={file.path} title={file.path}>
+              <Icon name="paperclip" size={12} />
+              <span>{file.name}</span>
+              <button
+                className="attachment-remove"
+                aria-label={`Remove ${file.name}`}
+                onClick={() => void removeAttachment(file)}
+              >×</button>
+            </span>
+          ))}
+        </div>
+      )}
+      {attachmentError && (
+        <div className="terminal-attachment-error error small" role="alert">
+          {attachmentError}
+        </div>
+      )}
       <div ref={hostRef} className="agent-terminal-host" />
     </section>
   );

--- a/src/lib/chatAttachments.test.ts
+++ b/src/lib/chatAttachments.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { promptWithAttachments } from "./chatAttachments";
+import { promptWithAttachments, terminalAttachmentContext } from "./chatAttachments";
 
 describe("chat attachments", () => {
   it("passes exact local paths to the agent", () => {
@@ -11,5 +11,12 @@ describe("chat attachments", () => {
 
   it("does not alter prompts without attachments", () => {
     expect(promptWithAttachments("Hello", [])).toBe("Hello");
+  });
+
+  it("builds terminal context from staged attachment paths", () => {
+    expect(terminalAttachmentContext([
+      { name: "brief.pdf", path: "/workspace/.attachments/chat/brief.pdf", size: 42 },
+    ])).toBe("[Attached local files — open/read these exact paths:]\n- /workspace/.attachments/chat/brief.pdf");
+    expect(terminalAttachmentContext([])).toBeUndefined();
   });
 });

--- a/src/lib/chatAttachments.ts
+++ b/src/lib/chatAttachments.ts
@@ -6,3 +6,10 @@ export function promptWithAttachments(text: string, attachments: ChatAttachment[
     .map((file) => `- ${file.path}`)
     .join("\n")}`;
 }
+
+export function terminalAttachmentContext(attachments: ChatAttachment[]): string | undefined {
+  if (!attachments.length) return undefined;
+  return `[Attached local files — open/read these exact paths:]\n${attachments
+    .map((file) => `- ${file.path}`)
+    .join("\n")}`;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -2680,6 +2680,19 @@ body.is-resizing-sidebar {
 }
 .agent-terminal-host .xterm { height: 100%; }
 .agent-terminal-host .xterm-viewport { scrollbar-color: var(--surface-8) transparent; }
+.terminal-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface-2);
+}
+.terminal-attachment-error {
+  padding: 7px 12px;
+  border-bottom: 1px solid color-mix(in srgb, var(--error) 35%, transparent);
+  background: color-mix(in srgb, var(--error) 8%, transparent);
+}
 [data-theme="light"] .agent-terminal-panel { background: #f7f7f8; }
 .msg { max-width: 80%; min-width: 0; overflow-wrap: anywhere; }
 .msg-system { text-align: center; color: var(--muted); font-size: 12px; }


### PR DESCRIPTION
## Summary

- add a paperclip action and attachment chips to Terminal Mode
- stage selected files inside the sandbox-accessible agent workspace
- pass exact staged paths to the next Codex or Claude terminal prompt
- allow removal before sending and cleanly report attachment errors in the terminal UI
- enforce compatibility limits of 30 MB per file, 20 files, and 600 MB per selection
- protect staged files with restricted permissions and validate deletion paths

## Validation

- `node --test electron/agent-workspace.test.cjs` (6 passed)
- TypeScript compilation
- Vite production build
- existing frontend suite previously verified (271 tests)