### PR TITLE
feat: make the automation library account scoped

### DIFF
--- a/.agents/skills/nextbrowser-user-journey-qa/references/acceptance-matrix.md
+++ b/.agents/skills/nextbrowser-user-journey-qa/references/acceptance-matrix.md
@@ -102,7 +102,7 @@ Avoid destructive posting, purchases, account creation, or messages unless the u
 
 ### Persistence and sharing
 
-- Recordings/workflows survive app restart and appear in the correct workspace.
+- Recordings/workflows survive app restart and appear in the account automation library from every workspace; run history and local artifacts remain in the workspace where execution occurred.
 - Unsaved/in-progress attempts do not reappear as completed entities.
 - Shared entities exclude credentials, transient profile identifiers, and local artifact contents unless explicitly part of the sharing design.
 

--- a/docs/automation-audit.md
+++ b/docs/automation-audit.md
@@ -37,7 +37,7 @@ It does not currently support:
 | 7 | Isolation | Competing workspace, agent, and pre-start runs | Pass; only the owning workspace, agent, and time window are captured |
 | 8 | Security | Password, bearer token, API key, card/security-code contexts | Pass; values redacted client-side and raw secrets rejected by workflow API |
 | 9 | Builder lifecycle | Duplicate, invalidate domain, block Save/Run, save revision, delete | Pass; inline validation and optimistic revisions work |
-| 10 | Persistence lifecycle | PostgreSQL CRUD for recordings/workflows/runs; local CRUD for artifacts | Pass; terminal run states cannot revert, steps close with the run, and artifacts remain in per-workspace app storage until the user deletes them |
+| 10 | Persistence lifecycle | PostgreSQL CRUD for account recordings/workflows and workspace runs; local CRUD for artifacts | Pass; reusable automations follow the signed-in account, terminal run states cannot revert, steps close with the run, and artifacts remain in per-workspace app storage until the user deletes them |
 | 11 | Visual workflow authoring | Select a Books result row, title, price, and URL, then run the generated recipe | Pass; 20 rows collected with generated relative selectors and automatic `href` extraction |
 
 ## Defects found and corrected

--- a/electron/automation-sync.cjs
+++ b/electron/automation-sync.cjs
@@ -49,7 +49,46 @@ async function listAutomationShares(box, deps) {
   return body?.shares || [];
 }
 const createAutomationShare = (share, deps) => projectRequest("/v1/automation/shares", { method: "POST", body: JSON.stringify(share) }, deps);
-const acceptAutomationShare = (id, workspaceId, deps) => projectRequest(`/v1/automation/shares/${encodeURIComponent(id)}/accept`, { method: "POST", body: JSON.stringify({ workspace_id: workspaceId }) }, deps);
+async function acceptAutomationShare(id, workspaceId, workspace, deps) {
+  const accept = () => projectRequest(`/v1/automation/shares/${encodeURIComponent(id)}/accept`, {
+    method: "POST", body: JSON.stringify({ workspace_id: workspaceId }),
+  }, deps);
+  try {
+    return await accept();
+  } catch (error) {
+    // A newly created/local workspace can be visible in the renderer before the
+    // best-effort project sync has created it for this account. Repair that race
+    // here so accepting an inbox item remains a single user action.
+    if (error?.status !== 404 || !/workspace not found/i.test(String(error?.message || ""))) throw error;
+  }
+  if (!workspaceId || !String(workspace?.name || "").trim()) {
+    const error = new Error("Select or create a workspace for this account, then add the shared copy again.");
+    error.code = "AUTOMATION_SHARE_WORKSPACE_UNAVAILABLE";
+    throw error;
+  }
+  try {
+    await projectRequest(`/v1/workspaces/${encodeURIComponent(workspaceId)}`, {
+      method: "PUT",
+      body: JSON.stringify({
+        name: String(workspace.name).trim(),
+        document: workspace.document && typeof workspace.document === "object" ? workspace.document : {},
+        base_revision: 0,
+      }),
+    }, deps);
+  } catch (syncError) {
+    // A concurrent sync may have won after the first accept request. Only hide
+    // that conflict when the destination now belongs to this account.
+    if (syncError?.status === 409) {
+      const listed = await projectRequest("/v1/workspaces", {}, deps);
+      if ((listed?.workspaces || []).some((item) => String(item?.id || "") === workspaceId)) return await accept();
+    }
+    const error = new Error("This workspace is not available for the signed-in account. Select or create a workspace for this account, then add the shared copy again.");
+    error.code = "AUTOMATION_SHARE_WORKSPACE_UNAVAILABLE";
+    error.cause = syncError;
+    throw error;
+  }
+  return await accept();
+}
 const declineAutomationShare = (id, deps) => projectRequest(`/v1/automation/shares/${encodeURIComponent(id)}/decline`, { method: "POST" }, deps);
 const revokeAutomationShare = (id, deps) => projectRequest(`/v1/automation/shares/${encodeURIComponent(id)}`, { method: "DELETE" }, deps);
 

--- a/electron/automation-sync.cjs
+++ b/electron/automation-sync.cjs
@@ -14,16 +14,16 @@ function normalizeWorkflow(item) {
   };
 }
 
-async function listAutomationWorkflows(workspaceId, deps) {
-  const body = await projectRequest(`/v1/automation/workflows${query(workspaceId)}`, {}, deps);
+async function listAutomationWorkflows(deps) {
+  const body = await projectRequest("/v1/automation/workflows", {}, deps);
   return (body?.workflows || []).map(normalizeWorkflow);
 }
 
-async function putAutomationWorkflow(workspaceId, workflow, deps) {
+async function putAutomationWorkflow(workflow, deps) {
   const body = await projectRequest(`/v1/automation/workflows/${encodeURIComponent(workflow.id)}`, {
     method: "PUT",
     body: JSON.stringify({
-      workspace_id: workspaceId, title: workflow.title, domain: workflow.domain, task: workflow.task,
+      title: workflow.title, domain: workflow.domain, task: workflow.task,
       instructions: workflow.instructions, capability: workflow.capability,
       parameters_schema: workflow.parametersSchema || {}, output_schema: workflow.outputSchema || {},
       recipe: { ...workflow.recipe, actions: workflow.actions }, base_revision: workflow.revision || 0,
@@ -34,8 +34,8 @@ async function putAutomationWorkflow(workspaceId, workflow, deps) {
 
 const deleteAutomationWorkflow = (id, deps) => projectRequest(`/v1/automation/workflows/${encodeURIComponent(id)}`, { method: "DELETE" }, deps);
 
-async function listAutomationRecordings(workspaceId, deps) {
-  const body = await projectRequest(`/v1/automation/recordings${query(workspaceId)}`, {}, deps);
+async function listAutomationRecordings(deps) {
+  const body = await projectRequest("/v1/automation/recordings", {}, deps);
   return body?.recordings || [];
 }
 
@@ -49,46 +49,7 @@ async function listAutomationShares(box, deps) {
   return body?.shares || [];
 }
 const createAutomationShare = (share, deps) => projectRequest("/v1/automation/shares", { method: "POST", body: JSON.stringify(share) }, deps);
-async function acceptAutomationShare(id, workspaceId, workspace, deps) {
-  const accept = () => projectRequest(`/v1/automation/shares/${encodeURIComponent(id)}/accept`, {
-    method: "POST", body: JSON.stringify({ workspace_id: workspaceId }),
-  }, deps);
-  try {
-    return await accept();
-  } catch (error) {
-    // A newly created/local workspace can be visible in the renderer before the
-    // best-effort project sync has created it for this account. Repair that race
-    // here so accepting an inbox item remains a single user action.
-    if (error?.status !== 404 || !/workspace not found/i.test(String(error?.message || ""))) throw error;
-  }
-  if (!workspaceId || !String(workspace?.name || "").trim()) {
-    const error = new Error("Select or create a workspace for this account, then add the shared copy again.");
-    error.code = "AUTOMATION_SHARE_WORKSPACE_UNAVAILABLE";
-    throw error;
-  }
-  try {
-    await projectRequest(`/v1/workspaces/${encodeURIComponent(workspaceId)}`, {
-      method: "PUT",
-      body: JSON.stringify({
-        name: String(workspace.name).trim(),
-        document: workspace.document && typeof workspace.document === "object" ? workspace.document : {},
-        base_revision: 0,
-      }),
-    }, deps);
-  } catch (syncError) {
-    // A concurrent sync may have won after the first accept request. Only hide
-    // that conflict when the destination now belongs to this account.
-    if (syncError?.status === 409) {
-      const listed = await projectRequest("/v1/workspaces", {}, deps);
-      if ((listed?.workspaces || []).some((item) => String(item?.id || "") === workspaceId)) return await accept();
-    }
-    const error = new Error("This workspace is not available for the signed-in account. Select or create a workspace for this account, then add the shared copy again.");
-    error.code = "AUTOMATION_SHARE_WORKSPACE_UNAVAILABLE";
-    error.cause = syncError;
-    throw error;
-  }
-  return await accept();
-}
+const acceptAutomationShare = (id, deps) => projectRequest(`/v1/automation/shares/${encodeURIComponent(id)}/accept`, { method: "POST" }, deps);
 const declineAutomationShare = (id, deps) => projectRequest(`/v1/automation/shares/${encodeURIComponent(id)}/decline`, { method: "POST" }, deps);
 const revokeAutomationShare = (id, deps) => projectRequest(`/v1/automation/shares/${encodeURIComponent(id)}`, { method: "DELETE" }, deps);
 
@@ -110,18 +71,18 @@ function exampleRun(id, task, title, evidence, createdAt) {
 
 const seedAutomationPromises = new Map();
 
-function seedAutomationExamples(workspaceId, deps) {
-  if (!workspaceId) throw new Error("A workspace is required for Automation Studio examples.");
-  const current = seedAutomationPromises.get(workspaceId);
+function seedAutomationExamples(deps) {
+  const key = "account";
+  const current = seedAutomationPromises.get(key);
   if (current) return current;
-  const promise = seedAutomationExamplesOnce(workspaceId, deps).finally(() => seedAutomationPromises.delete(workspaceId));
-  seedAutomationPromises.set(workspaceId, promise);
+  const promise = seedAutomationExamplesOnce(deps).finally(() => seedAutomationPromises.delete(key));
+  seedAutomationPromises.set(key, promise);
   return promise;
 }
 
-async function seedAutomationExamplesOnce(workspaceId, deps) {
+async function seedAutomationExamplesOnce(deps) {
   const [workflows, recordings] = await Promise.all([
-    listAutomationWorkflows(workspaceId, deps), listAutomationRecordings(workspaceId, deps),
+    listAutomationWorkflows(deps), listAutomationRecordings(deps),
   ]);
   const now = Date.now();
   const exampleVersion = 5;
@@ -135,7 +96,7 @@ async function seedAutomationExamplesOnce(workspaceId, deps) {
   for (const example of workflowExamples) {
     const existing = workflows.find((item) => item.recipe?.example_key === example.key || item.recipe?.demo_key === example.key || item.title === example.title);
     if (existing && Number(existing.recipe?.example_version || 0) >= exampleVersion) continue;
-    await putAutomationWorkflow(workspaceId, {
+    await putAutomationWorkflow({
       id: existing?.id || randomUUID(), ...example,
       instructions: "Execute the structured recipe first. Inspect the page and adapt selectors if its layout changed.",
       parametersSchema: { type: "object", properties: { task: { type: "string" } } },
@@ -152,7 +113,7 @@ async function seedAutomationExamplesOnce(workspaceId, deps) {
   for (const example of recordingExamples) {
     const existing = recordings.find((item) => item.document?.example_key === example.key || item.document?.demo_key === example.key);
     if (existing && Number(existing.document?.example_version || 0) >= exampleVersion) continue;
-    await putAutomationRecording({ id: existing?.id || randomUUID(), workspace_id: workspaceId, status: "completed", document: { run: example.run, example_key: example.key, example_version: exampleVersion }, base_revision: existing?.revision || 0 }, deps);
+    await putAutomationRecording({ id: existing?.id || randomUUID(), status: "completed", document: { run: example.run, example_key: example.key, example_version: exampleVersion }, base_revision: existing?.revision || 0 }, deps);
     seededRecordings += 1;
   }
   return { seeded: { workflows: seededWorkflows, recordings: seededRecordings } };

--- a/electron/automation-sync.test.cjs
+++ b/electron/automation-sync.test.cjs
@@ -19,11 +19,12 @@ const jsonResponse = (body, status = 200) => ({ ok: status < 400, status, text: 
 test("maps workflows and sends their optimistic revision", async (t) => {
   const backend = { id: "w", title: "Login", domain: "example.com", task: "Log in", instructions: "Do it", capability: "form", parameters_schema: {}, output_schema: {}, recipe: { version: 1, capability: "form", actions: [{ tool: "navigate", arguments: { url: "https://example.com" } }] }, revision: 4, created_at: "2026-01-01T00:00:00Z", updated_at: "2026-01-02T00:00:00Z" };
   const f = await fixture(t, (_url, options) => jsonResponse(options.method === "PUT" ? { ...backend, revision: 5 } : { workflows: [backend] }));
-  const listed = await listAutomationWorkflows("space id", f.deps);
+  const listed = await listAutomationWorkflows(f.deps);
   assert.equal(listed[0].actions[0].tool, "navigate");
-  assert.match(f.calls[0].url, /workspace_id=space%20id$/);
-  assert.equal((await putAutomationWorkflow("space id", listed[0], f.deps)).revision, 5);
+  assert.equal(f.calls[0].url, "https://core.test/v1/automation/workflows");
+  assert.equal((await putAutomationWorkflow(listed[0], f.deps)).revision, 5);
   assert.equal(JSON.parse(f.calls[1].options.body).base_revision, 4);
+  assert.equal("workspace_id" in JSON.parse(f.calls[1].options.body), false);
   assert.equal(f.calls[1].options.headers.authorization, "Bearer secret");
 });
 
@@ -48,7 +49,7 @@ test("deletes a recording through the backend", async (t) => {
 
 test("shares, accepts, declines, and revokes immutable automation copies by email", async (t) => {
   const f = await fixture(t, (url, options) => {
-    if (url.includes("/accept")) return jsonResponse({ id: "copy-id", source_kind: "workflow", workspace_id: "recipient-space" }, 201);
+    if (url.includes("/accept")) return jsonResponse({ id: "copy-id", source_kind: "workflow" }, 201);
     if (url.includes("/decline")) return { ok: true, status: 204, text: async () => "" };
     if (options.method === "POST") return jsonResponse({ id: "share-id", ...JSON.parse(options.body), status: "pending" }, 201);
     if (options.method === "DELETE") return { ok: true, status: 204, text: async () => "" };
@@ -59,56 +60,14 @@ test("shares, accepts, declines, and revokes immutable automation copies by emai
   assert.match(f.calls[0].url, /\/v1\/automation\/shares\?box=inbox$/);
   await createAutomationShare({ source_kind: "workflow", source_id: "flow-id", recipient_email: "friend@example.com" }, f.deps);
   assert.deepEqual(JSON.parse(f.calls[1].options.body), { source_kind: "workflow", source_id: "flow-id", recipient_email: "friend@example.com" });
-  assert.equal((await acceptAutomationShare("share/id", "recipient-space", {}, f.deps)).id, "copy-id");
+  assert.equal((await acceptAutomationShare("share/id", f.deps)).id, "copy-id");
   assert.match(f.calls[2].url, /\/shares\/share%2Fid\/accept$/);
-  assert.deepEqual(JSON.parse(f.calls[2].options.body), { workspace_id: "recipient-space" });
+  assert.equal(f.calls[2].options.body, undefined);
   await declineAutomationShare("share/id", f.deps);
   assert.match(f.calls[3].url, /\/shares\/share%2Fid\/decline$/);
   assert.equal(f.calls[3].options.method, "POST");
   await revokeAutomationShare("share/id", f.deps);
   assert.equal(f.calls[4].options.method, "DELETE");
-});
-
-test("creates a missing share destination workspace and retries acceptance once", async (t) => {
-  let attempts = 0;
-  const f = await fixture(t, (url, options) => {
-    if (url.includes("/accept")) {
-      attempts += 1;
-      return attempts === 1
-        ? jsonResponse({ error: "workspace not found" }, 404)
-        : jsonResponse({ id: "copy-id", source_kind: "workflow", workspace_id: "recipient-space" }, 201);
-    }
-    if (url.includes("/v1/workspaces/recipient-space")) return jsonResponse({ id: "recipient-space", revision: 1 });
-    throw new Error(`Unexpected request: ${url}`);
-  });
-
-  const result = await acceptAutomationShare("share-id", "recipient-space", {
-    name: "Recipient workspace",
-    document: { profileNames: ["Worker"], profileToolsets: { Worker: "clawbrowser" } },
-  }, f.deps);
-
-  assert.equal(result.id, "copy-id");
-  assert.equal(attempts, 2);
-  assert.match(f.calls[1].url, /\/v1\/workspaces\/recipient-space$/);
-  assert.deepEqual(JSON.parse(f.calls[1].options.body), {
-    name: "Recipient workspace",
-    document: { profileNames: ["Worker"], profileToolsets: { Worker: "clawbrowser" } },
-    base_revision: 0,
-  });
-});
-
-test("explains when a shared copy targets a workspace owned by another account", async (t) => {
-  const f = await fixture(t, (url) => {
-    if (url.includes("/accept")) return jsonResponse({ error: "workspace not found" }, 404);
-    if (url.includes("/v1/workspaces/recipient-space")) return jsonResponse({ error: "workspace revision conflict" }, 409);
-    if (url.endsWith("/v1/workspaces")) return jsonResponse({ workspaces: [] });
-    throw new Error(`Unexpected request: ${url}`);
-  });
-
-  await assert.rejects(
-    acceptAutomationShare("share-id", "recipient-space", { name: "Old account workspace", document: {} }, f.deps),
-    /not available for the signed-in account/i,
-  );
 });
 
 test("seeds exactly two successful backend examples for recordings and workflows", async (t) => {
@@ -126,7 +85,7 @@ test("seeds exactly two successful backend examples for recordings and workflows
     if (url.includes("/recordings")) return jsonResponse({ recordings: [] });
     throw new Error(`Unexpected request: ${url}`);
   });
-  assert.deepEqual((await seedAutomationExamples("space", f.deps)).seeded, { workflows: 2, recordings: 2 });
+  assert.deepEqual((await seedAutomationExamples(f.deps)).seeded, { workflows: 2, recordings: 2 });
   assert.equal(created.workflows.length, 2);
   assert.ok(created.workflows.every((item) => item.recipe.actions.length >= 2));
   assert.deepEqual(created.workflows.map((item) => item.domain).sort(), ["books.toscrape.com", "quotes.toscrape.com"]);
@@ -144,7 +103,7 @@ test("does not duplicate examples when their internal example markers already ex
     if (url.includes("/recordings")) return jsonResponse({ recordings: ["product-research", "site-search"].map((key) => ({ id: key, document: { example_key: key, example_version: 5 } })) });
     throw new Error(`Unexpected request: ${url}`);
   });
-  assert.deepEqual((await seedAutomationExamples("space", f.deps)).seeded, { workflows: 0, recordings: 0 });
+  assert.deepEqual((await seedAutomationExamples(f.deps)).seeded, { workflows: 0, recordings: 0 });
   assert.equal(f.calls.length, 2);
 });
 
@@ -168,7 +127,7 @@ test("migrates legacy demo markers without creating duplicate entities", async (
     throw new Error(`Unexpected request: ${url}`);
   });
 
-  assert.deepEqual((await seedAutomationExamples("legacy-space", f.deps)).seeded, { workflows: 1, recordings: 1 });
+  assert.deepEqual((await seedAutomationExamples(f.deps)).seeded, { workflows: 1, recordings: 1 });
   assert.equal(updated.workflows[0].id, legacyWorkflow.id);
   assert.equal(updated.workflows[0].recipe.example_key, "collect-products");
   assert.ok(!("demo_key" in updated.workflows[0].recipe));
@@ -178,15 +137,29 @@ test("migrates legacy demo markers without creating duplicate entities", async (
   assert.ok(!("demo_key" in updated.recordings[0].document));
 });
 
-test("coalesces concurrent seed requests for the same workspace", async (t) => {
+test("coalesces concurrent seed requests for the same account", async (t) => {
   const f = await fixture(t, (url) => {
     if (url.includes("/workflows")) return jsonResponse({ workflows: [] });
     if (url.includes("/recordings")) return jsonResponse({ recordings: [] });
     throw new Error(`Unexpected request: ${url}`);
   });
-  const first = seedAutomationExamples("shared-space", f.deps);
-  const second = seedAutomationExamples("shared-space", f.deps);
+  const first = seedAutomationExamples(f.deps);
+  const second = seedAutomationExamples(f.deps);
   assert.strictEqual(first, second);
   assert.deepEqual((await first).seeded, { workflows: 2, recordings: 2 });
   assert.equal(f.calls.filter((call) => call.options.method === undefined).length, 2);
+});
+
+test("keeps sharing account-scoped in the host and visible UI", async () => {
+  const [main, studio] = await Promise.all([
+    fs.readFile(path.join(__dirname, "main.cjs"), "utf8"),
+    fs.readFile(path.join(__dirname, "../src/components/AutomationStudio.tsx"), "utf8"),
+  ]);
+  assert.match(main, /automation_share_accept[\s\S]*acceptAutomationShare\(String\(args\.id \|\| ""\), \{ env: childEnv\(\) \}\)/);
+  assert.doesNotMatch(main, /automation_share_accept[\s\S]{0,240}workspaceId/);
+  assert.match(studio, /automation_share_accept", \{ id: share\.id \}/);
+  assert.match(studio, /Add to my automations/);
+  assert.match(studio, /Shared by you/);
+  assert.match(studio, /automation_share_revoke/);
+  assert.doesNotMatch(studio, /ready to add to this workspace/);
 });

--- a/electron/automation-sync.test.cjs
+++ b/electron/automation-sync.test.cjs
@@ -59,7 +59,7 @@ test("shares, accepts, declines, and revokes immutable automation copies by emai
   assert.match(f.calls[0].url, /\/v1\/automation\/shares\?box=inbox$/);
   await createAutomationShare({ source_kind: "workflow", source_id: "flow-id", recipient_email: "friend@example.com" }, f.deps);
   assert.deepEqual(JSON.parse(f.calls[1].options.body), { source_kind: "workflow", source_id: "flow-id", recipient_email: "friend@example.com" });
-  assert.equal((await acceptAutomationShare("share/id", "recipient-space", f.deps)).id, "copy-id");
+  assert.equal((await acceptAutomationShare("share/id", "recipient-space", {}, f.deps)).id, "copy-id");
   assert.match(f.calls[2].url, /\/shares\/share%2Fid\/accept$/);
   assert.deepEqual(JSON.parse(f.calls[2].options.body), { workspace_id: "recipient-space" });
   await declineAutomationShare("share/id", f.deps);
@@ -67,6 +67,48 @@ test("shares, accepts, declines, and revokes immutable automation copies by emai
   assert.equal(f.calls[3].options.method, "POST");
   await revokeAutomationShare("share/id", f.deps);
   assert.equal(f.calls[4].options.method, "DELETE");
+});
+
+test("creates a missing share destination workspace and retries acceptance once", async (t) => {
+  let attempts = 0;
+  const f = await fixture(t, (url, options) => {
+    if (url.includes("/accept")) {
+      attempts += 1;
+      return attempts === 1
+        ? jsonResponse({ error: "workspace not found" }, 404)
+        : jsonResponse({ id: "copy-id", source_kind: "workflow", workspace_id: "recipient-space" }, 201);
+    }
+    if (url.includes("/v1/workspaces/recipient-space")) return jsonResponse({ id: "recipient-space", revision: 1 });
+    throw new Error(`Unexpected request: ${url}`);
+  });
+
+  const result = await acceptAutomationShare("share-id", "recipient-space", {
+    name: "Recipient workspace",
+    document: { profileNames: ["Worker"], profileToolsets: { Worker: "clawbrowser" } },
+  }, f.deps);
+
+  assert.equal(result.id, "copy-id");
+  assert.equal(attempts, 2);
+  assert.match(f.calls[1].url, /\/v1\/workspaces\/recipient-space$/);
+  assert.deepEqual(JSON.parse(f.calls[1].options.body), {
+    name: "Recipient workspace",
+    document: { profileNames: ["Worker"], profileToolsets: { Worker: "clawbrowser" } },
+    base_revision: 0,
+  });
+});
+
+test("explains when a shared copy targets a workspace owned by another account", async (t) => {
+  const f = await fixture(t, (url) => {
+    if (url.includes("/accept")) return jsonResponse({ error: "workspace not found" }, 404);
+    if (url.includes("/v1/workspaces/recipient-space")) return jsonResponse({ error: "workspace revision conflict" }, 409);
+    if (url.endsWith("/v1/workspaces")) return jsonResponse({ workspaces: [] });
+    throw new Error(`Unexpected request: ${url}`);
+  });
+
+  await assert.rejects(
+    acceptAutomationShare("share-id", "recipient-space", { name: "Old account workspace", document: {} }, f.deps),
+    /not available for the signed-in account/i,
+  );
 });
 
 test("seeds exactly two successful backend examples for recordings and workflows", async (t) => {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1272,22 +1272,22 @@ async function invokeCommand(command, args = {}, sender) {
     case "artifact_delete": {
       return await localAutomationArtifacts().delete(String(args.workspaceId || ""), String(args.id || ""));
     }
-    case "automation_workflows_list": return await listAutomationWorkflows(String(args.workspaceId || ""), { env: childEnv() });
-    case "automation_workflow_put": return await putAutomationWorkflow(String(args.workspaceId || ""), args.workflow || {}, { env: childEnv() });
+    case "automation_workflows_list": return await listAutomationWorkflows({ env: childEnv() });
+    case "automation_workflow_put": return await putAutomationWorkflow(args.workflow || {}, { env: childEnv() });
     case "automation_workflow_delete": return await deleteAutomationWorkflow(String(args.id || ""), { env: childEnv() });
-    case "automation_recordings_list": return await listAutomationRecordings(String(args.workspaceId || ""), { env: childEnv() });
+    case "automation_recordings_list": return await listAutomationRecordings({ env: childEnv() });
     case "automation_recording_put": return await putAutomationRecording(args.recording || {}, { env: childEnv() });
     case "automation_recording_delete": return await deleteAutomationRecording(String(args.id || ""), { env: childEnv() });
     case "automation_shares_list": return await listAutomationShares(String(args.box || "inbox"), { env: childEnv() });
     case "automation_share_create": return await createAutomationShare(args.share || {}, { env: childEnv() });
-    case "automation_share_accept": return await acceptAutomationShare(String(args.id || ""), String(args.workspaceId || ""), args.workspace || {}, { env: childEnv() });
+    case "automation_share_accept": return await acceptAutomationShare(String(args.id || ""), { env: childEnv() });
     case "automation_share_decline": return await declineAutomationShare(String(args.id || ""), { env: childEnv() });
     case "automation_share_revoke": return await revokeAutomationShare(String(args.id || ""), { env: childEnv() });
     case "automation_runs_list": return await listAutomationRuns(String(args.workspaceId || ""), { env: childEnv() });
     case "automation_seed_examples": {
       const workspaceId = String(args.workspaceId || "");
       const [backend, artifacts] = await Promise.all([
-        seedAutomationExamples(workspaceId, { env: childEnv() }),
+        seedAutomationExamples({ env: childEnv() }),
         localAutomationArtifacts().seedExamples(workspaceId),
       ]);
       return { seeded: { ...backend.seeded, artifacts } };

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1280,7 +1280,7 @@ async function invokeCommand(command, args = {}, sender) {
     case "automation_recording_delete": return await deleteAutomationRecording(String(args.id || ""), { env: childEnv() });
     case "automation_shares_list": return await listAutomationShares(String(args.box || "inbox"), { env: childEnv() });
     case "automation_share_create": return await createAutomationShare(args.share || {}, { env: childEnv() });
-    case "automation_share_accept": return await acceptAutomationShare(String(args.id || ""), String(args.workspaceId || ""), { env: childEnv() });
+    case "automation_share_accept": return await acceptAutomationShare(String(args.id || ""), String(args.workspaceId || ""), args.workspace || {}, { env: childEnv() });
     case "automation_share_decline": return await declineAutomationShare(String(args.id || ""), { env: childEnv() });
     case "automation_share_revoke": return await revokeAutomationShare(String(args.id || ""), { env: childEnv() });
     case "automation_runs_list": return await listAutomationRuns(String(args.workspaceId || ""), { env: childEnv() });

--- a/src/components/AutomationStudio.tsx
+++ b/src/components/AutomationStudio.tsx
@@ -26,7 +26,7 @@ type ElementPickState = { pickId: string; actionIndex: number; mode: ElementPick
 type ElementPickResult = { cancelled?: boolean; selector?: string; locator?: { role?: string; name?: string; text?: string }; label?: string; tag?: string; attribute?: string; pageUrl?: string };
 type WorkflowContextMenu = { workflowId: string; x: number; y: number };
 type RecordingReview = { active: ActiveAutomationRecording; captured: CapturedRun; reason: string; actionCount: number; missingAgentTrace: boolean; saveError?: string };
-type AutomationShare = { id: string; source_kind: "recording" | "workflow"; source_id: string; title: string; sender_email?: string; recipient_email?: string; status: string; created_at: string };
+type AutomationShare = { id: string; source_kind: "recording" | "workflow"; source_id: string; title: string; sender_email?: string; recipient_email?: string; status: "pending" | "accepted" | "declined" | "revoked"; accepted_copy_id?: string; created_at: string; accepted_at?: string };
 type ShareTarget = { kind: "recording" | "workflow"; id: string; title: string };
 
 const ACTION_OPTIONS = [
@@ -47,12 +47,6 @@ function isUnavailableRecordingSession(error: unknown) {
   const message = error instanceof Error ? error.message : String(error);
   return /(?:connection refused|session ["']?.+?["']? not found|state failed|list cdp targets|cdp became reachable|browser (?:is )?not running)/i.test(message);
 }
-const DEFAULT_EXAMPLES_VERSION = "5";
-
-function defaultExamplesKey(workspaceId: string) {
-  return `nextbrowser:automation-default-examples:${workspaceId}`;
-}
-
 function actionLabel(tool: string) {
   return ACTION_OPTIONS.find(([value]) => value === tool)?.[1] || `Advanced: ${tool}`;
 }
@@ -211,6 +205,7 @@ export function AutomationStudio() {
   const [workflowAiRequest, setWorkflowAiRequest] = useState("");
   const [workflowAiBusy, setWorkflowAiBusy] = useState(false);
   const [incomingShares, setIncomingShares] = useState<AutomationShare[]>([]);
+  const [sentShares, setSentShares] = useState<AutomationShare[]>([]);
   const [shareTarget, setShareTarget] = useState<ShareTarget>();
   const [shareEmail, setShareEmail] = useState("");
   const [shareBusy, setShareBusy] = useState(false);
@@ -288,12 +283,11 @@ export function AutomationStudio() {
   }, [selectedWorkflowId, workflows]);
 
   const loadWorkflows = async () => {
-    if (!workspaceId) return setWorkflows([]);
-    try { setWorkflows(await invoke<BrowserWorkflowSkill[]>("automation_workflows_list", { workspaceId })); setStudioError(undefined); }
+    try { setWorkflows(await invoke<BrowserWorkflowSkill[]>("automation_workflows_list")); setStudioError(undefined); }
     catch (error) { setStudioError(error instanceof Error ? error.message : String(error)); }
   };
 
-  useEffect(() => { void loadWorkflows(); }, [workspaceId]);
+  useEffect(() => { if (s.authed) void loadWorkflows(); }, [s.authed]);
 
   const loadRuns = async () => {
     if (!workspaceId) return setBackendRuns([]);
@@ -304,9 +298,8 @@ export function AutomationStudio() {
   useEffect(() => { void loadRuns(); }, [workspaceId]);
 
   const loadRecordings = async () => {
-    if (!workspaceId) return setRecordings([]);
     try {
-      const items = await invoke<BackendRecording[]>("automation_recordings_list", { workspaceId });
+      const items = await invoke<BackendRecording[]>("automation_recordings_list");
       const completed = items.filter((item) => !!item.document.run);
       const unfinished = items.filter((item) => !item.document.run);
       setRecordings(completed);
@@ -315,20 +308,26 @@ export function AutomationStudio() {
     catch (error) { setStudioError(error instanceof Error ? error.message : String(error)); }
   };
 
-  useEffect(() => { void loadRecordings(); }, [workspaceId]);
+  useEffect(() => { if (s.authed) void loadRecordings(); }, [s.authed]);
 
   const loadIncomingShares = async () => {
     try { setIncomingShares(await invoke<AutomationShare[]>("automation_shares_list", { box: "inbox" })); }
     catch { setIncomingShares([]); }
   };
 
-  useEffect(() => { void loadIncomingShares(); }, [workspaceId]);
+  const loadSentShares = async () => {
+    try { setSentShares(await invoke<AutomationShare[]>("automation_shares_list", { box: "sent" })); }
+    catch { setSentShares([]); }
+  };
+
+  useEffect(() => { if (s.authed) void Promise.all([loadIncomingShares(), loadSentShares()]); }, [s.authed]);
 
   const sendShare = async () => {
     if (!shareTarget || !shareEmail.trim()) return;
     setShareBusy(true);
     try {
       await invoke("automation_share_create", { share: { source_kind: shareTarget.kind, source_id: shareTarget.id, recipient_email: shareEmail.trim() } });
+      await loadSentShares();
       setShareTarget(undefined);
       setShareEmail("");
       setNotice("Shared. It will appear in Automation Studio when that email signs in.");
@@ -337,24 +336,12 @@ export function AutomationStudio() {
   };
 
   const acceptShare = async (share: AutomationShare) => {
-    if (!workspaceId || !activeWorkspace) return setStudioError("Select or create a workspace before adding this copy.");
     setShareBusy(true);
     try {
-      await invoke("automation_share_accept", {
-        id: share.id,
-        workspaceId,
-        workspace: {
-          name: activeWorkspace.name,
-          document: {
-            profileNames: activeWorkspace.profileNames,
-            profileToolsets: activeWorkspace.profileToolsets,
-            profileProxyIds: activeWorkspace.profileProxyIds ?? {},
-          },
-        },
-      });
+      await invoke("automation_share_accept", { id: share.id });
       await Promise.all([loadIncomingShares(), loadRecordings(), loadWorkflows()]);
       setSection(share.source_kind === "workflow" ? "workflows" : "recorder");
-      setNotice(`${share.source_kind === "workflow" ? "Workflow" : "Recording"} added to this workspace as your own editable copy.`);
+      setNotice(`${share.source_kind === "workflow" ? "Workflow" : "Recording"} added to your automation library as your own editable copy.`);
     } catch (error) { reportError(error); }
     finally { setShareBusy(false); }
   };
@@ -369,13 +356,20 @@ export function AutomationStudio() {
     finally { setShareBusy(false); }
   };
 
+  const revokeShare = async (share: AutomationShare) => {
+    setShareBusy(true);
+    try {
+      await invoke("automation_share_revoke", { id: share.id });
+      await loadSentShares();
+      setNotice("Pending shared copy revoked.");
+    } catch (error) { reportError(error); }
+    finally { setShareBusy(false); }
+  };
+
   useEffect(() => {
     if (!workspaceId) return;
-    const storageKey = defaultExamplesKey(workspaceId);
-    if (window.localStorage.getItem(storageKey) === DEFAULT_EXAMPLES_VERSION) return;
     void invoke("automation_seed_examples", { workspaceId })
       .then(() => {
-        window.localStorage.setItem(storageKey, DEFAULT_EXAMPLES_VERSION);
         return Promise.all([loadWorkflows(), loadRecordings(), loadRuns(), loadArtifacts()]);
       })
       .catch((error) => setStudioError(error instanceof Error ? error.message : String(error)));
@@ -585,13 +579,13 @@ export function AutomationStudio() {
   };
 
   const saveCompletedRecording = async (active: ActiveAutomationRecording, captured: CapturedRun) => {
-        await invoke("automation_recording_put", { recording: { id: active.id, workspace_id: workspaceId, status: "completed", document: { run: captured }, base_revision: 0 } });
+        await invoke("automation_recording_put", { recording: { id: active.id, status: "completed", document: { run: captured }, base_revision: 0 } });
         let savedWorkflow: BrowserWorkflowSkill | undefined;
         if (active.destination === "workflow") {
           const domain = capturedWorkflowDomain(captured.task, captured.evidence);
           const quality = workflowQuality(captured.task, captured.evidence, domain);
           if (quality.reusable) {
-            savedWorkflow = await invoke<BrowserWorkflowSkill>("automation_workflow_put", { workspaceId, workflow: skillFromRun(captured) });
+            savedWorkflow = await invoke<BrowserWorkflowSkill>("automation_workflow_put", { workflow: skillFromRun(captured) });
           }
         }
         clearActiveAutomationRecording();
@@ -645,7 +639,7 @@ export function AutomationStudio() {
 
   const saveCapture = async (run: CapturedRun) => {
     try {
-      const saved = await invoke<BrowserWorkflowSkill>("automation_workflow_put", { workspaceId, workflow: skillFromRun(run) });
+      const saved = await invoke<BrowserWorkflowSkill>("automation_workflow_put", { workflow: skillFromRun(run) });
       clearActiveAutomationRecording();
       setRecordingSince(0);
       await loadWorkflows();
@@ -858,7 +852,7 @@ export function AutomationStudio() {
     if (!draft || draftValidationError || Object.keys(actionErrors).length) return undefined;
     setSaving(true);
     try {
-      const saved = await invoke<BrowserWorkflowSkill>("automation_workflow_put", { workspaceId, workflow: { ...draft, recipe: { ...draft.recipe, actions: draft.actions } } });
+      const saved = await invoke<BrowserWorkflowSkill>("automation_workflow_put", { workflow: { ...draft, recipe: { ...draft.recipe, actions: draft.actions } } });
       setWorkflows((current) => current.some((item) => item.id === saved.id) ? current.map((item) => item.id === saved.id ? saved : item) : [saved, ...current]);
       setDraft(saved);
       setStudioError(undefined);
@@ -925,7 +919,7 @@ export function AutomationStudio() {
       recipe: { version: 1, capability: "other", actions: [action] }, createdAt, updatedAt: createdAt,
     };
     try {
-      const saved = await invoke<BrowserWorkflowSkill>("automation_workflow_put", { workspaceId, workflow });
+      const saved = await invoke<BrowserWorkflowSkill>("automation_workflow_put", { workflow });
       setWorkflows((current) => [saved, ...current]);
       setSelectedWorkflowId(saved.id);
       setWorkflowListCollapsed(true);
@@ -949,7 +943,7 @@ export function AutomationStudio() {
   const duplicateWorkflow = async (workflow: BrowserWorkflowSkill) => {
     const now = Date.now();
     try {
-      const copy = await invoke<BrowserWorkflowSkill>("automation_workflow_put", { workspaceId, workflow: { ...structuredClone(workflow), id: uid(), title: `${workflow.title} copy`, revision: 0, createdAt: now, updatedAt: now, recipe: { ...workflow.recipe, example_key: undefined, example_version: undefined, demo_key: undefined, demo_version: undefined } } });
+      const copy = await invoke<BrowserWorkflowSkill>("automation_workflow_put", { workflow: { ...structuredClone(workflow), id: uid(), title: `${workflow.title} copy`, revision: 0, createdAt: now, updatedAt: now, recipe: { ...workflow.recipe, example_key: undefined, example_version: undefined, demo_key: undefined, demo_version: undefined } } });
       setWorkflows((current) => [copy, ...current]);
       setSelectedWorkflowId(copy.id);
       setWorkflowListCollapsed(true);
@@ -1152,7 +1146,7 @@ export function AutomationStudio() {
   return (
     <div ref={studioRef} className="automation-studio page">
       <header className="automation-hero">
-        <div><span className="eyebrow">Automation Studio</span><h1>Record, build, and collect</h1><p>Turn successful browser runs into repeatable workflows and keep their files with the workspace.</p></div>
+        <div><span className="eyebrow">Automation Studio</span><h1>Record, build, and collect</h1><p>Keep recordings and workflows in your automation library. Run outputs stay local to the active workspace.</p></div>
         <div className="automation-summary"><strong>{recordings.length}</strong><span>recordings</span><strong>{workflows.length}</strong><span>workflows</span><strong>{artifacts.length}</strong><span>artifacts</span></div>
       </header>
       <div className="automation-sections" role="tablist">
@@ -1170,7 +1164,8 @@ export function AutomationStudio() {
       </div>
       {studioError && <div className="error automation-global-message" role="alert"><strong>Automation couldn’t complete the action.</strong><span>{studioError}</span><button onClick={() => setStudioError(undefined)}>Dismiss</button></div>}
       {notice && <div className="automation-global-message success" role="status"><span>{notice}</span><button onClick={() => setNotice(undefined)}>Dismiss</button></div>}
-      {incomingShares.length > 0 && <section className="automation-share-inbox" aria-label="Shared with me"><div><Icon name="person.2.fill" size={15} /><span><strong>Shared with you</strong><small>{incomingShares.length} automation {incomingShares.length === 1 ? "copy is" : "copies are"} ready to add to this workspace.</small></span></div><div className="automation-share-inbox-items">{incomingShares.map((share) => <article key={share.id}><span><strong>{share.title}</strong><small>{share.source_kind === "workflow" ? "Workflow" : "Recording"}{share.sender_email ? ` · from ${share.sender_email}` : ""}</small></span><div className="automation-inline-actions"><button className="secondary" disabled={shareBusy} onClick={() => void declineShare(share)}>Decline</button><button className="secondary" disabled={shareBusy} onClick={() => void acceptShare(share)}>Add copy</button></div></article>)}</div></section>}
+      {incomingShares.length > 0 && <section className="automation-share-inbox" aria-label="Shared with me"><div><Icon name="person.2.fill" size={15} /><span><strong>Shared with you</strong><small>{incomingShares.length} automation {incomingShares.length === 1 ? "copy is" : "copies are"} ready to add to your library.</small></span></div><div className="automation-share-inbox-items">{incomingShares.map((share) => <article key={share.id}><span><strong>{share.title}</strong><small>{share.source_kind === "workflow" ? "Workflow" : "Recording"}{share.sender_email ? ` · from ${share.sender_email}` : ""}</small></span><div className="automation-inline-actions"><button className="secondary" disabled={shareBusy} onClick={() => void declineShare(share)}>Decline</button><button className="secondary" disabled={shareBusy} onClick={() => void acceptShare(share)}>Add to my automations</button></div></article>)}</div></section>}
+      {sentShares.length > 0 && <section className="automation-share-inbox automation-share-sent" aria-label="Shared by me"><div><Icon name="paperplane.fill" size={15} /><span><strong>Shared by you</strong><small>Track copies sent to other NextBrowser users.</small></span></div><div className="automation-share-inbox-items">{sentShares.map((share) => <article key={share.id}><span><strong>{share.title}</strong><small>{share.source_kind === "workflow" ? "Workflow" : "Recording"}{share.recipient_email ? ` · to ${share.recipient_email}` : ""}</small></span><div className="automation-inline-actions"><span className={`automation-share-status ${share.status}`}>{share.status === "pending" ? "Waiting" : share.status === "accepted" ? "Added" : "Declined"}</span>{share.status === "pending" && <button className="secondary" disabled={shareBusy} onClick={() => void revokeShare(share)}>Revoke</button>}</div></article>)}</div></section>}
       {playback && playbackView && <div className={`recording-progress-card ${playbackView.phase}`} role="status"><div className="recording-progress-head"><span><Icon name={playbackView.phase === "completed" ? "checkmark.circle.fill" : ["failed", "cancelled"].includes(playbackView.phase) ? "xmark.circle.fill" : playbackView.phase === "stopping" ? "stop.fill" : "play.fill"} size={14} /><strong>{playbackView.phase === "completed" ? "Execution completed" : playbackView.phase === "cancelled" ? "Execution stopped" : playbackView.phase === "failed" ? "Execution failed" : playbackView.phase === "stopping" ? "Stopping execution" : playback.engine === "agent" ? "AI is repairing the workflow" : playbackView.phase === "preparing" ? "Preparing execution" : "Running saved steps"}</strong></span><b>{playbackView.progress}%</b></div><div className="recording-progress-track"><i style={{ width: `${playbackView.progress}%` }} /></div><small>{playbackView.detail}</small><div className="row">{["completed", "failed", "cancelled"].includes(playbackView.phase) ? <button onClick={() => { setPlayback(undefined); clearActiveAutomationExecution(); }}>Dismiss</button> : <button className="secondary danger-text" disabled={playbackView.phase === "stopping"} onClick={() => void stopExecution()}><Icon name="stop.fill" size={12} /> {playbackView.phase === "stopping" ? "Stopping…" : "Stop"}</button>}</div></div>}
 
       {section === "recorder" && <section className="automation-panel">

--- a/src/components/AutomationStudio.tsx
+++ b/src/components/AutomationStudio.tsx
@@ -337,10 +337,21 @@ export function AutomationStudio() {
   };
 
   const acceptShare = async (share: AutomationShare) => {
-    if (!workspaceId) return;
+    if (!workspaceId || !activeWorkspace) return setStudioError("Select or create a workspace before adding this copy.");
     setShareBusy(true);
     try {
-      await invoke("automation_share_accept", { id: share.id, workspaceId });
+      await invoke("automation_share_accept", {
+        id: share.id,
+        workspaceId,
+        workspace: {
+          name: activeWorkspace.name,
+          document: {
+            profileNames: activeWorkspace.profileNames,
+            profileToolsets: activeWorkspace.profileToolsets,
+            profileProxyIds: activeWorkspace.profileProxyIds ?? {},
+          },
+        },
+      });
       await Promise.all([loadIncomingShares(), loadRecordings(), loadWorkflows()]);
       setSection(share.source_kind === "workflow" ? "workflows" : "recorder");
       setNotice(`${share.source_kind === "workflow" ? "Workflow" : "Recording"} added to this workspace as your own editable copy.`);

--- a/src/lib/userFacingBrowserError.test.ts
+++ b/src/lib/userFacingBrowserError.test.ts
@@ -27,9 +27,9 @@ describe("userFacingBrowserError", () => {
       .toBe("Could not open page");
   });
 
-  it("turns an unavailable share destination into a clear recovery action", () => {
+  it("turns an unavailable workspace into a clear recovery action", () => {
     expect(userFacingBrowserError("Error invoking remote method 'nextbrowser:invoke': Error: workspace not found"))
-      .toBe("This workspace is not available for the signed-in account. Select or create a workspace for this account, then add the shared copy again.");
+      .toBe("The selected workspace is no longer available. Select or create a workspace, then try again.");
   });
 
   it("removes the Electron IPC prefix from ordinary errors", () => {

--- a/src/lib/userFacingBrowserError.test.ts
+++ b/src/lib/userFacingBrowserError.test.ts
@@ -26,4 +26,14 @@ describe("userFacingBrowserError", () => {
     expect(userFacingBrowserError("Could not open page; see log /Users/person/private/child.log"))
       .toBe("Could not open page");
   });
+
+  it("turns an unavailable share destination into a clear recovery action", () => {
+    expect(userFacingBrowserError("Error invoking remote method 'nextbrowser:invoke': Error: workspace not found"))
+      .toBe("This workspace is not available for the signed-in account. Select or create a workspace for this account, then add the shared copy again.");
+  });
+
+  it("removes the Electron IPC prefix from ordinary errors", () => {
+    expect(userFacingBrowserError("Error invoking remote method 'nextbrowser:invoke': Error: The shared workflow is invalid"))
+      .toBe("The shared workflow is invalid");
+  });
 });

--- a/src/lib/userFacingBrowserError.ts
+++ b/src/lib/userFacingBrowserError.ts
@@ -13,6 +13,10 @@ export function userFacingBrowserError(error: unknown): string {
   const raw = rawErrorMessage(error);
   if (!raw) return "The browser could not be prepared. Try again.";
 
+  if (/AUTOMATION_SHARE_WORKSPACE_UNAVAILABLE|workspace not found|workspace revision conflict/i.test(raw)) {
+    return "This workspace is not available for the signed-in account. Select or create a workspace for this account, then add the shared copy again.";
+  }
+
   if (REMOTE_BACKEND_CODE.test(raw) || REMOTE_CONTROL_FAILURE.test(raw)) {
     if (/\b404\b|not found/i.test(raw)) {
       return "Remote Control is not available on the connected NextBrowser service. Update NextBrowser and try again. If it continues, contact support.";
@@ -35,8 +39,8 @@ export function userFacingBrowserError(error: unknown): string {
 
   // Never expose private filesystem locations from host-process diagnostics.
   return raw
+    .replace(/^Error invoking remote method ['"][^'"]+['"]:\s*(?:Error:\s*)?/i, "")
     .replace(/;?\s*see log\s+[^\r\n]+/gi, "")
     .replace(/(?:\/Users|\/home)\/[^\s;]+/g, "the local diagnostic log")
     .trim();
 }
-

--- a/src/lib/userFacingBrowserError.ts
+++ b/src/lib/userFacingBrowserError.ts
@@ -13,8 +13,8 @@ export function userFacingBrowserError(error: unknown): string {
   const raw = rawErrorMessage(error);
   if (!raw) return "The browser could not be prepared. Try again.";
 
-  if (/AUTOMATION_SHARE_WORKSPACE_UNAVAILABLE|workspace not found|workspace revision conflict/i.test(raw)) {
-    return "This workspace is not available for the signed-in account. Select or create a workspace for this account, then add the shared copy again.";
+  if (/workspace not found|workspace revision conflict/i.test(raw)) {
+    return "The selected workspace is no longer available. Select or create a workspace, then try again.";
   }
 
   if (REMOTE_BACKEND_CODE.test(raw) || REMOTE_CONTROL_FAILURE.test(raw)) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -7665,6 +7665,10 @@ pre,
 .automation-share-inbox-items { display: grid; gap: 7px; }
 .automation-share-inbox article { padding: 9px 10px; border: 1px solid var(--line); border-radius: 10px; background: var(--panel); }
 .automation-share-inbox article strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.automation-share-sent { border-color: var(--line); background: color-mix(in srgb, var(--panel) 92%, var(--accent)); }
+.automation-share-status { padding: 5px 8px; border-radius: 999px; background: var(--bg-elevated); color: var(--muted); font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .035em; }
+.automation-share-status.accepted { background: color-mix(in srgb, var(--success) 13%, var(--panel)); color: var(--success); }
+.automation-share-status.declined { background: color-mix(in srgb, var(--red) 10%, var(--panel)); color: var(--red); }
 .automation-share-dialog { width: min(500px, calc(100vw - 32px)); display: grid; gap: 16px; padding: 20px; }
 .automation-share-dialog h2 { display: inline; margin: 0 0 0 10px; font-size: 18px; }
 .automation-share-dialog p { margin: 8px 0 0; color: var(--muted); font-size: 13px; line-height: 1.45; }


### PR DESCRIPTION
## Summary
- load recordings and workflows as an account library across workspaces
- accept email shares directly into My automations without workspace coupling
- show incoming and sent shares, their status, and allow pending revocation
- keep run history and local artifacts in the active workspace

## Verification
- npm test
- npx tsc --noEmit
- npm run pack
- account-scoped host/UI contract tests
