### PR TITLE
fix: retry workspace sync revision conflicts

### DIFF
--- a/src/lib/workspaceConflict.test.ts
+++ b/src/lib/workspaceConflict.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { isWorkspaceRevisionConflict, mergeWorkspaceAfterRevisionConflict } from "./workspaceConflict";
+import type { Workspace } from "../types";
+
+const local: Workspace = {
+  id: "workspace", name: "Local", createdAt: 1, updatedAt: 2,
+  profileNames: ["local", "shared"],
+  profileToolsets: { local: "clawbrowser", shared: "camoufox" },
+  profileProxyIds: { local: "proxy-local", shared: "proxy-new" },
+};
+
+describe("workspace conflict recovery", () => {
+  it("recognizes only the retryable optimistic-concurrency failure", () => {
+    expect(isWorkspaceRevisionConflict(new Error("workspace revision conflict"))).toBe(true);
+    expect(isWorkspaceRevisionConflict(new Error("workspace not found"))).toBe(false);
+  });
+
+  it("preserves remote profiles while retaining the local edit for collisions", () => {
+    const merged = mergeWorkspaceAfterRevisionConflict(local, {
+      ...local,
+      name: "Remote",
+      profileNames: ["remote", "shared"],
+      profileToolsets: { remote: "dasbrowser", shared: "clawbrowser" },
+      profileProxyIds: { remote: "proxy-remote", shared: "proxy-old" },
+    });
+
+    expect(merged.profileNames).toEqual(["remote", "shared", "local"]);
+    expect(merged.profileToolsets).toEqual({ remote: "dasbrowser", shared: "camoufox", local: "clawbrowser" });
+    expect(merged.profileProxyIds).toEqual({ remote: "proxy-remote", shared: "proxy-new", local: "proxy-local" });
+    expect(merged.name).toBe("Local");
+  });
+});

--- a/src/lib/workspaceConflict.ts
+++ b/src/lib/workspaceConflict.ts
@@ -1,0 +1,21 @@
+import type { Workspace } from "../types";
+
+/** An optimistic workspace write can race with another signed-in device. */
+export function isWorkspaceRevisionConflict(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return /workspace revision conflict/i.test(message);
+}
+
+/**
+ * Preserve both devices' profile associations when retrying an optimistic
+ * workspace update. The local edit wins only for the same profile key, while
+ * profiles introduced remotely are retained.
+ */
+export function mergeWorkspaceAfterRevisionConflict(local: Workspace, remote: Workspace): Workspace {
+  return {
+    ...local,
+    profileNames: [...new Set([...remote.profileNames, ...local.profileNames])],
+    profileToolsets: { ...remote.profileToolsets, ...local.profileToolsets },
+    profileProxyIds: { ...(remote.profileProxyIds ?? {}), ...(local.profileProxyIds ?? {}) },
+  };
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -51,6 +51,7 @@ import { accountLoginURL } from "./lib/accountAuth";
 import { requiresWorkspaceSetup } from "./lib/workspaceSetup";
 import { validateEntityName } from "./lib/entityValidation";
 import { moveProfileToWorkspace as moveProfileBetweenWorkspaces } from "./lib/workspaceProfiles";
+import { isWorkspaceRevisionConflict, mergeWorkspaceAfterRevisionConflict } from "./lib/workspaceConflict";
 import {
   normalizeConversation,
   normalizeWorkflowSkill,
@@ -3429,18 +3430,46 @@ export const useStore = create<State>((set, get) => {
       for (const workspace of workspaces) {
         const cloud = remoteWorkspaceById.get(workspace.id);
         if (cloud && workspace.updatedAt <= Date.parse(cloud.updated_at)) continue;
-        const saved = await invoke<{ revision: number }>("workspace_put", {
-          id: workspace.id,
+        const saveWorkspace = (candidate: Workspace, baseRevision: number) => invoke<{ revision: number }>("workspace_put", {
+          id: candidate.id,
           workspace: {
-            name: workspace.name,
+            name: candidate.name,
             document: {
-              profileNames: workspace.profileNames,
-              profileToolsets: workspace.profileToolsets,
-              profileProxyIds: workspace.profileProxyIds ?? {},
+              profileNames: candidate.profileNames,
+              profileToolsets: candidate.profileToolsets,
+              profileProxyIds: candidate.profileProxyIds ?? {},
             },
-            base_revision: workspaceRevisions[workspace.id] ?? 0,
+            base_revision: baseRevision,
           },
         });
+        let candidate = workspace;
+        let saved: { revision: number };
+        try {
+          saved = await saveWorkspace(candidate, workspaceRevisions[workspace.id] ?? 0);
+        } catch (error) {
+          if (!isWorkspaceRevisionConflict(error)) throw error;
+          // A second device changed the same workspace after our initial list.
+          // Refresh once, merge profile associations, and retry against its
+          // revision instead of surfacing a background 409 to the user.
+          const refreshed = await invoke<{ workspaces?: Array<{
+            id: string; name: string; document: Partial<Workspace>; revision: number; updated_at: string; created_at: string;
+          }> }>("workspaces_list");
+          const latest = refreshed.workspaces?.find((item) => item.id === workspace.id);
+          if (!latest) throw error;
+          const remote: Workspace = {
+            id: latest.id,
+            name: latest.name,
+            profileNames: Array.isArray(latest.document?.profileNames) ? latest.document.profileNames : [],
+            profileToolsets: latest.document?.profileToolsets ?? {},
+            profileProxyIds: latest.document?.profileProxyIds ?? {},
+            createdAt: Date.parse(latest.created_at),
+            updatedAt: Date.parse(latest.updated_at),
+          };
+          candidate = mergeWorkspaceAfterRevisionConflict(workspace, remote);
+          const index = workspaces.findIndex((item) => item.id === candidate.id);
+          if (index >= 0) workspaces[index] = candidate;
+          saved = await saveWorkspace(candidate, latest.revision);
+        }
         workspaceRevisions[workspace.id] = saved.revision;
       }
       let activeWorkspaceId = get().activeWorkspaceId;


### PR DESCRIPTION
## Summary
- retry one optimistic workspace sync conflict after refreshing the current remote revision
- preserve profile names, toolsets, and proxy associations from both devices
- keep non-conflict failures visible

## Verification
- `./node_modules/.bin/vitest run src/lib/workspaceConflict.test.ts src/lib/automationExecution.test.ts`
- `./node_modules/.bin/tsc --noEmit`