### PR TITLE
fix: explain and recover failed browser toolset updates

### DIFF
--- a/electron/browser-runtime-updates.cjs
+++ b/electron/browser-runtime-updates.cjs
@@ -36,6 +36,91 @@ function selectAvailableRuntimeUpdates(status, requestedRuntimes) {
   return (status?.runtimes || []).filter((runtime) => runtime.status === "available" && requested.has(runtime.runtime));
 }
 
+function updateInstallMessage(completed, errors) {
+  if (errors.length) {
+    return completed.length
+      ? "Some browser toolsets were updated, but others need attention."
+      : "The browser toolset updates could not be installed.";
+  }
+  return `${completed.length === 1 ? "The browser toolset is" : "Browser toolsets are"} ready to use.`;
+}
+
+// Keep the multi-toolset update policy independent from Electron. This makes
+// the important guarantee explicit: a failed runtime never prevents later,
+// confirmed runtimes from being attempted.
+async function installSelectedRuntimeUpdates({ requestedRuntimes, checkForUpdates, installRuntime, onStatus = () => {} }) {
+  const fresh = await checkForUpdates();
+  const updates = selectAvailableRuntimeUpdates(fresh, requestedRuntimes);
+  if (!updates.length) {
+    const result = {
+      status: "failed",
+      runtimes: [],
+      completed: [],
+      errors: [],
+      progress: 100,
+      message: "The selected browser toolsets are already up to date.",
+    };
+    onStatus(result);
+    return result;
+  }
+
+  const runtimes = updates.map((runtime) => runtime.runtime);
+  const completed = [];
+  const errors = [];
+  onStatus({
+    status: "installing",
+    runtimes,
+    completed: [],
+    errors: [],
+    currentRuntime: updates[0].runtime,
+    currentName: updates[0].name,
+    currentVersion: updates[0].latestVersion,
+    total: updates.length,
+    progress: 0,
+    message: "Downloading the confirmed updates in the background.",
+  });
+
+  for (let index = 0; index < updates.length; index += 1) {
+    const update = updates[index];
+    onStatus({
+      status: "installing",
+      runtimes,
+      completed: [...completed],
+      errors: [...errors],
+      currentRuntime: update.runtime,
+      currentName: update.name,
+      currentVersion: update.latestVersion,
+      total: updates.length,
+      progress: Math.round((index / updates.length) * 100),
+      message: `Installing ${update.name} ${update.latestVersion || "update"} in the background.`,
+    });
+    try {
+      await installRuntime(update);
+      completed.push(update.runtime);
+    } catch (error) {
+      errors.push({ runtime: update.runtime, name: update.name, message: error?.message || String(error) });
+    }
+  }
+
+  // A transient refresh failure must not turn completed updates into a failed
+  // operation. The next hourly check will refresh the available versions.
+  await checkForUpdates().catch(() => undefined);
+  const result = {
+    status: errors.length ? (completed.length ? "partial" : "failed") : "ready",
+    runtimes,
+    completed,
+    errors,
+    currentRuntime: undefined,
+    currentName: undefined,
+    currentVersion: undefined,
+    total: updates.length,
+    progress: 100,
+    message: updateInstallMessage(completed, errors),
+  };
+  onStatus(result);
+  return result;
+}
+
 function clawbrowserReleaseAsset(platform, arch, version) {
   const release = assertRuntimeReleaseVersion(version);
   let assetName = "";
@@ -249,6 +334,7 @@ module.exports = {
   compareVersions,
   installedCamoufoxVersion,
   installedClawbrowserVersion,
+  installSelectedRuntimeUpdates,
   installRuntimeUpdateWithVerification,
   normalizeVersion,
   runtimeResult,

--- a/electron/browser-runtime-updates.cjs
+++ b/electron/browser-runtime-updates.cjs
@@ -36,6 +36,34 @@ function selectAvailableRuntimeUpdates(status, requestedRuntimes) {
   return (status?.runtimes || []).filter((runtime) => runtime.status === "available" && requested.has(runtime.runtime));
 }
 
+function conciseFailureMessage(error) {
+  const message = String(error?.message || error || "The update process stopped unexpectedly.")
+    .replace(/\s+/g, " ")
+    .trim();
+  return message.length > 240 ? `${message.slice(0, 237)}…` : message;
+}
+
+function classifyRuntimeUpdateFailure(error) {
+  const message = conciseFailureMessage(error);
+  const normalized = message.toLowerCase();
+  if (/enospc|no space|disk full|not enough space/.test(normalized)) {
+    return { code: "UPDATE_DISK_SPACE", category: "Not enough disk space", retryable: false, message, recovery: "Free up disk space, then try again." };
+  }
+  if (/eacces|eperm|permission denied|operation not permitted|administrator/.test(normalized)) {
+    return { code: "UPDATE_PERMISSION", category: "Permission required", retryable: false, message, recovery: "Check that NextBrowser can write to its application data, then try again." };
+  }
+  if (/ebusy|locked|in use|already running|running browser|process.*running/.test(normalized)) {
+    return { code: "UPDATE_RUNTIME_IN_USE", category: "Browser is still running", retryable: true, message, recovery: "Close this browser toolset completely, then retry." };
+  }
+  if (/timeout|timed out|fetch failed|network|econn|enotfound|eai_again|http\s*[45]\d\d|update source returned/.test(normalized)) {
+    return { code: "UPDATE_NETWORK", category: "Connection problem", retryable: true, message, recovery: "Keep NextBrowser open and check your internet connection, then retry." };
+  }
+  if (/invalid version|signature verification|release did not contain|installed version is still|not available for/.test(normalized)) {
+    return { code: "UPDATE_RELEASE_VALIDATION", category: "Release verification failed", retryable: false, message, recovery: "Use the official manual update page below, or try again after a newer release is published." };
+  }
+  return { code: "UPDATE_UNKNOWN", category: "Update could not finish", retryable: true, message, recovery: "Keep NextBrowser open, check disk space and your connection, then retry." };
+}
+
 function updateInstallMessage(completed, errors) {
   if (errors.length) {
     return completed.length
@@ -98,7 +126,12 @@ async function installSelectedRuntimeUpdates({ requestedRuntimes, checkForUpdate
       await installRuntime(update);
       completed.push(update.runtime);
     } catch (error) {
-      errors.push({ runtime: update.runtime, name: update.name, message: error?.message || String(error) });
+      errors.push({
+        runtime: update.runtime,
+        name: update.name,
+        releasePage: update.releasePage,
+        ...classifyRuntimeUpdateFailure(error),
+      });
     }
   }
 
@@ -331,6 +364,7 @@ module.exports = {
   assertRuntimeReleaseVersion,
   checkBrowserRuntimeUpdates,
   clawbrowserReleaseAsset,
+  classifyRuntimeUpdateFailure,
   compareVersions,
   installedCamoufoxVersion,
   installedClawbrowserVersion,

--- a/electron/browser-runtime-updates.test.cjs
+++ b/electron/browser-runtime-updates.test.cjs
@@ -8,6 +8,7 @@ const {
   assertRuntimeReleaseVersion,
   checkBrowserRuntimeUpdates,
   clawbrowserReleaseAsset,
+  classifyRuntimeUpdateFailure,
   compareVersions,
   installedCamoufoxVersion,
   installSelectedRuntimeUpdates,
@@ -85,9 +86,26 @@ test("continues all confirmed toolset updates when one of three fails", async ()
   assert.equal(checks, 2);
   assert.equal(result.status, "partial");
   assert.deepEqual(result.completed, ["clawbrowser", "dasbrowser"]);
-  assert.deepEqual(result.errors, [{ runtime: "camoufox", name: "Camoufox", message: "Package mirror timed out" }]);
+  assert.deepEqual(result.errors, [{
+    runtime: "camoufox",
+    name: "Camoufox",
+    releasePage: undefined,
+    code: "UPDATE_NETWORK",
+    category: "Connection problem",
+    retryable: true,
+    message: "Package mirror timed out",
+    recovery: "Keep NextBrowser open and check your internet connection, then retry.",
+  }]);
   assert.equal(result.progress, 100);
   assert.equal(statuses.at(-1).message, "Some browser toolsets were updated, but others need attention.");
+});
+
+test("classifies recovery guidance without exposing an opaque raw failure", () => {
+  assert.equal(classifyRuntimeUpdateFailure(new Error("ENOSPC: no space left on device")).code, "UPDATE_DISK_SPACE");
+  assert.equal(classifyRuntimeUpdateFailure(new Error("EACCES permission denied")).code, "UPDATE_PERMISSION");
+  assert.equal(classifyRuntimeUpdateFailure(new Error("runtime is locked by a running browser")).code, "UPDATE_RUNTIME_IN_USE");
+  assert.equal(classifyRuntimeUpdateFailure(new Error("fetch failed: ETIMEDOUT")).code, "UPDATE_NETWORK");
+  assert.equal(classifyRuntimeUpdateFailure(new Error("bad release payload")).code, "UPDATE_UNKNOWN");
 });
 
 test("retries once when a CLI self-update completes before the browser runtime changes", async () => {

--- a/electron/browser-runtime-updates.test.cjs
+++ b/electron/browser-runtime-updates.test.cjs
@@ -10,6 +10,7 @@ const {
   clawbrowserReleaseAsset,
   compareVersions,
   installedCamoufoxVersion,
+  installSelectedRuntimeUpdates,
   installRuntimeUpdateWithVerification,
   runtimeResult,
   selectAvailableRuntimeUpdates,
@@ -57,6 +58,36 @@ test("installs only explicitly confirmed updates that are still available", () =
   };
   assert.deepEqual(selectAvailableRuntimeUpdates(status, ["clawbrowser", "camoufox", "invented"]), [status.runtimes[0]]);
   assert.deepEqual(selectAvailableRuntimeUpdates(status, []), []);
+});
+
+test("continues all confirmed toolset updates when one of three fails", async () => {
+  const available = {
+    runtimes: [
+      { runtime: "clawbrowser", name: "ClawBrowser", latestVersion: "1.0.4", status: "available" },
+      { runtime: "camoufox", name: "Camoufox", latestVersion: "0.5.5", status: "available" },
+      { runtime: "dasbrowser", name: "DasBrowser", latestVersion: "144.32", status: "available" },
+    ],
+  };
+  const calls = [];
+  const statuses = [];
+  let checks = 0;
+  const result = await installSelectedRuntimeUpdates({
+    requestedRuntimes: ["clawbrowser", "camoufox", "dasbrowser"],
+    checkForUpdates: async () => { checks += 1; return available; },
+    installRuntime: async (runtime) => {
+      calls.push(runtime.runtime);
+      if (runtime.runtime === "camoufox") throw new Error("Package mirror timed out");
+    },
+    onStatus: (status) => statuses.push(status),
+  });
+
+  assert.deepEqual(calls, ["clawbrowser", "camoufox", "dasbrowser"]);
+  assert.equal(checks, 2);
+  assert.equal(result.status, "partial");
+  assert.deepEqual(result.completed, ["clawbrowser", "dasbrowser"]);
+  assert.deepEqual(result.errors, [{ runtime: "camoufox", name: "Camoufox", message: "Package mirror timed out" }]);
+  assert.equal(result.progress, 100);
+  assert.equal(statuses.at(-1).message, "Some browser toolsets were updated, but others need attention.");
 });
 
 test("retries once when a CLI self-update completes before the browser runtime changes", async () => {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -75,8 +75,8 @@ const {
   compareVersions,
   installedCamoufoxVersion,
   installedClawbrowserVersion,
+  installSelectedRuntimeUpdates,
   installRuntimeUpdateWithVerification,
-  selectAvailableRuntimeUpdates,
 } = require("./browser-runtime-updates.cjs");
 const { createMultiloginCredentialStore, exchangeAutomationToken } = require("./multilogin-credential.cjs");
 const { parseMultiloginProfiles, parseMultiloginCreatedProfile } = require("./multilogin-profiles.cjs");
@@ -1140,39 +1140,10 @@ async function installedBrowserRuntimeVersion(runtime) {
 async function installBrowserRuntimeUpdates(requestedRuntimes = []) {
   if (browserRuntimeUpdateInstallPromise) return browserRuntimeUpdateInstallPromise;
   browserRuntimeUpdateInstallPromise = (async () => {
-    const fresh = await checkForBrowserRuntimeUpdates();
-    const updates = selectAvailableRuntimeUpdates(fresh, requestedRuntimes);
-    if (!updates.length) {
-      setBrowserRuntimeUpdateInstallStatus("failed", {
-        runtimes: [],
-        message: "The selected browser toolsets are already up to date.",
-      });
-      return browserRuntimeUpdateInstallStatus;
-    }
-    const completed = [];
-    const errors = [];
-    setBrowserRuntimeUpdateInstallStatus("installing", {
-      runtimes: updates.map((runtime) => runtime.runtime),
-      completed,
-      errors: [],
-      currentRuntime: updates[0].runtime,
-      currentName: updates[0].name,
-      currentVersion: updates[0].latestVersion,
-      total: updates.length,
-      progress: 0,
-      message: "Downloading the confirmed updates in the background.",
-    });
-    for (let index = 0; index < updates.length; index += 1) {
-      const update = updates[index];
-      setBrowserRuntimeUpdateInstallStatus("installing", {
-        currentRuntime: update.runtime,
-        currentName: update.name,
-        currentVersion: update.latestVersion,
-        completed: [...completed],
-        progress: Math.round((index / updates.length) * 100),
-        message: `Installing ${update.name} ${update.latestVersion || "update"} in the background.`,
-      });
-      try {
+    return installSelectedRuntimeUpdates({
+      requestedRuntimes,
+      checkForUpdates: checkForBrowserRuntimeUpdates,
+      installRuntime: async (update) => {
         if (update.runtime === "clawbrowser") await updateClawbrowserRuntime(update.latestVersion);
         else if (update.runtime === "camoufox") await updateCamoufoxRuntime(update.latestVersion);
         else if (update.runtime === "dasbrowser") await ensureDasbrowserRuntime({ force: true, reportStatus: false });
@@ -1181,27 +1152,9 @@ async function installBrowserRuntimeUpdates(requestedRuntimes = []) {
         if (!installed || compareVersions(installed, expected) < 0) {
           throw new Error(`${update.name} ${expected} was downloaded, but the installed version is still ${installed || "unknown"}.`);
         }
-        completed.push(update.runtime);
-      } catch (error) {
-        errors.push({ runtime: update.runtime, name: update.name, message: error?.message || String(error) });
-      }
-    }
-    await checkForBrowserRuntimeUpdates();
-    const status = errors.length ? (completed.length ? "partial" : "failed") : "ready";
-    setBrowserRuntimeUpdateInstallStatus(status, {
-      currentRuntime: undefined,
-      currentName: undefined,
-      currentVersion: undefined,
-      completed,
-      errors,
-      progress: 100,
-      message: errors.length
-        ? completed.length
-          ? "Some browser toolsets were updated, but others need attention."
-          : "The browser toolset updates could not be installed."
-        : `${completed.length === 1 ? "The browser toolset is" : "Browser toolsets are"} ready to use.`,
+      },
+      onStatus: ({ status, ...patch }) => setBrowserRuntimeUpdateInstallStatus(status, patch),
     });
-    return browserRuntimeUpdateInstallStatus;
   })().finally(() => {
     browserRuntimeUpdateInstallPromise = null;
   });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,7 +84,16 @@ interface BrowserRuntimeUpdateInstallStatus {
   total?: number;
   progress?: number;
   message?: string;
-  errors?: { runtime: BrowserRuntimeUpdateEntry["runtime"]; name: string; message: string }[];
+  errors?: {
+    runtime: BrowserRuntimeUpdateEntry["runtime"];
+    name: string;
+    releasePage?: string;
+    code?: string;
+    category?: string;
+    retryable?: boolean;
+    message: string;
+    recovery?: string;
+  }[];
 }
 
 const APP_UPDATE_ERROR = "We couldn't update NextBrowser. Please retry again.";
@@ -146,10 +155,11 @@ function BrowserRuntimeUpdatePrompt({ runtimes, onLater, onConfirm }: {
   );
 }
 
-function BrowserRuntimeUpdateProgress({ status, onClose, onRetry }: {
+function BrowserRuntimeUpdateProgress({ status, onClose, onRetry, onOpenManualGuide }: {
   status: BrowserRuntimeUpdateInstallStatus;
   onClose: () => void;
   onRetry: (runtimes: BrowserRuntimeUpdateEntry["runtime"][]) => void;
+  onOpenManualGuide: (url?: string) => void;
 }) {
   const installing = status.status === "installing";
   const failed = status.status === "failed";
@@ -163,8 +173,26 @@ function BrowserRuntimeUpdateProgress({ status, onClose, onRetry }: {
         <strong>{installing ? `Updating ${status.currentName ?? "browser toolsets"}` : failed ? "Update failed" : partial ? "Update partly complete" : "Browser toolsets updated"}</strong>
         <span className="muted small">{status.message}</span>
         {installing && <div className="runtime-update-progress-track"><span style={{ width: `${Math.max(4, status.progress ?? 0)}%` }} /></div>}
-        {!!status.errors?.length && <span className="error small" title={status.errors.map((error) => `${error.name}: ${error.message}`).join("\n")}>{status.errors.map((error) => error.name).join(", ")} could not be updated.</span>}
-        {partial && !!status.errors?.length && <button className="secondary small runtime-update-retry" onClick={() => onRetry(status.errors!.map((error) => error.runtime))}>Retry failed toolsets</button>}
+        {!!status.errors?.length && (
+          <div className="runtime-update-errors">
+            {status.errors.map((error) => (
+              <section className="runtime-update-error" key={error.runtime}>
+                <div className="runtime-update-error-heading">
+                  <strong>{error.name} couldn’t update</strong>
+                  {error.code && <code>{error.code}</code>}
+                </div>
+                <span className="error small">{error.category ?? "Update could not finish"}</span>
+                <p className="muted small">{error.message}</p>
+                <p className="runtime-update-recovery">{error.recovery ?? "Keep NextBrowser open, then try again."}</p>
+                <div className="row runtime-update-error-actions">
+                  {error.retryable !== false && <button className="secondary small" onClick={() => onRetry([error.runtime])}>Retry {error.name}</button>}
+                  <button className="secondary small" onClick={() => onOpenManualGuide(error.releasePage)}>Update manually</button>
+                </div>
+              </section>
+            ))}
+          </div>
+        )}
+        {(failed || partial) && <p className="runtime-update-requirements">Before retrying: keep NextBrowser open, use a stable connection, make sure there is free disk space, and close any running browser toolset.</p>}
       </div>
       {!installing && (
         <button className="plain-icon-btn plain-icon-btn-compact" onClick={onClose} aria-label="Dismiss update status">
@@ -794,6 +822,12 @@ export function App() {
   const requestBrowserRuntimeUpdate = (runtime: BrowserRuntimeUpdateEntry) => {
     setRuntimeUpdatePrompt([runtime]);
   };
+  const openBrowserRuntimeManualGuide = (url?: string) => {
+    const destination = url || "https://github.com/clawbrowser/clawbrowser/releases/latest";
+    void invoke("open_external", { url: destination }).catch(() => {
+      window.open(destination, "_blank", "noopener,noreferrer");
+    });
+  };
   const dismissBrowserRuntimeUpdatePrompt = () => {
     if (runtimeUpdatePrompt) setRuntimeUpdatePromptDismissed(browserRuntimeUpdateSignature(runtimeUpdatePrompt));
     setRuntimeUpdatePrompt(undefined);
@@ -1180,7 +1214,7 @@ export function App() {
           />
         )}
         {runtimeUpdateInstall.status !== "idle" && !runtimeUpdateProgressHidden && (
-          <BrowserRuntimeUpdateProgress status={runtimeUpdateInstall} onClose={() => setRuntimeUpdateProgressHidden(true)} onRetry={installBrowserRuntimeUpdates} />
+          <BrowserRuntimeUpdateProgress status={runtimeUpdateInstall} onClose={() => setRuntimeUpdateProgressHidden(true)} onRetry={installBrowserRuntimeUpdates} onOpenManualGuide={openBrowserRuntimeManualGuide} />
         )}
         {unexpectedError && <GlobalErrorNotice error={unexpectedError} onClose={() => setUnexpectedError(undefined)} />}
       </>
@@ -1295,7 +1329,7 @@ export function App() {
         setBrowserRuntimeInstall(undefined);
       }} />}
       {runtimeUpdateInstall.status !== "idle" && !runtimeUpdateProgressHidden && (
-        <BrowserRuntimeUpdateProgress status={runtimeUpdateInstall} onClose={() => setRuntimeUpdateProgressHidden(true)} onRetry={installBrowserRuntimeUpdates} />
+        <BrowserRuntimeUpdateProgress status={runtimeUpdateInstall} onClose={() => setRuntimeUpdateProgressHidden(true)} onRetry={installBrowserRuntimeUpdates} onOpenManualGuide={openBrowserRuntimeManualGuide} />
       )}
       {unexpectedError && <GlobalErrorNotice error={unexpectedError} onClose={() => setUnexpectedError(undefined)} />}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -146,9 +146,10 @@ function BrowserRuntimeUpdatePrompt({ runtimes, onLater, onConfirm }: {
   );
 }
 
-function BrowserRuntimeUpdateProgress({ status, onClose }: {
+function BrowserRuntimeUpdateProgress({ status, onClose, onRetry }: {
   status: BrowserRuntimeUpdateInstallStatus;
   onClose: () => void;
+  onRetry: (runtimes: BrowserRuntimeUpdateEntry["runtime"][]) => void;
 }) {
   const installing = status.status === "installing";
   const failed = status.status === "failed";
@@ -163,6 +164,7 @@ function BrowserRuntimeUpdateProgress({ status, onClose }: {
         <span className="muted small">{status.message}</span>
         {installing && <div className="runtime-update-progress-track"><span style={{ width: `${Math.max(4, status.progress ?? 0)}%` }} /></div>}
         {!!status.errors?.length && <span className="error small" title={status.errors.map((error) => `${error.name}: ${error.message}`).join("\n")}>{status.errors.map((error) => error.name).join(", ")} could not be updated.</span>}
+        {partial && !!status.errors?.length && <button className="secondary small runtime-update-retry" onClick={() => onRetry(status.errors!.map((error) => error.runtime))}>Retry failed toolsets</button>}
       </div>
       {!installing && (
         <button className="plain-icon-btn plain-icon-btn-compact" onClick={onClose} aria-label="Dismiss update status">
@@ -796,8 +798,8 @@ export function App() {
     if (runtimeUpdatePrompt) setRuntimeUpdatePromptDismissed(browserRuntimeUpdateSignature(runtimeUpdatePrompt));
     setRuntimeUpdatePrompt(undefined);
   };
-  const installBrowserRuntimeUpdates = () => {
-    const runtimes = runtimeUpdatePrompt?.map((runtime) => runtime.runtime) ?? [];
+  const installBrowserRuntimeUpdates = (requestedRuntimes?: BrowserRuntimeUpdateEntry["runtime"][]) => {
+    const runtimes = requestedRuntimes ?? runtimeUpdatePrompt?.map((runtime) => runtime.runtime) ?? [];
     if (!runtimes.length) return;
     setRuntimeUpdatePromptDismissed(browserRuntimeUpdateSignature(browserRuntimeUpdates.runtimes));
     setRuntimeUpdatePrompt(undefined);
@@ -1178,7 +1180,7 @@ export function App() {
           />
         )}
         {runtimeUpdateInstall.status !== "idle" && !runtimeUpdateProgressHidden && (
-          <BrowserRuntimeUpdateProgress status={runtimeUpdateInstall} onClose={() => setRuntimeUpdateProgressHidden(true)} />
+          <BrowserRuntimeUpdateProgress status={runtimeUpdateInstall} onClose={() => setRuntimeUpdateProgressHidden(true)} onRetry={installBrowserRuntimeUpdates} />
         )}
         {unexpectedError && <GlobalErrorNotice error={unexpectedError} onClose={() => setUnexpectedError(undefined)} />}
       </>
@@ -1293,7 +1295,7 @@ export function App() {
         setBrowserRuntimeInstall(undefined);
       }} />}
       {runtimeUpdateInstall.status !== "idle" && !runtimeUpdateProgressHidden && (
-        <BrowserRuntimeUpdateProgress status={runtimeUpdateInstall} onClose={() => setRuntimeUpdateProgressHidden(true)} />
+        <BrowserRuntimeUpdateProgress status={runtimeUpdateInstall} onClose={() => setRuntimeUpdateProgressHidden(true)} onRetry={installBrowserRuntimeUpdates} />
       )}
       {unexpectedError && <GlobalErrorNotice error={unexpectedError} onClose={() => setUnexpectedError(undefined)} />}
     </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -3665,7 +3665,7 @@ code { background: var(--surface-4); padding: 1px 5px; border-radius: 4px; }
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: start;
   gap: 11px;
-  width: min(390px, calc(100vw - 36px));
+  width: min(480px, calc(100vw - 36px));
   padding: 13px;
   border: 1px solid var(--line-strong);
   border-radius: var(--radius-lg);
@@ -3690,6 +3690,32 @@ code { background: var(--surface-4); padding: 1px 5px; border-radius: 4px; }
 .runtime-update-progress-mark.is-error { color: var(--red); background: color-mix(in srgb, var(--red) 12%, transparent); }
 .runtime-update-progress-copy { min-width: 0; display: flex; flex-direction: column; gap: 4px; }
 .runtime-update-progress-copy strong { font-size: 14px; }
+.runtime-update-errors {
+  display: grid;
+  gap: 8px;
+  margin-top: 4px;
+}
+.runtime-update-error {
+  padding: 9px;
+  border: 1px solid color-mix(in srgb, var(--red) 36%, var(--line));
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--red) 6%, var(--surface-2));
+}
+.runtime-update-error-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.runtime-update-error-heading code {
+  flex: none;
+  color: var(--muted);
+  font-size: 10px;
+}
+.runtime-update-error p { margin: 4px 0 0; }
+.runtime-update-recovery { color: var(--text); font-size: 12px; }
+.runtime-update-error-actions { gap: 6px; margin-top: 8px; }
+.runtime-update-requirements { margin: 4px 0 0; color: var(--muted); font-size: 11px; line-height: 1.4; }
 .runtime-update-progress-track {
   height: 4px;
   margin-top: 3px;


### PR DESCRIPTION
## Summary
- update confirmed browser toolsets sequentially and continue after an individual failure
- classify each failure into an actionable category and error code
- show the concrete reason, recovery steps, per-toolset retry, and an official manual update path
- preserve a partial-success result even when the follow-up update check is unavailable

## Verification
- npm test (242 tests)
- npm run build
- visible Electron Settings update check
- regression: ClawBrowser succeeds, Camoufox fails, DasBrowser still succeeds
- classification coverage for disk, permission, running browser, network, and unknown failures