### PR TITLE
fix: let users dismiss agent connection gate

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -690,6 +690,7 @@ export function App() {
   const [runtimeUpdateProgressHidden, setRuntimeUpdateProgressHidden] = useState(false);
   const [unexpectedError, setUnexpectedError] = useState<{ reference: string; detail: string }>();
   const [browserRuntimeInstall, setBrowserRuntimeInstall] = useState<BrowserRuntimeInstallStatus>();
+  const [agentGateDismissed, setAgentGateDismissed] = useState(false);
   const preview = getPreviewMode();
   const checking = useStore((s) => s.checking);
   const tab = useStore((s) => s.tab);
@@ -1282,7 +1283,9 @@ export function App() {
         />
       )}
       <DashboardKeyModal />
-      {!checking && !agentReady && preview !== "main" && <AgentConnectionGate />}
+      {!checking && !agentReady && !agentGateDismissed && preview !== "main" && (
+        <AgentConnectionGate onDismiss={() => setAgentGateDismissed(true)} />
+      )}
       {showOnboarding && agentReady && !workspaceSetupRequired && <OnboardingView />}
       {!checking && agentReady && workspaceSetupRequired && <WorkspaceSetupGate />}
       {browserRuntimeInstall && <BrowserRuntimeInstallModal status={browserRuntimeInstall} onCancel={() => {

--- a/src/components/AgentConnectionGate.test.tsx
+++ b/src/components/AgentConnectionGate.test.tsx
@@ -1,0 +1,30 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+const state = {
+  agentId: "claude",
+  runtime: { claude: { version: undefined, loggedIn: undefined, error: undefined, authorizing: false } },
+  switchAgent: vi.fn(),
+  authorizeAgent: vi.fn(),
+  loginAgent: vi.fn(),
+};
+
+vi.mock("../store", () => ({ useStore: () => state }));
+
+import { AgentConnectionGate } from "./AgentConnectionGate";
+
+describe("AgentConnectionGate", () => {
+  it("offers an explicit accessible close control", () => {
+    const html = renderToStaticMarkup(<AgentConnectionGate onDismiss={() => undefined} />);
+
+    expect(html).toContain('aria-label="Close agent setup"');
+    expect(html).toContain('title="Close"');
+  });
+
+  it("does not advertise a selection as connected before Connect is pressed", () => {
+    const html = renderToStaticMarkup(<AgentConnectionGate onDismiss={() => undefined} />);
+
+    expect(html).toContain("Connect Claude Code");
+    expect(html).toContain('aria-pressed="true"');
+  });
+});

--- a/src/components/AgentConnectionGate.tsx
+++ b/src/components/AgentConnectionGate.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { PRIMARY_AGENTS, agentById } from "../agents";
 import { useStore } from "../store";
 import { AgentInstallLink } from "./AgentInstallLink";
@@ -5,20 +6,49 @@ import { BrandLogo } from "./BrandLogo";
 import { Icon, Spinner } from "./Icon";
 import { UserFacingError } from "./UserFacingError";
 
-/** Required first-run gate. The product is unusable without an agent, so this
- * deliberately has no close, skip, backdrop-dismiss, or Escape action. */
-export function AgentConnectionGate() {
+/**
+ * First-run agent connection gate. A user may dismiss it and continue to look
+ * around the app, but actions which require an agent remain clearly disabled
+ * until one is connected.
+ */
+export function AgentConnectionGate({ onDismiss }: { onDismiss: () => void }) {
   const s = useStore();
-  const agent = agentById(s.agentId);
-  const version = s.agentVersion();
-  const loggedIn = s.agentLoggedIn();
-  const error = s.agentError();
-  const authorizing = s.runtime[s.agentId]?.authorizing ?? false;
+  // Do not mutate the active agent until Connect is pressed. This lets a user
+  // safely recover from selecting the wrong option and closing the dialog.
+  const [selectedAgentId, setSelectedAgentId] = useState(s.agentId);
+  const agent = agentById(selectedAgentId);
+  const runtime = s.runtime[selectedAgentId];
+  const version = runtime?.version;
+  const loggedIn = runtime?.loggedIn;
+  const error = runtime?.error;
+  const authorizing = runtime?.authorizing ?? false;
   const needsLogin = !!version && loggedIn === false;
+
+  useEffect(() => {
+    const dismissOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onDismiss();
+    };
+    window.addEventListener("keydown", dismissOnEscape);
+    return () => window.removeEventListener("keydown", dismissOnEscape);
+  }, [onDismiss]);
+
+  const connect = () => {
+    if (selectedAgentId !== s.agentId) s.switchAgent(selectedAgentId);
+    void (needsLogin ? s.loginAgent() : s.authorizeAgent());
+  };
 
   return (
     <div className="agent-gate-overlay">
       <div className="agent-gate-card" role="dialog" aria-modal="true" aria-labelledby="agent-gate-title">
+        <button
+          type="button"
+          className="agent-gate-close"
+          aria-label="Close agent setup"
+          title="Close"
+          onClick={onDismiss}
+        >
+          <Icon name="xmark" size={18} />
+        </button>
         <BrandLogo size={44} />
         <div className="agent-gate-copy">
           <h2 id="agent-gate-title">Connect an agent to continue</h2>
@@ -29,12 +59,13 @@ export function AgentConnectionGate() {
             <button
               type="button"
               key={candidate.id}
-              className={"agent-gate-option" + (candidate.id === s.agentId ? " is-selected" : "")}
-              onClick={() => s.switchAgent(candidate.id)}
+              className={"agent-gate-option" + (candidate.id === selectedAgentId ? " is-selected" : "")}
+              aria-pressed={candidate.id === selectedAgentId}
+              onClick={() => setSelectedAgentId(candidate.id)}
             >
               <Icon name="cpu.fill" size={17} />
               <strong>{candidate.name}</strong>
-              {candidate.id === s.agentId && <Icon name="checkmark.circle.fill" size={16} className="ok" />}
+              {candidate.id === selectedAgentId && <Icon name="checkmark.circle.fill" size={16} className="ok" />}
             </button>
           ))}
         </div>
@@ -42,7 +73,7 @@ export function AgentConnectionGate() {
           type="button"
           className="primary agent-gate-connect"
           disabled={authorizing}
-          onClick={() => void (needsLogin ? s.loginAgent() : s.authorizeAgent())}
+          onClick={connect}
         >
           {authorizing && <Spinner size={14} />}
           {authorizing ? "Checking…" : needsLogin ? `Sign in to ${agent.name}` : `Connect ${agent.name}`}

--- a/src/styles.css
+++ b/src/styles.css
@@ -6950,6 +6950,7 @@ code { background: var(--surface-4); padding: 1px 5px; border-radius: 4px; }
   backdrop-filter: blur(14px);
 }
 .agent-gate-card {
+  position: relative;
   width: min(480px, 100%);
   display: flex;
   flex-direction: column;
@@ -6967,6 +6968,22 @@ code { background: var(--surface-4); padding: 1px 5px; border-radius: 4px; }
 .agent-gate-option.is-selected { border-color: var(--accent); }
 .agent-gate-option .ok { margin-left: auto; }
 .agent-gate-connect { justify-content: center; min-height: 42px; }
+.agent-gate-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--muted);
+}
+.agent-gate-close:hover { color: var(--text); border-color: var(--line); background: var(--surface-2); }
+.agent-gate-close:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
 /* --------------------------------------------------------------------------
    Theme direction: Obsidian Violet across dark and light modes


### PR DESCRIPTION
## Summary
- add a visible close control and Escape dismissal to the agent connection gate
- keep agent selection pending until Connect is pressed
- retain clear disabled states for agent-dependent actions after dismissal

## Verification
- `./node_modules/.bin/vitest run src/components/AgentConnectionGate.test.tsx`
- `./node_modules/.bin/tsc --noEmit`
- clean Electron dev profile: verified visible close button and Escape dismissal