### PR TITLE
fix: make automation replay resilient to transient navigation errors

### DIFF
--- a/electron/automation-runner.cjs
+++ b/electron/automation-runner.cjs
@@ -10,6 +10,13 @@ const DIRECT_TOOLS = new Set([
 ]);
 const LOCAL_TOOLS = new Set(["save_artifact"]);
 const activeExecutions = new Map();
+const RETRYABLE_NAVIGATION_ERRORS = [
+  "ERR_SSL_PROTOCOL_ERROR",
+  "ERR_NETWORK_CHANGED",
+  "ERR_CONNECTION_RESET",
+  "ERR_CONNECTION_CLOSED",
+  "ERR_TIMED_OUT",
+];
 
 function cleanExecutionId(value) {
   const id = String(value || "").trim();
@@ -180,6 +187,24 @@ function parseToolResult(result) {
   catch { return text; }
 }
 
+function isRetryableNavigationError(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  return RETRYABLE_NAVIGATION_ERRORS.some((code) => message.includes(code));
+}
+
+async function callBrowserTool(client, call, options = {}) {
+  const attempts = call.name === "open" ? 3 : 1;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      return parseToolResult(await client.callTool(call.name, call.arguments));
+    } catch (error) {
+      if (attempt + 1 >= attempts || !isRetryableNavigationError(error) || options.cancelled?.()) throw error;
+      options.onRetry?.(attempt + 1, error);
+      await (options.sleep || ((ms) => new Promise((resolve) => setTimeout(resolve, ms))))(attempt === 0 ? 400 : 900);
+    }
+  }
+}
+
 function boundedOutput(value, maxBytes = 1_500_000) {
   if (value == null) return value;
   try {
@@ -300,7 +325,11 @@ async function executeAutomationRecipe(input, deps) {
           const scopedArguments = profile
             ? { ...resolved.arguments, profile }
             : resolved.arguments;
-          output = parseToolResult(await client.callTool(resolved.name, scopedArguments));
+          output = await callBrowserTool(client, { name: resolved.name, arguments: scopedArguments }, {
+            cancelled: () => state.cancelled,
+            sleep: deps.sleep,
+            onRetry: (attempt) => progress({ phase: "running", stepIndex: index, tool: action.tool, detail: `Temporary network error. Retrying navigation (${attempt}/2)…` }),
+          });
           callOutputs.push(output);
         }
         localResults.push({ index, tool: action.tool, ok: true, output });

--- a/electron/automation-runner.test.cjs
+++ b/electron/automation-runner.test.cjs
@@ -123,6 +123,42 @@ test("executes every recipe step through one persistent MCP process", async () =
   assert.equal(progress.at(-1).phase, "completed");
 });
 
+test("retries only transient navigation failures", async () => {
+  let opens = 0;
+  const server = fakeMCP((message) => {
+    if (message.method === "initialize") return { protocolVersion: "2025-03-26", capabilities: {} };
+    if (message.params.name === "open" && opens++ === 0) {
+      return { isError: true, content: [{ type: "text", text: "navigation failed: net::ERR_SSL_PROTOCOL_ERROR" }] };
+    }
+    return { content: [{ type: "text", text: JSON.stringify({ ok: true }) }] };
+  });
+  const progress = [];
+  const result = await executeAutomationRecipe({
+    executionId: "retry-navigation",
+    recipe: { version: 1, actions: [{ tool: "open", arguments: { url: "https://example.com" } }] },
+  }, { binary: "nbc", env: {}, spawnImpl: server.spawnImpl, sleep: async () => {}, onProgress: (update) => progress.push(update) });
+
+  assert.equal(result.status, "completed");
+  assert.equal(opens, 2);
+  assert.ok(progress.some((update) => /Retrying navigation/.test(update.detail)));
+});
+
+test("does not retry permanent navigation failures", async () => {
+  let opens = 0;
+  const server = fakeMCP((message) => {
+    if (message.method === "initialize") return { protocolVersion: "2025-03-26", capabilities: {} };
+    opens += 1;
+    return { isError: true, content: [{ type: "text", text: "navigation failed: invalid URL" }] };
+  });
+  const result = await executeAutomationRecipe({
+    executionId: "no-retry-invalid-url",
+    recipe: { version: 1, actions: [{ tool: "open", arguments: { url: "not-a-url" } }] },
+  }, { binary: "nbc", env: {}, spawnImpl: server.spawnImpl, sleep: async () => {} });
+
+  assert.equal(result.status, "failed");
+  assert.equal(opens, 1);
+});
+
 test("runs artifact steps locally with access to earlier results", async () => {
   const server = fakeMCP((message) => message.method === "initialize"
     ? { protocolVersion: "2025-03-26", capabilities: {} }

--- a/src/lib/workflowCapture.test.ts
+++ b/src/lib/workflowCapture.test.ts
@@ -35,6 +35,11 @@ describe("terminal workflow capture", () => {
     expect(capturedWorkflowDomain("найди все матизы", answer)).toBe("makler.md");
   });
 
+  it("does not mistake an artifact filename for the website that was opened", () => {
+    const answer = 'Called clawbrowser.open({"url":"https://news.ycombinator.com/newest"})\n{"ok":true}';
+    expect(capturedWorkflowDomain("Collect stories and save them as hacker-news-newest.csv", answer)).toBe("news.ycombinator.com");
+  });
+
   it("creates a useful title and normalized instructions", () => {
     const task = terminalBrowserTask(transcript);
     expect(workflowTitle(task, "makler.md")).toBe("makler.md — матизы");

--- a/src/lib/workflowCapture.ts
+++ b/src/lib/workflowCapture.ts
@@ -159,12 +159,17 @@ function publicDomainsInText(text: string): string[] {
 
 /** Resolve the task's website without accidentally selecting verification/API URLs from tool output. */
 export function capturedWorkflowDomain(task: string, transcript: string): string {
-  const requested = workflowDomain(task);
-  if (requested) return requested;
+  // An explicit URL in the request is authoritative. For bare dotted tokens,
+  // prefer the URL that was actually opened: artifact names such as report.csv
+  // otherwise look like hostnames and leak into recording cards and titles.
+  const explicitRequested = publicDomainsInText(task)[0];
+  if (explicitRequested) return explicitRequested;
   for (const call of capturedCalls(transcript)) {
     const domain = publicDomainFromURL(call.args.url);
     if (domain) return domain;
   }
+  const requested = workflowDomain(task);
+  if (requested) return requested;
   // Normal chat messages may keep tool events outside the rendered answer. Result
   // links are still a reliable fallback once internal verification hosts are removed.
   return publicDomainsInText(transcript)[0] ?? "";


### PR DESCRIPTION
## Summary
- retry only transient TLS/network failures during deterministic navigation
- show retry progress instead of failing the whole recording immediately
- resolve recording-card domains from the actually opened URL before dotted artifact filenames

## Verification
- replayed both real-site demo recordings end to end in the dev app
- Hacker News and Wikipedia each recovered from an initial ERR_SSL_PROTOCOL_ERROR and completed all 4 steps
- full test suite: 389 Vitest tests + 137 Node tests
- production build passed