### PR TITLE
feat: improve personal proxy validation and error coverage

### DIFF
--- a/electron/project-sync.test.cjs
+++ b/electron/project-sync.test.cjs
@@ -75,3 +75,26 @@ test("stores and resolves personal proxies through the authenticated entity back
   ]);
   assert.ok(calls.every((call) => call.options.headers.authorization === "Bearer secret"));
 });
+
+test("preserves personal proxy backend errors without returning submitted credentials", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "personal-proxy-error-"));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  const configDir = path.join(root, "config");
+  await fs.mkdir(configDir, { recursive: true });
+  await fs.writeFile(path.join(configDir, "config.json"), JSON.stringify({ api_key: "secret" }));
+  const deps = {
+    env: { NEXTBROWSER_CONFIG_DIR: configDir, CLAWCTL_SKILL_SERVICE: "https://core.test" },
+    fetchImpl: async () => ({
+      ok: false,
+      status: 422,
+      text: async () => JSON.stringify({ error: "Proxy credentials were rejected." }),
+    }),
+  };
+
+  await assert.rejects(
+    createPersonalProxy({ name: "Broken", scheme: "http", host: "proxy.test", port: 8080, password: "do-not-return" }, deps),
+    (error) => error.status === 422
+      && error.message === "Proxy credentials were rejected."
+      && !error.message.includes("do-not-return"),
+  );
+});

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -7,7 +7,7 @@ import { Icon, Spinner } from "./Icon";
 import { withLocalScripts } from "../skillsCatalog";
 import { countryFlag, countryLabel, ROTATION_COUNTRIES } from "../lib/countryFlag";
 import { guideProfileTarget } from "../lib/guideQuickStart";
-import { manualProxyDefaultName, parseManualProxyUrl, type ManualProxyScheme } from "../lib/manualProxy";
+import { manualProxyDefaultName, manualProxyLimits, parseManualProxyUrl, validateManualProxyFields, type ManualProxyScheme } from "../lib/manualProxy";
 import { internalError, needsSupportLink } from "../lib/userFacingError";
 import { cancelNextctlRun } from "../nextctl";
 import { conversationPreview, type AppTab } from "../types";
@@ -352,9 +352,11 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
         ...parsed,
       };
     } else {
-      const port = Number.parseInt(manualPort, 10);
-      if (!name || !manualHost.trim() || !Number.isInteger(port) || port < 1 || port > 65535) {
-        setManualError("Name, host, and a valid port are required.");
+      const port = Number(manualPort);
+      try {
+        validateManualProxyFields({ name, host: manualHost, port, username: manualUsername, password: manualPassword });
+      } catch (error) {
+        setManualError(error instanceof Error ? error.message : String(error));
         return;
       }
       input = {
@@ -366,6 +368,12 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
         password: manualPassword,
       };
     }
+    try {
+      validateManualProxyFields(input);
+    } catch (error) {
+      setManualError(error instanceof Error ? error.message : String(error));
+      return;
+    }
     setManualSaving(true);
     setManualError(null);
     try {
@@ -373,8 +381,13 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
       setProfilePersonalProxyId(saved.id);
       resetManualProxyForm();
       setManualProxyEditing(false);
-    } catch {
-      setManualError(internalError("We couldn't save the proxy.", "PERSONAL_PROXY_SAVE_FAILED"));
+    } catch (error) {
+      const detail = (error instanceof Error ? error.message : String(error))
+        .replace(/^Error invoking remote method '[^']+': Error:\s*/, "")
+        .trim();
+      setManualError(detail && !/^fetch failed$/i.test(detail)
+        ? detail
+        : internalError("We couldn't save the proxy. Check the format and your connection, then try again.", "PERSONAL_PROXY_SAVE_FAILED"));
     } finally {
       setManualSaving(false);
     }
@@ -1224,6 +1237,7 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
                         value={manualProxyUrl}
                         onChange={(e) => setManualProxyUrl(e.target.value)}
                         placeholder="http://user:pass@host:8080"
+                        maxLength={manualProxyLimits.url + 1}
                         autoFocus
                       />
                     </label>
@@ -1233,6 +1247,7 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
                         value={manualName}
                         onChange={(e) => setManualName(e.target.value)}
                         placeholder="generated from proxy URL"
+                        maxLength={manualProxyLimits.name + 1}
                       />
                     </label>
                   </>
@@ -1240,7 +1255,7 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
                   <>
                     <label className="modal-field">
                       <span>Name</span>
-                      <input value={manualName} onChange={(e) => setManualName(e.target.value)} autoFocus />
+                      <input value={manualName} maxLength={manualProxyLimits.name + 1} onChange={(e) => setManualName(e.target.value)} autoFocus />
                     </label>
                     <div className="manual-proxy-grid">
                       <label className="modal-field">
@@ -1257,15 +1272,15 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
                     </div>
                     <label className="modal-field">
                       <span>Host</span>
-                      <input value={manualHost} onChange={(e) => setManualHost(e.target.value)} />
+                      <input value={manualHost} maxLength={manualProxyLimits.host + 1} onChange={(e) => setManualHost(e.target.value)} />
                     </label>
                     <label className="modal-field">
                       <span>Username</span>
-                      <input value={manualUsername} onChange={(e) => setManualUsername(e.target.value)} />
+                      <input value={manualUsername} maxLength={manualProxyLimits.username + 1} onChange={(e) => setManualUsername(e.target.value)} />
                     </label>
                     <label className="modal-field">
                       <span>Password</span>
-                      <input type="password" value={manualPassword} onChange={(e) => setManualPassword(e.target.value)} />
+                      <input type="password" value={manualPassword} maxLength={manualProxyLimits.password + 1} onChange={(e) => setManualPassword(e.target.value)} />
                     </label>
                   </>
                 )}

--- a/src/lib/manualProxy.test.ts
+++ b/src/lib/manualProxy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { manualProxyDefaultName, parseManualProxyUrl } from "./manualProxy";
+import { manualProxyDefaultName, manualProxyLimits, parseManualProxyUrl, validateManualProxyFields } from "./manualProxy";
 
 describe("manual proxy URL parsing", () => {
   it("parses HTTP proxy URLs with credentials", () => {
@@ -54,6 +54,24 @@ describe("manual proxy URL parsing", () => {
       host: "[::1]",
       port: 1080,
     });
+  });
+
+  it("rejects URL parts that are not proxy connection details", () => {
+    expect(() => parseManualProxyUrl("http://proxy.example:8080/path"))
+      .toThrow("remove the path, query, or fragment");
+    expect(() => parseManualProxyUrl("http://proxy.example:8080?x=1"))
+      .toThrow("remove the path, query, or fragment");
+  });
+
+  it("reports field length limits and malformed field values", () => {
+    expect(() => validateManualProxyFields({ name: "x".repeat(manualProxyLimits.name + 1), host: "host", port: 80, username: "", password: "" }))
+      .toThrow("Proxy name is too long");
+    expect(() => validateManualProxyFields({ name: "Proxy", host: "bad host", port: 80, username: "", password: "" }))
+      .toThrow("cannot contain spaces");
+    expect(() => validateManualProxyFields({ name: "Proxy", host: "host", port: 12.5, username: "", password: "" }))
+      .toThrow("whole number between 1 and 65535");
+    expect(() => validateManualProxyFields({ name: "Proxy", host: "host", port: 80, username: "x".repeat(manualProxyLimits.username + 1), password: "" }))
+      .toThrow("Proxy username is too long");
   });
 
   it("builds stable generated profile names", () => {

--- a/src/lib/manualProxy.test.ts
+++ b/src/lib/manualProxy.test.ts
@@ -39,6 +39,23 @@ describe("manual proxy URL parsing", () => {
     expect(() => parseManualProxyUrl("https://proxy.example:443")).toThrow("http:// or socks5://");
   });
 
+  it.each([
+    ["", "Proxy URL is required."],
+    ["http://", "Enter a valid proxy URL."],
+    ["http://proxy.example:0", "Proxy URL must include a valid port."],
+    ["http://proxy.example:65536", "Enter a valid proxy URL."],
+  ])("rejects invalid proxy URL %j", (value, message) => {
+    expect(() => parseManualProxyUrl(value)).toThrow(message);
+  });
+
+  it("parses IPv6 proxy hosts", () => {
+    expect(parseManualProxyUrl("socks5://[::1]:1080")).toMatchObject({
+      scheme: "socks5",
+      host: "[::1]",
+      port: 1080,
+    });
+  });
+
   it("builds stable generated profile names", () => {
     expect(manualProxyDefaultName(parseManualProxyUrl("socks5://proxy.example:1080"))).toBe(
       "manual-socks5-proxy.example-1080",

--- a/src/lib/manualProxy.ts
+++ b/src/lib/manualProxy.ts
@@ -8,6 +8,14 @@ export interface ParsedManualProxyUrl {
   password: string;
 }
 
+export const manualProxyLimits = {
+  name: 120,
+  host: 512,
+  username: 512,
+  password: 16_384,
+  url: 17_500,
+} as const;
+
 const defaultPorts: Record<ManualProxyScheme, number> = {
   http: 80,
   socks5: 1080,
@@ -25,6 +33,9 @@ function decodeUrlPart(value: string): string {
 export function parseManualProxyUrl(rawValue: string): ParsedManualProxyUrl {
   const raw = rawValue.trim();
   if (!raw) throw new Error("Proxy URL is required.");
+  if (raw.length > manualProxyLimits.url) {
+    throw new Error(`Proxy URL is too long (maximum ${manualProxyLimits.url.toLocaleString("en-US")} characters).`);
+  }
 
   let url: URL;
   try {
@@ -38,19 +49,62 @@ export function parseManualProxyUrl(rawValue: string): ParsedManualProxyUrl {
     throw new Error("Proxy URL must use http:// or socks5://.");
   }
   if (!url.hostname) throw new Error("Proxy URL must include a host.");
+  if ((url.pathname && url.pathname !== "/") || url.search || url.hash) {
+    throw new Error("Proxy URL must contain only scheme, credentials, host, and port — remove the path, query, or fragment.");
+  }
+  if (url.hostname.length > manualProxyLimits.host) {
+    throw new Error(`Proxy host is too long (maximum ${manualProxyLimits.host} characters).`);
+  }
 
   const port = url.port ? Number.parseInt(url.port, 10) : defaultPorts[scheme];
   if (!Number.isInteger(port) || port < 1 || port > 65535) {
     throw new Error("Proxy URL must include a valid port.");
   }
 
+  const username = decodeUrlPart(url.username);
+  const password = decodeUrlPart(url.password);
+  if (username.length > manualProxyLimits.username) {
+    throw new Error(`Proxy username is too long (maximum ${manualProxyLimits.username} characters).`);
+  }
+  if (password.length > manualProxyLimits.password) {
+    throw new Error(`Proxy password is too long (maximum ${manualProxyLimits.password.toLocaleString("en-US")} characters).`);
+  }
+
   return {
     scheme,
     host: url.hostname,
     port,
-    username: decodeUrlPart(url.username),
-    password: decodeUrlPart(url.password),
+    username,
+    password,
   };
+}
+
+export function validateManualProxyFields(input: {
+  name: string;
+  host: string;
+  port: number;
+  username?: string;
+  password?: string;
+}): void {
+  if (!input.name.trim()) throw new Error("Proxy name is required.");
+  if ([...input.name.trim()].length > manualProxyLimits.name) {
+    throw new Error(`Proxy name is too long (maximum ${manualProxyLimits.name} characters).`);
+  }
+  const host = input.host.trim();
+  if (!host) throw new Error("Proxy host is required.");
+  if (host.length > manualProxyLimits.host) {
+    throw new Error(`Proxy host is too long (maximum ${manualProxyLimits.host} characters).`);
+  }
+  if (/\s/.test(host)) throw new Error("Proxy host cannot contain spaces.");
+  if (!Number.isInteger(input.port) || input.port < 1 || input.port > 65535) {
+    throw new Error("Proxy port must be a whole number between 1 and 65535.");
+  }
+  if ((input.username?.length ?? 0) > manualProxyLimits.username) {
+    throw new Error(`Proxy username is too long (maximum ${manualProxyLimits.username} characters).`);
+  }
+  if ((input.password?.length ?? 0) > manualProxyLimits.password) {
+    throw new Error(`Proxy password is too long (maximum ${manualProxyLimits.password.toLocaleString("en-US")} characters).`);
+  }
 }
 
 export function manualProxyDefaultName(proxy: ParsedManualProxyUrl): string {

--- a/src/store.vps.test.ts
+++ b/src/store.vps.test.ts
@@ -583,6 +583,18 @@ describe("browser profile creation", () => {
     expect(JSON.stringify(bridge.invoke.mock.calls)).not.toContain("NBC_PROXY_PASSWORD");
   });
 
+  it("rejects a failed saved-proxy profile creation without selecting the profile", async () => {
+    bridge.invoke.mockResolvedValue({
+      stdout: JSON.stringify({ ok: false, error: { code: "PROXY_CONNECTION_FAILED", message: "Proxy refused the connection." } }),
+      stderr: "",
+      code: 1,
+    });
+
+    await expect(useStore.getState().createPersonalProxyProfile("broken-proxy", "proxy-id"))
+      .rejects.toThrow("Proxy refused the connection.");
+    expect(useStore.getState().selectedProfile).not.toBe("broken-proxy");
+  });
+
   it("persists the personal proxy association in the workspace document", () => {
     useStore.setState({
       activeWorkspaceId: "workspace",


### PR DESCRIPTION
## Summary

- add clear client-side validation for proxy name, URL, host, port, username, and password
- match the backend limits: name 120, host/username 512, password 16,384 characters, port 1–65535
- reject unsupported schemes and URL paths, queries, or fragments with actionable messages
- surface safe backend errors instead of replacing every failure with a generic message
- add success, malformed-input, backend-failure, credential-safety, and failed-profile tests

## Live proxy verification

A public HTTP proxy from the frequently refreshed ProxyScrape list was tested with non-sensitive IP echo requests:

- proxy URL: `http://34.94.46.8:80`
- direct IP: `212.28.86.243`
- proxied IP: `34.94.46.8`
- HTTP target: 200
- HTTPS target through CONNECT: 200

Public proxies are untrusted and unstable; this address is included only as a point-in-time functional smoke test.

## Validation

- targeted Vitest suite — 44 passed
- Electron project sync tests — 4 passed
- targeted nextctl Go manual-proxy tests — passed
- TypeScript compilation — passed
- Vite production build — passed

## Environment limitation

The installed Electron/nextctl runtime has no configured Clawbrowser API key, so it correctly stops profile creation with structured `API_KEY_REQUIRED` before a full browser launch.