### PR TITLE
feat: unlock free proxy traffic through Discord

### DIFF
--- a/ANALYTICS.md
+++ b/ANALYTICS.md
@@ -33,7 +33,7 @@ reports and explorations.
   `nextctl_missing`, `nextctl_update_started`, `nextctl_update_completed`,
   `nextctl_update_failed`.
 - Proxy/session/profile: `proxy_loaded`, `proxy_refresh_started`,
-  `proxy_refresh_succeeded`, `proxy_top_up_requested`,
+  `proxy_refresh_succeeded`, `proxy_traffic_gate_discord_opened`,
   `session_start_requested`, `session_stop_requested`,
   `session_rotate_requested`, `profile_start_requested`,
   `profile_stop_requested`, `profile_rotate_requested`,

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -16,7 +16,7 @@ It is not a marketing site, a decorative dashboard, or a consumer chat toy. The 
 
 - Connect a local agent and keep its state understandable.
 - Create, start, stop, inspect, rotate, and delete browser profiles.
-- Understand proxy traffic usage and top up when needed.
+- Understand proxy traffic usage and how to unlock more of the free allowance.
 - Send chat requests to the active agent with the right profile/session context.
 - Apply skills and scripts without losing trust in what will run.
 - Observe a live browser session and recover when local components are missing.

--- a/docs/product-guide.md
+++ b/docs/product-guide.md
@@ -35,6 +35,18 @@ A profile may exist while its browser session is stopped. Selecting a profile do
 
 A session is the running browser context for a profile. The session must be running before an agent can work with its pages. Session diagnostics include status, open tabs, page state, screenshots, and identity verification.
 
+### Free traffic allowance
+
+New accounts are shown a 1 GiB free proxy allowance, but they are provisioned with a
+smaller starting limit — somewhere between 10 MiB and 70 MiB. When that starting limit
+is reached, proxy traffic pauses and **Proxy usage** explains how to unlock the rest:
+ask in the NextBrowser Discord. The remaining allowance is then released by hand, one
+1 GiB grant at a time, up to a 3 GiB ceiling. Feedback, repository stars, and pull
+requests are what earn the larger grants.
+
+Accounts created before this gate keep their existing allocation and are never paused
+by it.
+
 ### Proxy and fingerprint rotation
 
 Rotation requests a refreshed browser identity, optionally with a country. Verification should follow rotation when a workflow depends on geography or identity consistency.

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -28,7 +28,6 @@ const {
   cancelCommand,
   runCommand,
 } = require("./command-runner.cjs");
-const { topUpProxyTraffic } = require("./proxy-traffic.cjs");
 const { terminateProcessTree } = require("./process-tree.cjs");
 const {
   createPersonalProxy,
@@ -1410,7 +1409,6 @@ async function invokeCommand(command, args = {}, sender) {
       const r = await run(bin, ["version"]); return r.stdout.trim();
     }
     case "nextctl_supports_skill": { const bin = await resolveOrInstallNextctl(); if (!bin) throw new Error("not found"); return nextctlHasSkill(bin); }
-    case "proxy_traffic_top_up": return await topUpProxyTraffic({ env: childEnv() });
     case "projects_list": return await listProjects({ env: childEnv() });
     case "project_put": return await putProject(String(args.id || ""), args.project, { env: childEnv() });
     case "project_delete": return await deleteProject(String(args.id || ""), { env: childEnv() });

--- a/electron/proxy-traffic.cjs
+++ b/electron/proxy-traffic.cjs
@@ -3,8 +3,6 @@ const os = require("node:os");
 const path = require("node:path");
 
 const DEFAULT_API_BASE_URL = "https://api.nextbrowser.com";
-const PROXY_TRAFFIC_TOP_UP_PATH = "/v1/proxy/traffic/top-up";
-const PROXY_TRAFFIC_REQUEST_TIMEOUT_MS = 30_000;
 
 function configPath({
   env = process.env,
@@ -67,37 +65,4 @@ async function loadBackendConfig({
   return { apiKey, baseURL: normalizeAPIBaseURL(configuredBaseURL) };
 }
 
-async function topUpProxyTraffic(options = {}) {
-  const fetchImpl = options.fetchImpl || fetch;
-  const { apiKey, baseURL } = await loadBackendConfig(options);
-  let response;
-  try {
-    response = await fetchImpl(`${baseURL}${PROXY_TRAFFIC_TOP_UP_PATH}`, {
-      method: "POST",
-      headers: {
-        accept: "application/json",
-        authorization: `Bearer ${apiKey}`,
-      },
-      signal: AbortSignal.timeout(PROXY_TRAFFIC_REQUEST_TIMEOUT_MS),
-    });
-  } catch {
-    throw new Error("NextBrowser proxy traffic service is unavailable.");
-  }
-
-  if (!response.ok) {
-    throw new Error(`NextBrowser proxy traffic request failed (${response.status}).`);
-  }
-
-  let payload;
-  try {
-    payload = await response.json();
-  } catch {
-    throw new Error("NextBrowser proxy traffic response is invalid.");
-  }
-  if (!payload || typeof payload !== "object" || typeof payload.used_bytes !== "number" || typeof payload.state !== "string") {
-    throw new Error("NextBrowser proxy traffic response is incomplete.");
-  }
-  return payload;
-}
-
-module.exports = { configPath, loadBackendConfig, normalizeAPIBaseURL, topUpProxyTraffic };
+module.exports = { configPath, loadBackendConfig, normalizeAPIBaseURL };

--- a/electron/proxy-traffic.test.cjs
+++ b/electron/proxy-traffic.test.cjs
@@ -1,11 +1,10 @@
 const assert = require("node:assert/strict");
 const fs = require("node:fs/promises");
-const http = require("node:http");
 const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
 
-const { configPath, loadBackendConfig, normalizeAPIBaseURL, topUpProxyTraffic } = require("./proxy-traffic.cjs");
+const { configPath, loadBackendConfig, normalizeAPIBaseURL } = require("./proxy-traffic.cjs");
 
 async function tempHome(t) {
   const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "nextbrowser-proxy-traffic-"));
@@ -20,14 +19,6 @@ async function writeConfig(homeDir, payload) {
     JSON.stringify(payload),
     { mode: 0o600 },
   );
-}
-
-async function startServer(t, handler) {
-  const server = http.createServer(handler);
-  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
-  t.after(() => new Promise((resolve) => server.close(resolve)));
-  const address = server.address();
-  return `http://127.0.0.1:${address.port}`;
 }
 
 test("loads the backend key without exposing it to the renderer", async (t) => {
@@ -64,45 +55,4 @@ test("normalizes the legacy dashboard host and rejects non-http URLs", () => {
   assert.equal(normalizeAPIBaseURL("https://app.nextbrowser.com/"), "https://api.nextbrowser.com");
   assert.throws(() => normalizeAPIBaseURL("file:///tmp/config.json"), /Unsupported NextBrowser API URL/);
   assert.throws(() => normalizeAPIBaseURL("https://user:password@api.example.test"), /Unsupported NextBrowser API URL/);
-});
-
-test("tops up proxy traffic through the authenticated backend endpoint", async (t) => {
-  let authorization = "";
-  let requestPath = "";
-  const baseURL = await startServer(t, (request, response) => {
-    authorization = request.headers.authorization || "";
-    requestPath = request.url || "";
-    response.setHeader("content-type", "application/json");
-    response.end(JSON.stringify({
-      limited: true,
-      used_bytes: 1_073_741_824,
-      limit_bytes: 2_147_483_648,
-      remaining_bytes: 1_073_741_824,
-      percent_used: 50,
-      state: "ok",
-      top_up_bytes: 1_073_741_824,
-    }));
-  });
-  const homeDir = await tempHome(t);
-  await writeConfig(homeDir, { api_key: "traffic-key", api_base_url: baseURL });
-
-  const traffic = await topUpProxyTraffic({ homeDir, platform: "darwin", env: {} });
-
-  assert.equal(requestPath, "/v1/proxy/traffic/top-up");
-  assert.equal(authorization, "Bearer traffic-key");
-  assert.equal(traffic.limit_bytes, 2_147_483_648);
-});
-
-test("does not expose backend error bodies", async (t) => {
-  const baseURL = await startServer(t, (_request, response) => {
-    response.statusCode = 503;
-    response.end("private upstream failure");
-  });
-  const homeDir = await tempHome(t);
-  await writeConfig(homeDir, { api_key: "traffic-key", api_base_url: baseURL });
-
-  await assert.rejects(
-    topUpProxyTraffic({ homeDir, platform: "darwin", env: {} }),
-    (error) => error.message === "NextBrowser proxy traffic request failed (503).",
-  );
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,8 +13,9 @@ import { BrandLogo } from "./components/BrandLogo";
 import { Icon, Spinner } from "./components/Icon";
 import { AgentPicker } from "./components/AgentPicker";
 import { brandName, dashboardUrl, discordUrl, latestReleaseUrl, repoUrl } from "./constants";
+import { trafficAllowanceBytes, trafficAllowanceFraction } from "./lib/trafficGate";
 import { getPreviewMode, getPreviewTab } from "./preview";
-import { humanBytes, proxyFraction, type AppTab, type Conversation } from "./types";
+import { humanBytes, type AppTab, type Conversation } from "./types";
 import { resolveTheme, type Theme } from "./theme";
 import { flushAnalyticsEngagement, initAnalytics, trackEvent, trackScreenView } from "./lib/analytics";
 import {
@@ -396,9 +397,10 @@ function SettingsModal({
   const agentName = agentSpec.name;
   const agentDetected = !!agentVersion;
   const agentNeedsLogin = agentDetected && agentLoggedIn === false;
+  const proxyAllowance = trafficAllowanceBytes(proxy);
   const proxyUsed = proxy ? humanBytes(proxy.used_bytes) : "Locked";
-  const proxyLimit = proxy?.limit_bytes ? humanBytes(proxy.limit_bytes) : proxy ? "unlimited" : "Sign in";
-  const proxyPercent = proxy?.limited ? Math.round(proxyFraction(proxy) * 100) : null;
+  const proxyLimit = proxyAllowance != null ? humanBytes(proxyAllowance) : proxy ? "unlimited" : "Sign in";
+  const proxyPercent = proxy?.limited ? Math.round(trafficAllowanceFraction(proxy) * 100) : null;
   const handleAgentLogout = async () => {
     if (agentLogoutPending) return;
     setAgentLogoutPending(true);

--- a/src/components/UsageView.tsx
+++ b/src/components/UsageView.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import { nextctlJson } from "../nextctl";
-import { invoke } from "../electronBridge";
 import { useStore } from "../store";
+import { discordUrl } from "../constants";
 import { trackEvent } from "../lib/analytics";
-import { internalError } from "../lib/userFacingError";
 import {
   domainPaginationItems,
   domainsPageByTraffic,
@@ -13,27 +12,28 @@ import {
   proxyTrafficHistoryMaxDays,
   proxyTrafficHistoryPresetDays,
   proxyTrafficHistoryWindows,
-  proxyTrafficTopUpBytes,
-  proxyTrafficWarning,
-  shouldShowProxyTrafficTopUp,
   proxyTrafficDomainsPageSize,
   type ProxyTrafficHistoryCoverage,
   type ProxyTrafficHistoryPreset,
 } from "../lib/proxyTraffic";
+import {
+  freeTrafficAllowanceBytes,
+  trafficAllowanceBytes,
+  trafficAllowanceFraction,
+  trafficAllowanceRemainingBytes,
+  trafficGateState,
+  trafficGateStateLabel,
+} from "../lib/trafficGate";
 import { formatHistoryDateLabel } from "../lib/trafficChart";
 import {
   humanBytes,
-  proxyFraction,
-  type ProxyTraffic,
   type ProxyTrafficHistory,
   type ProxyTrafficHistoryPoint,
 } from "../types";
 import { Icon, Spinner } from "./Icon";
 import { TrafficChart } from "./TrafficChart";
-import { UserFacingError } from "./UserFacingError";
 
 type RangePreset = ProxyTrafficHistoryPreset | "custom";
-type TopUpNotice = { tone: "success" | "error"; message: string };
 
 const numberFormatter = new Intl.NumberFormat();
 const historyRequestConcurrency = 3;
@@ -118,9 +118,10 @@ export function UsageView() {
   const [historyNotice, setHistoryNotice] = useState<string>();
   const [historyReload, setHistoryReload] = useState(0);
   const [domainsPage, setDomainsPage] = useState(1);
-  const [topUpLoading, setTopUpLoading] = useState(false);
-  const [topUpNotice, setTopUpNotice] = useState<TopUpNotice>();
-  const fraction = proxyFraction(s.proxy);
+  const gateState = trafficGateState(s.proxy);
+  const allowanceBytes = trafficAllowanceBytes(s.proxy);
+  const allowanceRemainingBytes = trafficAllowanceRemainingBytes(s.proxy);
+  const fraction = trafficAllowanceFraction(s.proxy);
 
   useEffect(() => {
     setDomainsPage(1);
@@ -178,48 +179,16 @@ export function UsageView() {
     await s.refreshProxyData();
     setHistoryReload((value) => value + 1);
   };
-  const topUpProxyTraffic = async () => {
-    if (!s.proxy || topUpLoading) return;
-    const analyticsParams = {
-      proxy_state: s.proxy.state,
-      limited: s.proxy.limited,
-      percent_used_bucket:
-        s.proxy.percent_used == null
-          ? "unknown"
-          : Math.min(100, Math.floor(s.proxy.percent_used / 10) * 10),
-    };
-    setTopUpLoading(true);
-    setTopUpNotice(undefined);
-    trackEvent("proxy_top_up_requested", analyticsParams);
-    try {
-      const proxyTraffic = await invoke<ProxyTraffic>("proxy_traffic_top_up");
-      try {
-        await s.loadProxy();
-      } catch {
-        useStore.setState({
-          proxy: proxyTraffic,
-          proxyWarning: proxyTrafficWarning(proxyTraffic),
-        });
-      }
-      setTopUpNotice({
-        tone: "success",
-        message: `Added ${humanBytes(proxyTraffic.top_up_bytes ?? proxyTrafficTopUpBytes)} of proxy traffic.`,
-      });
-      trackEvent("proxy_top_up_succeeded", analyticsParams);
-    } catch {
-      setTopUpNotice({
-        tone: "error",
-        message: internalError("We couldn't add proxy traffic.", "PROXY_TRAFFIC_TOP_UP_FAILED"),
-      });
-      trackEvent("proxy_top_up_failed", analyticsParams);
-    } finally {
-      setTopUpLoading(false);
-    }
+  const openTrafficGateDiscord = () => {
+    trackEvent("proxy_traffic_gate_discord_opened", {
+      proxy_state: s.proxy?.state ?? "unknown",
+      used_bytes_bucket: s.proxy ? Math.floor(s.proxy.used_bytes / (10 * 1024 * 1024)) * 10 : "unknown",
+    });
+    window.open(discordUrl, "_blank", "noopener,noreferrer");
   };
   const points = history?.data_points ?? [];
   const topDomains = history?.top_domains ?? [];
   const domainPage = domainsPageByTraffic(topDomains, domainsPage);
-  const showProxyTrafficTopUp = shouldShowProxyTrafficTopUp(s.proxy);
   const peak = peakPoint(points);
   const averageBytes = points.length ? (history?.total_bytes ?? 0) / points.length : 0;
 
@@ -251,15 +220,19 @@ export function UsageView() {
                 <span className="muted">
                   {" / "}
                   {s.proxy.limited
-                    ? s.proxy.limit_bytes != null
-                      ? humanBytes(s.proxy.limit_bytes)
+                    ? allowanceBytes != null
+                      ? humanBytes(allowanceBytes)
                       : "limit unavailable"
                     : "no fixed limit"}
                 </span>
               )}
             </div>
           </div>
-          {s.proxy && <span className="status-pill proxy-state">{s.proxy.state}</span>}
+          {s.proxy && (
+            <span className={`status-pill proxy-state${gateState === "blocked" ? " paused" : ""}`}>
+              {trafficGateStateLabel(s.proxy)}
+            </span>
+          )}
         </div>
         {s.proxy ? (
           <>
@@ -282,13 +255,15 @@ export function UsageView() {
             <div className="row small proxy-usage-allocation-meta">
               <span>
                 {s.proxy.limited
-                  ? s.proxy.percent_used == null
+                  ? allowanceBytes == null
                     ? "Usage percentage unavailable"
-                    : `${Math.round(s.proxy.percent_used)}% used`
+                    : `${Math.round(fraction * 100)}% used`
                   : "No fixed traffic limit"}
               </span>
               <span className="spacer" />
-              {s.proxy.remaining_bytes != null && <span>{humanBytes(s.proxy.remaining_bytes)} remaining</span>}
+              {allowanceRemainingBytes != null && (
+                <span>{humanBytes(allowanceRemainingBytes)} remaining</span>
+              )}
             </div>
             {s.proxyWarning && (
               <div className="warning-banner">
@@ -296,29 +271,25 @@ export function UsageView() {
                 {s.proxyWarning}
               </div>
             )}
-            {showProxyTrafficTopUp && (
-              <div className="proxy-usage-top-up-actions">
+            {gateState === "blocked" && (
+              <div className="proxy-traffic-gate" role="status">
+                <div className="proxy-traffic-gate-heading">
+                  <Icon name="lock.fill" size={16} />
+                  <strong>Your free {humanBytes(freeTrafficAllowanceBytes)} is yours</strong>
+                </div>
+                <p className="muted small">
+                  New accounts pause after the first few dozen megabytes so we can meet the
+                  people using NextBrowser. Say hi in Discord and we unlock the rest of your
+                  allowance by hand — feedback, repo stars, and pull requests earn more.
+                </p>
                 <button
                   className="btn-bordered-prominent"
-                  disabled={topUpLoading}
                   type="button"
-                  onClick={() => void topUpProxyTraffic()}
+                  onClick={openTrafficGateDiscord}
                 >
-                  {topUpLoading ? <Spinner size={13} /> : <Icon name="plus" size={13} />}
-                  {topUpLoading ? "Adding 1 GiB" : "Add 1 GiB"}
+                  <Icon name="bubble.left.and.bubble.right.fill" size={13} />
+                  Ask in Discord
                 </button>
-              </div>
-            )}
-            {topUpNotice && (
-              <div
-                className={`proxy-usage-top-up-notice ${topUpNotice.tone}`}
-                role={topUpNotice.tone === "error" ? "alert" : "status"}
-              >
-                <Icon
-                  name={topUpNotice.tone === "error" ? "exclamationmark.triangle.fill" : "checkmark.circle.fill"}
-                  size={14}
-                />
-                <UserFacingError message={topUpNotice.message} surface="proxy_top_up" />
               </div>
             )}
           </>

--- a/src/lib/proxyTraffic.test.ts
+++ b/src/lib/proxyTraffic.test.ts
@@ -10,9 +10,7 @@ import {
   proxyTrafficHistoryPresetDays,
   proxyTrafficHistoryRequestDays,
   proxyTrafficHistoryWindows,
-  proxyTrafficTopUpBytes,
-  proxyTrafficTopUpThresholdBytes,
-  shouldShowProxyTrafficTopUp,
+  proxyTrafficWarning,
   sortDomainsByTraffic,
 } from "./proxyTraffic";
 
@@ -164,36 +162,45 @@ describe("proxy traffic domain sorting", () => {
   });
 });
 
-describe("proxy traffic top-up", () => {
-  it("matches the dashboard top-up cycle at 3 GiB boundaries", () => {
-    expect(shouldShowProxyTrafficTopUp({
+describe("proxy traffic warning", () => {
+  it("asks a blocked account to reach out in Discord", () => {
+    expect(proxyTrafficWarning({
       limited: true,
-      used_bytes: 3 * proxyTrafficTopUpBytes - proxyTrafficTopUpThresholdBytes - 1,
-      limit_bytes: 3 * proxyTrafficTopUpBytes,
-      remaining_bytes: proxyTrafficTopUpThresholdBytes + 1,
-      state: "ok",
-    })).toBe(false);
-    expect(shouldShowProxyTrafficTopUp({
-      limited: true,
-      used_bytes: 3 * proxyTrafficTopUpBytes - proxyTrafficTopUpThresholdBytes,
-      limit_bytes: 3 * proxyTrafficTopUpBytes,
-      remaining_bytes: proxyTrafficTopUpThresholdBytes,
-      state: "near_limit",
-    })).toBe(true);
-    expect(shouldShowProxyTrafficTopUp({
-      limited: true,
-      used_bytes: proxyTrafficTopUpBytes,
-      limit_bytes: 4 * proxyTrafficTopUpBytes,
-      remaining_bytes: 3 * proxyTrafficTopUpBytes,
-      state: "ok",
-    })).toBe(true);
+      used_bytes: 37 * 1024 * 1024,
+      limit_bytes: 37 * 1024 * 1024,
+      remaining_bytes: 0,
+      percent_used: 100,
+      state: "exhausted",
+    })).toBe("Free traffic is paused. Ask in Discord to unlock the rest.");
   });
 
-  it("hides top-up for unlimited traffic", () => {
-    expect(shouldShowProxyTrafficTopUp({
-      limited: false,
-      used_bytes: proxyTrafficTopUpBytes,
-      state: "ok",
-    })).toBe(false);
+  it("stays quiet while a gated account still has traffic", () => {
+    expect(proxyTrafficWarning({
+      limited: true,
+      used_bytes: 12 * 1024 * 1024,
+      limit_bytes: 37 * 1024 * 1024,
+      remaining_bytes: 25 * 1024 * 1024,
+      percent_used: 32,
+      state: "near_limit",
+    })).toBeUndefined();
+  });
+
+  it("keeps the plain warnings for accounts that hold the full allowance", () => {
+    expect(proxyTrafficWarning({
+      limited: true,
+      used_bytes: 2.9 * 1024 * 1024 * 1024,
+      limit_bytes: 3 * 1024 * 1024 * 1024,
+      remaining_bytes: 0.1 * 1024 * 1024 * 1024,
+      percent_used: 96,
+      state: "near_limit",
+    })).toBe("Proxy traffic almost exhausted.");
+    expect(proxyTrafficWarning({
+      limited: true,
+      used_bytes: 3 * 1024 * 1024 * 1024,
+      limit_bytes: 3 * 1024 * 1024 * 1024,
+      remaining_bytes: 0,
+      percent_used: 100,
+      state: "exhausted",
+    })).toBe("Proxy traffic limit reached.");
   });
 });

--- a/src/lib/proxyTraffic.ts
+++ b/src/lib/proxyTraffic.ts
@@ -6,14 +6,12 @@ import {
   type ProxyTrafficHistoryPoint,
   type ProxyTrafficSourceBreakdown,
 } from "../types";
+import { trafficGateState } from "./trafficGate";
 
 export const proxyTrafficDomainsPageSize = 10;
 export const proxyTrafficHistoryMaxDays = 365;
 export const proxyTrafficHistoryPresetDays = [7, 14, 30, 90, 180, 365] as const;
 export const proxyTrafficHistoryRequestDays = 30;
-export const proxyTrafficTopUpBytes = 1024 * 1024 * 1024;
-export const proxyTrafficTopUpCycleSize = 3;
-export const proxyTrafficTopUpThresholdBytes = 100 * 1024 * 1024;
 
 const millisecondsPerDay = 86_400_000;
 
@@ -153,23 +151,15 @@ export function mergeProxyTrafficHistories(
   };
 }
 
-export function shouldShowProxyTrafficTopUp(proxyTraffic?: ProxyTraffic | null): boolean {
-  if (!proxyTraffic?.limited || proxyTraffic.limit_bytes == null) {
-    return false;
-  }
-
-  const remainingBytes =
-    proxyTraffic.remaining_bytes ?? proxyTraffic.limit_bytes - proxyTraffic.used_bytes;
-  const topUpCount = Math.floor(proxyTraffic.limit_bytes / proxyTrafficTopUpBytes);
-  return (
-    topUpCount % proxyTrafficTopUpCycleSize !== 0
-    || remainingBytes <= proxyTrafficTopUpThresholdBytes
-  );
-}
-
 export function proxyTrafficWarning(proxyTraffic: ProxyTraffic): string | undefined {
+  const state = trafficGateState(proxyTraffic);
+  if (state === "blocked") return "Free traffic is paused. Ask in Discord to unlock the rest.";
+  // A gated account still believes it has the full allowance, so stay quiet
+  // until the gate actually closes.
+  if (state === "gated") return undefined;
+
   const fraction = proxyFraction(proxyTraffic);
-  if (fraction >= 1) return "Proxy traffic limit reached. Add data in Usage.";
+  if (fraction >= 1) return "Proxy traffic limit reached.";
   if (fraction >= 0.9) return "Proxy traffic almost exhausted.";
   return undefined;
 }

--- a/src/lib/trafficGate.test.ts
+++ b/src/lib/trafficGate.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import type { ProxyTraffic } from "../types";
+import {
+  freeTrafficAllowanceBytes,
+  trafficAllowanceBytes,
+  trafficAllowanceFraction,
+  trafficAllowanceRemainingBytes,
+  trafficGateState,
+  trafficGateStateLabel,
+} from "./trafficGate";
+
+const mebibyte = 1024 * 1024;
+
+function proxy(overrides: Partial<ProxyTraffic>): ProxyTraffic {
+  return {
+    limited: true,
+    used_bytes: 0,
+    state: "ok",
+    ...overrides,
+  };
+}
+
+describe("free traffic allowance", () => {
+  it("shows every free account the same 1 GiB", () => {
+    expect(freeTrafficAllowanceBytes).toBe(1024 * mebibyte);
+  });
+});
+
+describe("traffic gate state", () => {
+  it("gates a new account until its provisioned limit runs out", () => {
+    expect(trafficGateState(proxy({
+      used_bytes: 12 * mebibyte,
+      limit_bytes: 37 * mebibyte,
+      remaining_bytes: 25 * mebibyte,
+    }))).toBe("gated");
+    expect(trafficGateState(proxy({
+      used_bytes: 37 * mebibyte,
+      limit_bytes: 37 * mebibyte,
+      remaining_bytes: 0,
+      state: "exhausted",
+    }))).toBe("blocked");
+  });
+
+  it("derives the remaining bytes when the backend omits them", () => {
+    expect(trafficGateState(proxy({ used_bytes: 70 * mebibyte, limit_bytes: 70 * mebibyte })))
+      .toBe("blocked");
+  });
+
+  it("never gates accounts that already hold the full allowance", () => {
+    expect(trafficGateState(proxy({
+      used_bytes: 3 * 1024 * mebibyte,
+      limit_bytes: 3 * 1024 * mebibyte,
+      remaining_bytes: 0,
+      state: "exhausted",
+    }))).toBe("open");
+    expect(trafficGateState(proxy({ used_bytes: 0, limit_bytes: freeTrafficAllowanceBytes })))
+      .toBe("open");
+  });
+
+  it("reports unlimited and unknown allocations", () => {
+    expect(trafficGateState(proxy({ limited: false, used_bytes: 5 * mebibyte }))).toBe("unlimited");
+    expect(trafficGateState(proxy({ used_bytes: 5 * mebibyte }))).toBe("unknown");
+    expect(trafficGateState(undefined)).toBe("unknown");
+  });
+});
+
+describe("displayed allowance", () => {
+  it("shows a gated account the full free allowance", () => {
+    const gated = proxy({
+      used_bytes: 37 * mebibyte,
+      limit_bytes: 37 * mebibyte,
+      remaining_bytes: 0,
+      percent_used: 100,
+      state: "exhausted",
+    });
+
+    expect(trafficAllowanceBytes(gated)).toBe(freeTrafficAllowanceBytes);
+    expect(trafficAllowanceRemainingBytes(gated)).toBe(freeTrafficAllowanceBytes - 37 * mebibyte);
+    expect(Math.round(trafficAllowanceFraction(gated) * 100)).toBe(4);
+    expect(trafficGateStateLabel(gated)).toBe("paused");
+  });
+
+  it("keeps the provider allocation for accounts outside the gate", () => {
+    const open = proxy({
+      used_bytes: 1536 * mebibyte,
+      limit_bytes: 3 * 1024 * mebibyte,
+      remaining_bytes: 1536 * mebibyte,
+      percent_used: 50,
+    });
+
+    expect(trafficAllowanceBytes(open)).toBe(3 * 1024 * mebibyte);
+    expect(trafficAllowanceRemainingBytes(open)).toBe(1536 * mebibyte);
+    expect(trafficAllowanceFraction(open)).toBe(0.5);
+    expect(trafficGateStateLabel(open)).toBe("ok");
+  });
+
+  it("has no allowance to show for unlimited accounts", () => {
+    const unlimited = proxy({ limited: false, used_bytes: 5 * mebibyte });
+    expect(trafficAllowanceBytes(unlimited)).toBeNull();
+    expect(trafficAllowanceRemainingBytes(unlimited)).toBeNull();
+    expect(trafficAllowanceFraction(unlimited)).toBe(0);
+  });
+});

--- a/src/lib/trafficGate.ts
+++ b/src/lib/trafficGate.ts
@@ -1,0 +1,70 @@
+import type { ProxyTraffic } from "../types";
+
+/**
+ * Free traffic gate.
+ *
+ * Every free account is shown the same 1 GiB allowance, but new accounts are
+ * provisioned with a much smaller proxy limit. When that limit is reached the
+ * traffic pauses and the account has to ask for the rest in Discord, where an
+ * admin lifts the limit by hand.
+ *
+ * Accounts provisioned before the gate hold a limit at or above the allowance,
+ * so they are never gated — the classification below is derived from
+ * `limit_bytes` alone and needs no extra backend field.
+ */
+export const freeTrafficAllowanceBytes = 1024 * 1024 * 1024;
+
+export type TrafficGateState =
+  /** No proxy allocation is known yet. */
+  | "unknown"
+  /** The account has no enforced traffic limit at all. */
+  | "unlimited"
+  /** The account holds at least the full free allowance. */
+  | "open"
+  /** The account is inside the gate but still has traffic left. */
+  | "gated"
+  /** The gate closed: traffic is paused until an admin grants more. */
+  | "blocked";
+
+export function trafficGateState(proxyTraffic?: ProxyTraffic | null): TrafficGateState {
+  if (!proxyTraffic) return "unknown";
+  if (!proxyTraffic.limited) return "unlimited";
+  if (proxyTraffic.limit_bytes == null) return "unknown";
+  if (proxyTraffic.limit_bytes >= freeTrafficAllowanceBytes) return "open";
+
+  const remainingBytes =
+    proxyTraffic.remaining_bytes ?? proxyTraffic.limit_bytes - proxyTraffic.used_bytes;
+  return remainingBytes > 0 ? "gated" : "blocked";
+}
+
+/** The allocation the account is shown: the free allowance while gated. */
+export function trafficAllowanceBytes(proxyTraffic?: ProxyTraffic | null): number | null {
+  switch (trafficGateState(proxyTraffic)) {
+    case "gated":
+    case "blocked":
+      return freeTrafficAllowanceBytes;
+    case "open":
+      return proxyTraffic?.limit_bytes ?? null;
+    default:
+      return null;
+  }
+}
+
+export function trafficAllowanceRemainingBytes(proxyTraffic?: ProxyTraffic | null): number | null {
+  const allowanceBytes = trafficAllowanceBytes(proxyTraffic);
+  if (allowanceBytes == null || !proxyTraffic) return null;
+  return Math.max(allowanceBytes - proxyTraffic.used_bytes, 0);
+}
+
+export function trafficAllowanceFraction(proxyTraffic?: ProxyTraffic | null): number {
+  const allowanceBytes = trafficAllowanceBytes(proxyTraffic);
+  if (!allowanceBytes || !proxyTraffic) return 0;
+  return Math.min(Math.max(proxyTraffic.used_bytes / allowanceBytes, 0), 1);
+}
+
+export function trafficGateStateLabel(proxyTraffic?: ProxyTraffic | null): string {
+  const state = trafficGateState(proxyTraffic);
+  if (state === "blocked") return "paused";
+  if (state === "gated") return "ok";
+  return proxyTraffic?.state ?? "unknown";
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -939,26 +939,25 @@ body.is-resizing-sidebar {
 }
 .proxy-usage-allocation-meta { margin-top: 8px; }
 .proxy-usage-card .warning-banner { margin-top: 12px; }
-.proxy-usage-top-up-actions {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 12px;
+.proxy-traffic-gate {
   margin-top: 13px;
+  padding: 13px 14px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: var(--surface-1);
 }
-.proxy-usage-top-up-notice {
+.proxy-traffic-gate-heading {
   display: flex;
   align-items: center;
-  gap: 7px;
-  margin-top: 10px;
-  padding: 8px 10px;
-  border-radius: var(--radius-sm);
-  font-size: 12px;
+  gap: 8px;
+  font-size: 14px;
 }
-.proxy-usage-top-up-notice.success { background: var(--green-soft); color: var(--green); }
-.proxy-usage-top-up-notice.error { background: var(--red-soft); color: var(--red); }
-.user-facing-error a,
-.proxy-usage-top-up-notice a {
+.proxy-traffic-gate p {
+  margin: 7px 0 12px;
+  max-width: 62ch;
+  line-height: 1.5;
+}
+.user-facing-error a {
   color: inherit;
   font-weight: 600;
   text-decoration: underline;
@@ -1487,6 +1486,10 @@ body.is-resizing-sidebar {
 .status-pill.is-ready {
   background: var(--green-soft);
   color: var(--green);
+}
+.status-pill.proxy-state.paused {
+  background: var(--red-soft);
+  color: var(--red);
 }
 .agent-primary { display: flex; gap: 8px; margin: 8px 0; }
 .chip {


### PR DESCRIPTION
## What

New accounts see the full 1 GB free allowance but are provisioned with a much smaller proxy limit. When that limit runs out, **Proxy usage** now reports the traffic as paused and points at Discord, where the rest of the allowance is released by hand.

The self-serve "Add 1 GiB" top-up is gone — it made the gate pointless. Its IPC command and Electron helper go with it.

## How it classifies

Everything is derived from `limit_bytes`, so no new backend field is needed:

| `limit_bytes` | State | Usage view |
| --- | --- | --- |
| below 1 GB, traffic left | `gated` | Normal, counted against 1 GB |
| below 1 GB, exhausted | `blocked` | `Paused` pill + Discord unlock card |
| 1 GB or more | `open` | Unchanged |
| unlimited | `unlimited` | Unchanged |

Usage counts against the 1 GB allowance rather than the provisioned limit, so a gated account still reads as barely used and no warning appears until the gate actually closes.

**Existing accounts are never gated** — they hold a limit at or above the allowance, so their usage view is unchanged.

## Depends on

The gate is inert until the backend provisions new sub-users with a limit inside the 10–70 MB window instead of the current 3 GiB default. Admin-side grants land in nextbrowser-oss/nextbrowser-admin#1.

## Checks

`npm test` (72 files, 495 tests) and `npm run build` pass. Verified in the running app against a gated allocation: `37 MiB / 1 GiB`, `Paused`, and the Discord card.