### PR TITLE
fix: persist GitHub stars fallback locally

### DIFF
--- a/electron/github-stars.cjs
+++ b/electron/github-stars.cjs
@@ -1,3 +1,6 @@
+const fs = require("node:fs/promises");
+const path = require("node:path");
+
 const REPOSITORY_API_URL = "https://api.github.com/repos/nextbrowser-oss/nextbrowser-app";
 
 async function fetchGitHubStars(fetchImpl = globalThis.fetch, options = {}) {
@@ -15,4 +18,41 @@ async function fetchGitHubStars(fetchImpl = globalThis.fetch, options = {}) {
   return Number.isInteger(count) && count >= 0 ? count : null;
 }
 
-module.exports = { REPOSITORY_API_URL, fetchGitHubStars };
+function validStarCount(value) {
+  return Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+async function readLocalGitHubStars(filePath) {
+  try {
+    const parsed = JSON.parse(await fs.readFile(filePath, "utf8"));
+    return validStarCount(parsed?.count);
+  } catch {
+    return null;
+  }
+}
+
+async function writeLocalGitHubStars(filePath, count) {
+  if (validStarCount(count) == null) return false;
+  const directory = path.dirname(filePath);
+  const temporaryPath = `${filePath}.${process.pid}.tmp`;
+  try {
+    await fs.mkdir(directory, { recursive: true });
+    await fs.writeFile(
+      temporaryPath,
+      JSON.stringify({ count, fetchedAt: new Date().toISOString() }, null, 2),
+      "utf8",
+    );
+    await fs.rename(temporaryPath, filePath);
+    return true;
+  } catch {
+    await fs.rm(temporaryPath, { force: true }).catch(() => undefined);
+    return false;
+  }
+}
+
+module.exports = {
+  REPOSITORY_API_URL,
+  fetchGitHubStars,
+  readLocalGitHubStars,
+  writeLocalGitHubStars,
+};

--- a/electron/github-stars.test.cjs
+++ b/electron/github-stars.test.cjs
@@ -1,6 +1,14 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const { REPOSITORY_API_URL, fetchGitHubStars } = require("./github-stars.cjs");
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const {
+  REPOSITORY_API_URL,
+  fetchGitHubStars,
+  readLocalGitHubStars,
+  writeLocalGitHubStars,
+} = require("./github-stars.cjs");
 
 test("returns the repository star count", async () => {
   const count = await fetchGitHubStars(async (url, options) => {
@@ -26,4 +34,31 @@ test("returns null for an invalid star count", async () => {
     json: async () => ({ stargazers_count: "8" }),
   }));
   assert.equal(count, null);
+});
+
+test("persists and restores the last GitHub count locally", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "nextbrowser-stars-"));
+  const filePath = path.join(directory, "github-stars.json");
+  try {
+    assert.equal(await readLocalGitHubStars(filePath), null);
+    assert.equal(await writeLocalGitHubStars(filePath, 19), true);
+    assert.equal(await readLocalGitHubStars(filePath), 19);
+    const parsed = JSON.parse(await fs.readFile(filePath, "utf8"));
+    assert.equal(parsed.count, 19);
+    assert.equal(typeof parsed.fetchedAt, "string");
+  } finally {
+    await fs.rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("rejects malformed local cache values", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "nextbrowser-stars-"));
+  const filePath = path.join(directory, "github-stars.json");
+  try {
+    await fs.writeFile(filePath, JSON.stringify({ count: "19" }), "utf8");
+    assert.equal(await readLocalGitHubStars(filePath), null);
+    assert.equal(await writeLocalGitHubStars(filePath, -1), false);
+  } finally {
+    await fs.rm(directory, { recursive: true, force: true });
+  }
 });

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -20,7 +20,7 @@ const {
   searchDirs,
 } = require("./binary-resolver.cjs");
 const { applyLegacyRuntimeMigration, applyRuntimeRootMigration, clearRuntimeCredential, runtimeAPIBaseURL } = require("./runtime-config.cjs");
-const { fetchGitHubStars } = require("./github-stars.cjs");
+const { fetchGitHubStars, readLocalGitHubStars, writeLocalGitHubStars } = require("./github-stars.cjs");
 const { ensureWorkspaceInstructions } = require("./workspace-instructions.cjs");
 const pty = require("node-pty");
 const {
@@ -724,6 +724,7 @@ async function ensureDasbrowserRuntime({ force = false, reportStatus = true } = 
   return dasbrowserInstallPromise;
 }
 function dataDir() { return path.join(app.getPath("userData")); }
+function githubStarsCachePath() { return path.join(dataDir(), "github-stars.json"); }
 function localAutomationArtifacts() {
   if (!automationArtifactStore) {
     automationArtifactStore = createLocalArtifactStore({ rootDir: path.join(dataDir(), "automation-artifacts") });
@@ -1258,11 +1259,17 @@ async function apiFetchJSON(baseURL, route, options = {}) {
 async function invokeCommand(command, args = {}, sender) {
   switch (command) {
     case "github_stars": {
+      let count = null;
       try {
-        return await fetchGitHubStars(fetch, { signal: AbortSignal.timeout(5000) });
+        count = await fetchGitHubStars(fetch, { signal: AbortSignal.timeout(5000) });
       } catch {
-        return null;
+        // A local result is still useful when GitHub is unavailable.
       }
+      if (typeof count === "number") {
+        await writeLocalGitHubStars(githubStarsCachePath(), count);
+        return count;
+      }
+      return (await readLocalGitHubStars(githubStarsCachePath())) ?? 17;
     }
     case "app_update_status": return appUpdateStatus;
     case "browser_runtime_update_status": return browserRuntimeUpdateStatus;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -274,15 +274,8 @@ function formatStars(count?: number | null): string {
   return `${rounded}k`;
 }
 
-// GitHub's API is unavailable in some regions. Prefer a slightly stale count
-// over rendering a broken-looking dash; a successful request replaces it.
-const GITHUB_STARS_FALLBACK = 16;
-const GITHUB_STARS_CACHE_KEY = "nextbrowser.github-stars";
-
-function cachedGithubStars(): number {
-  const cached = Number(localStorage.getItem(GITHUB_STARS_CACHE_KEY));
-  return Number.isFinite(cached) && cached >= 0 ? cached : GITHUB_STARS_FALLBACK;
-}
+// The Electron host resolves GitHub → local on-disk cache → this fallback.
+const GITHUB_STARS_FALLBACK = 17;
 
 function GithubStarButton({ stars }: { stars?: number | null }) {
   const label = "Star NextBrowser on GitHub";
@@ -316,7 +309,7 @@ function DiscordButton() {
 }
 
 function SocialButtons() {
-  const [stars, setStars] = useState<number>(cachedGithubStars);
+  const [stars, setStars] = useState<number>(GITHUB_STARS_FALLBACK);
 
   useEffect(() => {
     let cancelled = false;
@@ -324,7 +317,6 @@ function SocialButtons() {
       .then((count) => {
         if (!cancelled && typeof count === "number") {
           setStars(count);
-          localStorage.setItem(GITHUB_STARS_CACHE_KEY, String(count));
         }
       })
       .catch(() => undefined);


### PR DESCRIPTION
## Summary
- resolve GitHub stars as GitHub API → local app-data cache → 17
- persist only verified GitHub counts in `github-stars.json`
- remove renderer localStorage cache so the documented fallback order is authoritative

## Verification
- `node --test electron/github-stars.test.cjs`
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`