### PR TITLE
fix: production backend routing and startup credential access

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,6 +58,10 @@ NEXTBROWSER_DEV_API_BASE_URL=http://127.0.0.1:18098 npm run dev
 ~~~
 
 `NEXTBROWSER_DEV_API_BASE_URL` has priority over production API settings in the desktop process.
+For a dedicated non-production entity service without changing browser runtime traffic, use
+`NEXTBROWSER_ENTITY_API_BASE_URL`. `NEXTBROWSER_RUNTIME_API_BASE_URL` controls only browser
+runtime traffic. Production defaults remain `core.nextbrowser.com` for workspace/Automation
+entities and `api.nextbrowser.com` for browser sessions.
 
 Before submitting application changes, run:
 

--- a/electron/agent-workspace.test.cjs
+++ b/electron/agent-workspace.test.cjs
@@ -102,6 +102,13 @@ test("manual proxy operations use the isolated NextBrowser account configuration
   assert.equal((main.match(/resolvePersonalProxy\(args\.proxyId, \{ env: childEnv\(\) \}\)/g) || []).length, 2);
 });
 
+test("ordinary app startup does not unlock the optional Multilogin credential", () => {
+  const main = fs.readFileSync(path.join(__dirname, "main.cjs"), "utf8");
+  const startup = main.slice(main.indexOf("app.whenReady()"), main.indexOf('app.on("open-url"'));
+  assert.doesNotMatch(startup, /initializeMultiloginCredential/);
+  assert.match(main, /async function multiloginStatus\(\)[\s\S]*initializeMultiloginCredential\(\)/);
+});
+
 test("automation artifacts are persisted only in local app storage", () => {
   const main = fs.readFileSync(path.join(__dirname, "main.cjs"), "utf8");
   const studio = fs.readFileSync(path.join(__dirname, "..", "src", "components", "AutomationStudio.tsx"), "utf8");

--- a/electron/agent-workspace.test.cjs
+++ b/electron/agent-workspace.test.cjs
@@ -94,6 +94,14 @@ test("terminal attachments are staged inside the sandboxed workspace", () => {
   assert.match(terminal, /Please inspect the attached file\(s\)\./);
 });
 
+test("manual proxy operations use the isolated NextBrowser account configuration", () => {
+  const main = fs.readFileSync(path.join(__dirname, "main.cjs"), "utf8");
+  assert.match(main, /listPersonalProxies\(\{ env: childEnv\(\) \}\)/);
+  assert.match(main, /createPersonalProxy\(args\.proxy, \{ env: childEnv\(\) \}\)/);
+  assert.match(main, /deletePersonalProxy\(args\.id, \{ env: childEnv\(\) \}\)/);
+  assert.equal((main.match(/resolvePersonalProxy\(args\.proxyId, \{ env: childEnv\(\) \}\)/g) || []).length, 2);
+});
+
 test("automation artifacts are persisted only in local app storage", () => {
   const main = fs.readFileSync(path.join(__dirname, "main.cjs"), "utf8");
   const studio = fs.readFileSync(path.join(__dirname, "..", "src", "components", "AutomationStudio.tsx"), "utf8");

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -921,16 +921,16 @@ async function invokeCommand(command, args = {}, sender) {
     case "multilogin_status": return await multiloginStatus();
     case "multilogin_connect": return await connectMultilogin(args.bearerToken);
     case "multilogin_disconnect": return await disconnectMultilogin();
-    case "manual_proxies_list": return await listPersonalProxies();
-    case "manual_proxy_save": return await createPersonalProxy(args.proxy);
-    case "manual_proxy_delete": return await deletePersonalProxy(args.id);
+    case "manual_proxies_list": return await listPersonalProxies({ env: childEnv() });
+    case "manual_proxy_save": return await createPersonalProxy(args.proxy, { env: childEnv() });
+    case "manual_proxy_delete": return await deletePersonalProxy(args.id, { env: childEnv() });
     case "manual_proxy_profile_create": {
       const profileName = String(args.profileName || "").trim();
       if (!profileName) throw new Error("Profile name is required.");
       const runtime = ["clawbrowser", "dasbrowser", "camoufox"].includes(args.runtime)
         ? args.runtime
         : "clawbrowser";
-      const proxy = await resolvePersonalProxy(args.proxyId);
+      const proxy = await resolvePersonalProxy(args.proxyId, { env: childEnv() });
       return await executeNextctl([
         "profiles", "create", profileName,
         "--manual-proxy",
@@ -952,7 +952,7 @@ async function invokeCommand(command, args = {}, sender) {
       const runtime = ["clawbrowser", "dasbrowser", "camoufox"].includes(args.runtime)
         ? args.runtime
         : "clawbrowser";
-      const proxy = await resolvePersonalProxy(args.proxyId);
+      const proxy = await resolvePersonalProxy(args.proxyId, { env: childEnv() });
       return await executeNextctl([
         "profiles", "set-proxy", profileName,
         "--manual-proxy",

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1751,7 +1751,6 @@ if (!gotLock) {
   }).then(() => {
     return migrateLegacyRuntimeConfig();
   }).then(() => {
-    void initializeMultiloginCredential();
     applyAppIcon();
     if (process.defaultApp) {
       const script = process.argv[1];

--- a/electron/project-sync.cjs
+++ b/electron/project-sync.cjs
@@ -6,14 +6,14 @@ const REQUEST_TIMEOUT_MS = 30_000;
 const DEFAULT_SKILL_SERVICE_URL = "https://core.nextbrowser.com";
 
 function entityBackendURL(env = process.env) {
-  // next-browser-api owns both the entity APIs and the browser-facing API.
-  // A dev/staging API override must therefore move the whole app to the same
-  // backend instead of leaving Automation Studio pointed at production.
+  // Entity sync and browser runtime traffic intentionally use different
+  // production services. childEnv() always injects CLAWBROWSER_API_BASE_URL for
+  // browser sessions, so accepting that variable here silently sends workspace
+  // and Automation requests to api.nextbrowser.com instead of core.nextbrowser.com.
   const raw = String(
     env.CLAWCTL_SKILL_SERVICE
       || env.NEXTBROWSER_DEV_API_BASE_URL
-      || env.NEXTBROWSER_API_BASE_URL
-      || env.CLAWBROWSER_API_BASE_URL
+      || env.NEXTBROWSER_ENTITY_API_BASE_URL
       || DEFAULT_SKILL_SERVICE_URL,
   ).trim();
   const parsed = new URL(raw);

--- a/electron/project-sync.test.cjs
+++ b/electron/project-sync.test.cjs
@@ -42,11 +42,11 @@ test("uses the same default backend as cloud skills", () => {
 
 test("moves entity sync with an app API override", () => {
   assert.equal(
-    entityBackendURL({ NEXTBROWSER_API_BASE_URL: "http://127.0.0.1:18098/" }),
+    entityBackendURL({ NEXTBROWSER_DEV_API_BASE_URL: "http://127.0.0.1:18098/" }),
     "http://127.0.0.1:18098",
   );
   assert.equal(
-    entityBackendURL({ CLAWBROWSER_API_BASE_URL: "https://staging-api.nextbrowser.test/" }),
+    entityBackendURL({ NEXTBROWSER_ENTITY_API_BASE_URL: "https://staging-api.nextbrowser.test/" }),
     "https://staging-api.nextbrowser.test",
   );
   assert.equal(
@@ -55,6 +55,16 @@ test("moves entity sync with an app API override", () => {
       CLAWCTL_SKILL_SERVICE: "https://entities.test/",
     }),
     "https://entities.test",
+  );
+});
+
+test("keeps runtime API variables away from the production entity service", () => {
+  assert.equal(
+    entityBackendURL({
+      NEXTBROWSER_API_BASE_URL: "https://api.nextbrowser.com",
+      CLAWBROWSER_API_BASE_URL: "https://api.nextbrowser.com",
+    }),
+    "https://core.nextbrowser.com",
   );
 });
 

--- a/src/components/MultiloginChatProfilePicker.test.tsx
+++ b/src/components/MultiloginChatProfilePicker.test.tsx
@@ -23,7 +23,7 @@ function render({
   profileKind = "browser" as const,
   selection,
 }: {
-  status?: MultiloginConnectionStatus;
+  status?: MultiloginConnectionStatus | null;
   open?: boolean;
   query?: string;
   profileKind?: "browser" | "mobile";
@@ -109,5 +109,16 @@ describe("MultiloginChatProfilePickerView", () => {
     expect(html).toContain("7_GitHub_acc");
     expect(html).toContain("Token expired");
     expect(html).toContain("Manage connector");
+  });
+
+  it("renders a saved selection without treating an unopened credential as disconnected", () => {
+    const html = render({
+      status: null,
+      selection: { kind: "browser", id: "browser-1", name: "7_GitHub_acc" },
+    });
+
+    expect(html).toContain("7_GitHub_acc");
+    expect(html).not.toContain("is-warning");
+    expect(html).not.toContain("Reconnect");
   });
 });

--- a/src/components/MultiloginChatProfilePicker.tsx
+++ b/src/components/MultiloginChatProfilePicker.tsx
@@ -60,7 +60,9 @@ export function MultiloginChatProfilePickerView({
   onManage,
   searchRef,
 }: MultiloginChatProfilePickerViewProps) {
-  const connected = Boolean(status?.connected && status.valid);
+  // A persisted selection can be rendered without unlocking its credential.
+  // Validate it only when the person explicitly opens the picker.
+  const connected = status == null ? Boolean(selection) : Boolean(status.connected && status.valid);
   if (!selection && !status?.connected) return null;
 
   const browserProfiles = status?.browserProfiles ?? [];
@@ -192,7 +194,7 @@ export function MultiloginChatProfilePicker({
   const rootRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
   const [status, setStatus] = useState<MultiloginConnectionStatus | null>(() => preview ? previewMultiloginConnectionStatus() : null);
-  const [checking, setChecking] = useState(!preview);
+  const [checking, setChecking] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string>();
   const [open, setOpen] = useState(false);
@@ -216,14 +218,6 @@ export function MultiloginChatProfilePicker({
       setRefreshing(false);
     }
   }, [preview]);
-
-  useEffect(() => {
-    if (preview || !workspaceId) {
-      setChecking(false);
-      return;
-    }
-    void loadStatus();
-  }, [loadStatus, preview, workspaceId]);
 
   useEffect(() => {
     if (selection) setProfileKind(selection.kind);


### PR DESCRIPTION
## Summary
- keep workspace, Automation, and personal-proxy entity traffic on core.nextbrowser.com
- prevent browser runtime variables from overriding the production entity service
- pass the isolated NextBrowser account config to every manual-proxy operation
- stop unlocking the optional Multilogin credential during ordinary app startup
- load and validate Multilogin only when the picker, Connector, or Multilogin runtime is explicitly used
- document separate entity and runtime backend overrides

## Root causes
1. The desktop child environment always injects CLAWBROWSER_API_BASE_URL=https://api.nextbrowser.com for browser sessions. Entity sync reused that variable, so production workspaces and Automation requests were sent to api.nextbrowser.com and failed with 401 Invalid JWT instead of reaching core.nextbrowser.com.
2. The main process and chat picker eagerly loaded the optional Multilogin credential at startup, causing macOS Keychain prompts even when Multilogin was not being used.

## Verification
- production key validation: 200
- packaged macOS app without environment overrides: 3 workspaces and 4 production recordings loaded
- packaged app ordinary startup: no Keychain access/error
- manual proxy list loaded successfully
- Hacker News and Wikipedia production recordings completed all 4 steps
- full tests: 389 Vitest + 138 Node tests
- production build and packaged macOS app passed