### PR TITLE
feat: support free-tier CLI agents

### DIFF
--- a/electron/agent-workspace.test.cjs
+++ b/electron/agent-workspace.test.cjs
@@ -69,6 +69,14 @@ test("terminal Codex keeps workspace isolation while allowing Clawbrowser networ
   assert.doesNotMatch(main, /dangerously-bypass-approvals-and-sandbox/);
 });
 
+test("every officially free-capable agent shown in the catalog can start in Terminal mode", () => {
+  const main = fs.readFileSync(path.join(__dirname, "main.cjs"), "utf8");
+  assert.match(main, /antigravity: \{ binary: "agy", envVar: "AGY_BIN" \}/);
+  assert.match(main, /copilot: \{ binary: "copilot", envVar: "COPILOT_BIN" \}/);
+  assert.match(main, /kilo: \{ binary: "kilo", envVar: "KILO_BIN" \}/);
+  assert.match(main, /amazonq: \{ binary: "q", envVar: "Q_BIN" \}/);
+});
+
 test("Codex chat uses the managed Clawbrowser MCP configuration", () => {
   const main = fs.readFileSync(path.join(__dirname, "main.cjs"), "utf8");
   assert.match(main, /case "agent_run":[\s\S]*args\.agentId === "codex"/);

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -239,6 +239,9 @@ const TERMINAL_AGENTS = {
   cline: { binary: "cline", envVar: "CLINE_BIN" },
   pi: { binary: "pi", envVar: "PI_BIN" },
   gemini: { binary: "gemini", envVar: "GEMINI_BIN" },
+  // The visible agent catalog and Terminal registry must stay in sync.
+  antigravity: { binary: "agy", envVar: "AGY_BIN" },
+  copilot: { binary: "copilot", envVar: "COPILOT_BIN" },
   qwen: { binary: "qwen", envVar: "QWEN_BIN" },
   opencode: { binary: "opencode", envVar: "OPENCODE_BIN" },
   cursor: { binary: "cursor-agent", envVar: "CURSOR_AGENT_BIN" },

--- a/src/agents.test.ts
+++ b/src/agents.test.ts
@@ -17,6 +17,7 @@ describe("agent invocation parity", () => {
     expect(agentById("claude").installUrl).toBe("https://code.claude.com/docs/en/installation");
     expect(agentById("codex").installUrl).toBe("https://chatgpt.com/download/");
     expect(agentById("antigravity").installUrl).toBe("https://www.antigravity.google/docs/cli/install/");
+    expect(agentById("copilot").installUrl).toBe("https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli");
     expect(agentInstallName(agentById("claude"))).toBe("Claude Code CLI");
     expect(agentInstallName(agentById("codex"))).toBe("ChatGPT desktop app with Codex");
   });
@@ -56,6 +57,7 @@ describe("agent invocation parity", () => {
     ["cline", ["hello"], undefined],
     ["pi", ["-p", "hello"], undefined],
     ["antigravity", ["-p", "hello"], undefined],
+    ["copilot", ["-p", "hello"], undefined],
   ])("builds the exact %s command", (id, args, stdin) => {
     expect(agentInvocation(agentById(id as string), "hello")).toEqual({
       args,

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -73,6 +73,9 @@ export const AGENTS: AgentSpec[] = [
   // Authentication happens when its interactive terminal opens (keyring first,
   // then Google Sign-In), so it intentionally has no status or logout command.
   spec("antigravity", "Antigravity CLI", "agy", "promptFlag", { installUrl: "https://www.antigravity.google/docs/cli/install/" }),
+  // Copilot Free includes a monthly AI-credit allowance. Its documented
+  // programmatic mode is `copilot -p <prompt>`.
+  spec("copilot", "GitHub Copilot CLI", "copilot", "promptFlag", { loginArgs: ["login"], installUrl: "https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli" }),
   spec("qwen", "Qwen Code", "qwen", "promptFlag"),
   spec("opencode", "OpenCode", "opencode", "runSubcommand"),
   spec("cursor", "Cursor Agent", "cursor-agent", "promptFlag"),


### PR DESCRIPTION
## Summary
- add GitHub Copilot CLI to the selectable agent catalog
- register Antigravity CLI in Terminal mode (it was selectable but could not start there)
- register Copilot CLI in Terminal mode
- cover the free-capable agent registry with tests

## Verification
- `./node_modules/.bin/vitest run src/agents.test.ts`
- `node --test electron/agent-workspace.test.cjs`
- `npm run build`

## Notes
- Antigravity, Kilo, Amazon Q Developer and Copilot Free are the currently official no-cost routes. Gemini CLI individual-account usage has moved to Antigravity; Qwen OAuth free tier is discontinued.