### PR TITLE
feat: add trusted automation foundations

### DIFF
--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -4,6 +4,9 @@ import path from "node:path";
 const root = path.resolve(process.argv[2] ?? "skills");
 const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const allowedOperations = new Set(["search", "scrape", "paginate", "post", "comment", "message", "form"]);
+const allowedTargetModes = new Set(["fixed_domain", "current_tab"]);
+const allowedPermissions = new Set(["read_page", "use_page_controls", "save_local_artifact", "upload_file", "login", "publish"]);
+const allowedVerification = new Set(["community", "verified"]);
 const failures = [];
 
 for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
@@ -26,6 +29,21 @@ for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
   }
   if (!Array.isArray(manifest.operations) || !manifest.operations.length || manifest.operations.some((operation) => !allowedOperations.has(operation))) {
     failures.push(`${entry.name}: operations contains an unsupported value`);
+  }
+  if (!allowedTargetModes.has(manifest.target_mode)) {
+    failures.push(`${entry.name}: target_mode must be fixed_domain or current_tab`);
+  }
+  if (!Array.isArray(manifest.permissions) || !manifest.permissions.length || manifest.permissions.some((permission) => !allowedPermissions.has(permission))) {
+    failures.push(`${entry.name}: permissions must declare every browser/data capability used by the skill`);
+  }
+  if (manifest.verification != null && !allowedVerification.has(manifest.verification)) {
+    failures.push(`${entry.name}: verification must be community or verified`);
+  }
+  if (manifest.min_nextctl_version != null && (typeof manifest.min_nextctl_version !== "string" || !/^>=\d+\.\d+\.\d+$/.test(manifest.min_nextctl_version))) {
+    failures.push(`${entry.name}: min_nextctl_version must use the format >=x.y.z`);
+  }
+  if (manifest.verification === "verified" && manifest.min_nextctl_version == null) {
+    failures.push(`${entry.name}: verified skills must declare min_nextctl_version`);
   }
   if (!manifest.category || !slugPattern.test(manifest.category.id ?? "") || typeof manifest.category.title !== "string" || typeof manifest.category.icon !== "string" || !Number.isInteger(manifest.category.order)) {
     failures.push(`${entry.name}: category must include id, title, icon, and integer order`);
@@ -150,8 +168,8 @@ for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
   if (fs.existsSync(casesPath)) {
     try {
       const cases = JSON.parse(fs.readFileSync(casesPath, "utf8"));
-      if (!Array.isArray(cases) || cases.length < 3 || cases.some((testCase) => typeof testCase?.task !== "string" || !Array.isArray(testCase?.expects))) {
-        failures.push(`${entry.name}: tests/cases.json must contain at least three task/expects cases`);
+      if (!Array.isArray(cases) || cases.length < 3 || cases.some((testCase) => typeof testCase?.task !== "string" || !testCase.task.trim() || !Array.isArray(testCase?.expects) || !testCase.expects.length || testCase.expects.some((expectation) => typeof expectation !== "string" || !expectation.trim()))) {
+        failures.push(`${entry.name}: tests/cases.json must contain at least three non-empty task/expects cases`);
       }
     } catch { failures.push(`${entry.name}: tests/cases.json is not valid JSON`); }
   }

--- a/scripts/validate-skills.node.mjs
+++ b/scripts/validate-skills.node.mjs
@@ -26,6 +26,8 @@ function validFixture(id = "example-search") {
       author: "test-author",
       domains: ["example.com"],
       operations: ["search", "scrape", "paginate"],
+      target_mode: "fixed_domain",
+      permissions: ["read_page"],
       category: { id: "marketplaces", title: "Marketplaces", icon: "globe", order: 30 },
     },
     cases: [1, 2, 3].map((number) => ({ task: `Example task ${number}`, expects: ["returns results"] })),
@@ -52,6 +54,8 @@ test("rejects invalid metadata, instructions, and acceptance cases with actionab
       author: "test-author",
       domains: [],
       operations: ["teleport"],
+      target_mode: "wrong",
+      permissions: [],
       category: { id: "Invalid Category", title: "Invalid", icon: "globe", order: 30 },
     },
     cases: [{ task: "Only one case", expects: ["failure"] }],
@@ -62,6 +66,8 @@ test("rejects invalid metadata, instructions, and acceptance cases with actionab
   assert.match(errors, /manifest id must match its directory/);
   assert.match(errors, /domains must contain at least one hostname/);
   assert.match(errors, /operations contains an unsupported value/);
+  assert.match(errors, /target_mode must be fixed_domain or current_tab/);
+  assert.match(errors, /permissions must declare every browser\/data capability/);
   assert.match(errors, /SKILL\.md must start with YAML frontmatter/);
   assert.match(errors, /tests\/cases\.json must contain at least three/);
 });

--- a/skills/999-car-search/manifest.json
+++ b/skills/999-car-search/manifest.json
@@ -5,6 +5,8 @@
   "author": "nextbrowser-oss",
   "domains": ["999.md"],
   "operations": ["search", "scrape", "paginate"],
+  "target_mode": "fixed_domain",
+  "permissions": ["read_page", "use_page_controls"],
   "category": {
     "id": "marketplaces",
     "title": "Marketplaces",

--- a/skills/reddit/manifest.json
+++ b/skills/reddit/manifest.json
@@ -11,6 +11,13 @@
     "post",
     "comment"
   ],
+  "target_mode": "fixed_domain",
+  "permissions": [
+    "read_page",
+    "use_page_controls",
+    "login",
+    "publish"
+  ],
   "category": {
     "id": "social",
     "title": "Social",

--- a/skills/x-reply-agent/manifest.json
+++ b/skills/x-reply-agent/manifest.json
@@ -11,6 +11,8 @@
     "post",
     "comment"
   ],
+  "target_mode": "fixed_domain",
+  "permissions": ["read_page", "use_page_controls", "publish"],
   "category": {
     "id": "social",
     "title": "Social",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import { Icon, Spinner } from "./components/Icon";
 import { AgentPicker } from "./components/AgentPicker";
 import { brandName, dashboardUrl, discordUrl, latestReleaseUrl, repoUrl } from "./constants";
 import { trafficAllowanceBytes, trafficAllowanceFraction } from "./lib/trafficGate";
-import { getPreviewMode, getPreviewTab } from "./preview";
+import { getPreviewMode, getPreviewNodeMavenState, getPreviewTab } from "./preview";
 import { humanBytes, type AppTab, type Conversation } from "./types";
 import { resolveTheme, type Theme } from "./theme";
 import { flushAnalyticsEngagement, initAnalytics, trackEvent, trackScreenView } from "./lib/analytics";
@@ -1030,6 +1030,7 @@ export function App() {
     }
     if (preview === "main") {
       const tabParam = getPreviewTab();
+      const nodeMavenState = getPreviewNodeMavenState();
       const previewConvs: Conversation[] = [
         {
           id: "preview-conv-1",
@@ -1085,11 +1086,17 @@ export function App() {
         activeConvId: { claude: "preview-conv-1", codex: "" },
         proxy: {
           limited: true,
-          used_bytes: 1_200_000_000,
-          limit_bytes: 5_000_000_000,
-          percent_used: 24,
-          state: "active",
+          used_bytes: nodeMavenState === "exhausted" ? 1_000_000_000 : 240_000_000,
+          limit_bytes: 1_000_000_000,
+          remaining_bytes: nodeMavenState === "exhausted" ? 0 : 760_000_000,
+          percent_used: nodeMavenState === "exhausted" ? 100 : 24,
+          state: nodeMavenState === "exhausted" ? "exhausted" : "ok",
           dashboard_url: dashboardUrl,
+          provider: "nodemaven",
+          provider_account_email: "customer@example.com",
+          provider_access_method: "password_reset",
+          provider_access_url: "https://dashboard.nodemaven.com/accounts/password/reset/",
+          pricing_url: "https://dashboard.nodemaven.com/pricing?tab=MONTHLY_PLANS",
         },
         showOnboarding: false,
         ...(tabParam && PREVIEW_TABS.has(tabParam) ? { tab: tabParam as AppTab } : {}),

--- a/src/components/AutomationStudio.tsx
+++ b/src/components/AutomationStudio.tsx
@@ -12,11 +12,12 @@ import { capturedRunFromHybridRecording, capturedRunsForRecording, capturedTaskR
 import type { AutomationArtifact, BrowserWorkflowAction, BrowserWorkflowSkill } from "../types";
 import { humanBytes } from "../types";
 import { Icon, Spinner } from "./Icon";
-import { activeAutomationExecution, automationExecutionView, canContinueWithoutRemoteRunHistory, AUTOMATION_EXECUTION_EVENT, clearActiveAutomationExecution, setActiveAutomationExecution, type AutomationExecution } from "../lib/automationExecution";
+import { activeAutomationExecution, automationExecutionTimeline, automationExecutionView, canContinueWithoutRemoteRunHistory, AUTOMATION_EXECUTION_EVENT, clearActiveAutomationExecution, setActiveAutomationExecution, withAutomationExecutionEvent, type AutomationExecution } from "../lib/automationExecution";
 import { userFacingBrowserError } from "../lib/userFacingBrowserError";
 import { agentById, agentInvocation } from "../agents";
 import { parseWorkflowAiEdit, workflowAiEditPrompt } from "../lib/workflowAiEdit";
 import { automationRepairTask, shouldAutoRepairAutomation } from "../lib/automationRepair";
+import { automationTrustSummary, trustEffectLabel } from "../lib/automationTrust";
 
 type StudioSection = "recorder" | "workflows" | "artifacts";
 type BackendRecording = { id: string; status: string; revision: number; document: { run?: CapturedRun }; created_at?: string; updated_at: string };
@@ -28,6 +29,7 @@ type WorkflowContextMenu = { workflowId: string; x: number; y: number };
 type RecordingReview = { active: ActiveAutomationRecording; captured: CapturedRun; reason: string; actionCount: number; missingAgentTrace: boolean; saveError?: string };
 type AutomationShare = { id: string; source_kind: "recording" | "workflow"; source_id: string; title: string; sender_email?: string; recipient_email?: string; status: "pending" | "accepted" | "declined" | "revoked"; accepted_copy_id?: string; created_at: string; accepted_at?: string };
 type ShareTarget = { kind: "recording" | "workflow"; id: string; title: string };
+type PendingExecution = { workflow: BrowserWorkflowSkill; sourceKind: "recording" | "workflow"; sourceId: string };
 
 function validShareEmail(value: string): boolean {
   const normalized = value.trim();
@@ -217,6 +219,7 @@ export function AutomationStudio() {
   const [shareTarget, setShareTarget] = useState<ShareTarget>();
   const [shareEmail, setShareEmail] = useState("");
   const [shareBusy, setShareBusy] = useState(false);
+  const [pendingExecution, setPendingExecution] = useState<PendingExecution>();
   const workspaceId = s.activeWorkspaceId || "";
   const activeWorkspace = s.workspaces.find((workspace) => workspace.id === workspaceId);
   const automationProfile = s.selectedProfile || (activeWorkspace?.profileNames.length === 1 ? activeWorkspace.profileNames[0] : undefined);
@@ -235,6 +238,7 @@ export function AutomationStudio() {
     return automationExecutionView(playback, s.conversations, playbackClock);
   }, [playback, playbackClock, s.conversations, workspaceId]);
   const executionBusy = !!playback && !!playbackView && !["completed", "failed", "cancelled"].includes(playbackView.phase);
+  const playbackTimeline = useMemo(() => playback ? automationExecutionTimeline(playback, s.conversations) : [], [playback, s.conversations]);
 
   useEffect(() => {
     if (studioRef.current) studioRef.current.scrollTop = 0;
@@ -1010,7 +1014,16 @@ export function AutomationStudio() {
     if (playback) clearActiveAutomationExecution();
     const runId = sourceKind === "workflow" ? uid() : undefined;
     let backendRunId = runId;
-    let next: AutomationExecution = { executionId: uid(), sourceId, sourceKind, backendRunId, workspaceId, workflowTitle: workflow.title, task: workflow.task, startedAt: Date.now(), expectedActions: workflow.actions.length, actionTools: workflow.actions.map((action) => action.tool), engine: "deterministic", phase: "preparing", completedActions: 0, progress: 8, detail: "Preparing the browser session…", workflowSnapshot: workflow };
+    let next: AutomationExecution = {
+      executionId: uid(), sourceId, sourceKind, backendRunId, workspaceId, workflowTitle: workflow.title, task: workflow.task,
+      startedAt: Date.now(), expectedActions: workflow.actions.length, actionTools: workflow.actions.map((action) => action.tool),
+      engine: "deterministic", phase: "preparing", completedActions: 0, progress: 8,
+      detail: "Preparing the browser session…", workflowSnapshot: workflow,
+      events: [
+        { id: "run-approved", at: Date.now(), kind: "system", title: "Run approved", detail: `Using ${automationProfile || "the default browser"}`, state: "success" },
+        { id: "runner-preparing", at: Date.now(), kind: "system", title: "Preparing the selected browser", detail: workflow.domain || "Current workflow target", state: "pending" },
+      ],
+    };
     if (!workflow.actions.some((action) => ["open", "navigate"].includes(action.tool.replace(/^(?:clawbrowser|nextbrowser)\./, "")))) {
       const failed: AutomationExecution = { ...next, backendRunId: undefined, phase: "failed", progress: 100, failedStep: 0, detail: "The saved automation has no starting page.", error: "The saved automation has no starting page. Add an open step before replay." };
       setPlayback(failed);
@@ -1035,7 +1048,10 @@ export function AutomationStudio() {
       }
       setPlayback(next);
       setActiveAutomationExecution(next);
-      setNotice(`${sourceKind === "workflow" ? "Workflow" : "Recording"} is running. Progress and Stop remain visible in the main menu.`);
+      // The persistent execution card and sidebar control already show the
+      // live state and Stop action. Avoid a second transient banner that can
+      // outlive a failed run and contradict the actual state.
+      setNotice(undefined);
       setStudioError(undefined);
       const result = await s.runAutomationRecipe(workflow, next.executionId, { task: workflow.task, ...(backendRunId ? { backendRunId } : {}) });
       const completedActions = result.results.filter((step) => step.ok).length;
@@ -1045,7 +1061,13 @@ export function AutomationStudio() {
         : result.status === "cancelled" ? "Execution stopped by user."
           : `Step ${(result.failedStep ?? completedActions) + 1} failed: ${displayError || "The saved browser action could not be completed."}`;
       const progress = result.status === "completed" ? 100 : Math.max(12, Math.round(completedActions / Math.max(1, workflow.actions.length) * 100));
-      const finished: AutomationExecution = { ...next, phase: result.status, completedActions, progress, detail, error: displayError, failedStep: result.failedStep };
+      let finished: AutomationExecution = { ...next, phase: result.status, completedActions, progress, detail, error: displayError, failedStep: result.failedStep };
+      finished = withAutomationExecutionEvent(finished, {
+        kind: result.status === "completed" ? "validation" : "browser",
+        title: result.status === "completed" ? "Deterministic run verified" : `Step ${(result.failedStep ?? completedActions) + 1} needs attention`,
+        detail,
+        state: result.status === "completed" ? "success" : result.status === "cancelled" ? "info" : "failed",
+      });
       setPlayback(finished);
       setActiveAutomationExecution(finished);
       setNotice(undefined);
@@ -1072,7 +1094,13 @@ export function AutomationStudio() {
     }
   };
 
-  const runWorkflow = async (workflow: BrowserWorkflowSkill) => executeRecipe(workflow, "workflow", workflow.id);
+  const requestRecipe = (workflow: BrowserWorkflowSkill, sourceKind: "recording" | "workflow", sourceId: string) => {
+    if (executionBusy) return setStudioError(`“${playback?.workflowTitle || "Another workflow"}” is already running. Stop it before starting another automation.`);
+    setStudioError(undefined);
+    setPendingExecution({ workflow, sourceKind, sourceId });
+  };
+
+  const runWorkflow = async (workflow: BrowserWorkflowSkill) => requestRecipe(workflow, "workflow", workflow.id);
 
   const runDraft = async () => {
     if (!draft || draftValidationError || Object.keys(actionErrors).length || executionBusy || saving) return;
@@ -1082,7 +1110,7 @@ export function AutomationStudio() {
 
   const replayRecording = async (run: CapturedRun) => {
     const workflow = skillFromRun(run);
-    await executeRecipe(workflow, "recording", run.id);
+    requestRecipe(workflow, "recording", run.id);
   };
 
   const repairWithAgent = async (failedExecution = playback, automatic = false) => {
@@ -1094,7 +1122,8 @@ export function AutomationStudio() {
     const repairWorkflow = workflow && "recipe" in workflow ? workflow : workflow ? skillFromRun(workflow) : undefined;
     if (!repairWorkflow) return setStudioError("The source automation is no longer available.");
     const expectedArtifactName = [...repairWorkflow.actions].reverse().find((action) => action.tool === "save_artifact")?.arguments.name;
-    const agentExecution: AutomationExecution = { ...failedExecution, executionId: uid(), engine: "agent", phase: "preparing", startedAt: Date.now(), progress: undefined, completedActions: undefined, detail: automatic ? "The saved page step changed. Starting automatic AI repair…" : "Preparing AI-assisted repair…", error: undefined, failedStep: undefined, autoRepairAttempted: true, expectedArtifactName: typeof expectedArtifactName === "string" ? expectedArtifactName : undefined, outputValidated: undefined, outputValidationError: undefined, repairValidationRequired: true, repairPersisted: undefined, repairPersistenceError: undefined };
+    let agentExecution: AutomationExecution = { ...failedExecution, executionId: uid(), engine: "agent", phase: "preparing", startedAt: Date.now(), progress: undefined, completedActions: undefined, detail: automatic ? "The saved page step changed. Starting automatic AI repair…" : "Preparing AI-assisted repair…", error: undefined, failedStep: undefined, autoRepairAttempted: true, expectedArtifactName: typeof expectedArtifactName === "string" ? expectedArtifactName : undefined, outputValidated: undefined, outputValidationError: undefined, repairValidationRequired: true, repairPersisted: undefined, repairPersistenceError: undefined };
+    agentExecution = withAutomationExecutionEvent(agentExecution, { kind: "repair", title: automatic ? "Automatic AI repair started" : "AI repair started", detail: "The original goal and website boundary are preserved.", state: "info" });
     setPlayback(agentExecution);
     setActiveAutomationExecution(agentExecution);
     try {
@@ -1208,7 +1237,18 @@ export function AutomationStudio() {
       {notice && <div className="automation-global-message success" role="status"><span>{notice}</span><button onClick={() => setNotice(undefined)}>Dismiss</button></div>}
       {incomingShares.length > 0 && <section className="automation-share-inbox" aria-label="Shared with me"><div><Icon name="person.2.fill" size={15} /><span><strong>Shared with you</strong><small>{incomingShares.length} automation {incomingShares.length === 1 ? "copy is" : "copies are"} ready to add to your library.</small></span></div><div className="automation-share-inbox-items">{incomingShares.map((share) => <article key={share.id}><span><strong>{share.title}</strong><small>{share.source_kind === "workflow" ? "Workflow" : "Recording"}{share.sender_email ? ` · from ${share.sender_email}` : ""}</small></span><div className="automation-inline-actions"><button className="secondary" disabled={shareBusy} onClick={() => void declineShare(share)}>Decline</button><button className="secondary" disabled={shareBusy} onClick={() => void acceptShare(share)}>Add to my automations</button></div></article>)}</div></section>}
       {sentShares.length > 0 && <section className="automation-share-inbox automation-share-sent" aria-label="Shared by me"><div><Icon name="paperplane.fill" size={15} /><span><strong>Shared by you</strong><small>Track copies sent to other NextBrowser users.</small></span></div><div className="automation-share-inbox-items">{sentShares.map((share) => <article key={share.id}><span><strong>{share.title}</strong><small>{share.source_kind === "workflow" ? "Workflow" : "Recording"}{share.recipient_email ? ` · to ${share.recipient_email}` : ""}</small></span><div className="automation-inline-actions"><span className={`automation-share-status ${share.status}`}>{share.status === "pending" ? "Waiting" : share.status === "accepted" ? "Added" : "Declined"}</span>{share.status === "pending" && <button className="secondary" disabled={shareBusy} onClick={() => void revokeShare(share)}>Revoke</button>}</div></article>)}</div></section>}
-      {playback && playbackView && <div className={`recording-progress-card ${playbackView.phase}`} role="status"><div className="recording-progress-head"><span><Icon name={playbackView.phase === "completed" ? "checkmark.circle.fill" : ["failed", "cancelled"].includes(playbackView.phase) ? "xmark.circle.fill" : playbackView.phase === "stopping" ? "stop.fill" : "play.fill"} size={14} /><strong>{playbackView.phase === "completed" ? "Execution completed" : playbackView.phase === "cancelled" ? "Execution stopped" : playbackView.phase === "failed" ? "Execution failed" : playbackView.phase === "stopping" ? "Stopping execution" : playback.engine === "agent" ? "AI is repairing the workflow" : playbackView.phase === "preparing" ? "Preparing execution" : "Running saved steps"}</strong></span><b>{playbackView.progress}%</b></div><div className="recording-progress-track"><i style={{ width: `${playbackView.progress}%` }} /></div><small>{playbackView.detail}</small><div className="row">{["completed", "failed", "cancelled"].includes(playbackView.phase) ? <button onClick={() => { setPlayback(undefined); clearActiveAutomationExecution(); }}>Dismiss</button> : <button className="secondary danger-text" disabled={playbackView.phase === "stopping"} onClick={() => void stopExecution()}><Icon name="stop.fill" size={12} /> {playbackView.phase === "stopping" ? "Stopping…" : "Stop"}</button>}</div></div>}
+      {playback && playbackView && <div className={`recording-progress-card ${playbackView.phase}`} role="status">
+        <div className="recording-progress-head"><span><Icon name={playbackView.phase === "completed" ? "checkmark.circle.fill" : ["failed", "cancelled"].includes(playbackView.phase) ? "xmark.circle.fill" : playbackView.phase === "stopping" ? "stop.fill" : "play.fill"} size={14} /><strong>{playbackView.phase === "completed" ? "Execution completed" : playbackView.phase === "cancelled" ? "Execution stopped" : playbackView.phase === "failed" ? "Execution failed" : playbackView.phase === "stopping" ? "Stopping execution" : playback.engine === "agent" ? "AI is repairing the workflow" : playbackView.phase === "preparing" ? "Preparing execution" : "Running saved steps"}</strong></span><b>{playbackView.progress}%</b></div>
+        <div className="recording-progress-track"><i style={{ width: `${playbackView.progress}%` }} /></div>
+        <small>{playbackView.detail}</small>
+        <details className="automation-run-timeline" open={!["completed", "failed", "cancelled"].includes(playbackView.phase)}>
+          <summary>Run timeline <span>{automationProfile || "Default browser"} · {playback.workflowSnapshot?.domain || "Current website"}</span></summary>
+          <ol>{playbackTimeline.map((event) => <li key={event.id} className={`${event.kind} ${event.state}`}><Icon name={event.state === "failed" ? "xmark.circle.fill" : event.state === "success" ? "checkmark.circle.fill" : event.kind === "repair" ? "sparkles" : event.kind === "artifact" ? "tray.full.fill" : "circle"} size={12} /><span><strong>{event.title}</strong>{event.detail && <small>{event.detail}</small>}</span></li>)}</ol>
+          {playback.repairPersisted && <p className="automation-repair-saved"><Icon name="checkmark.seal.fill" size={12} /> AI repair was verified and saved as the next deterministic revision.</p>}
+          {playback.repairPersistenceError && <p className="error">The task completed, but the repaired revision was not saved: {playback.repairPersistenceError}</p>}
+        </details>
+        <div className="row">{["completed", "failed", "cancelled"].includes(playbackView.phase) ? <button onClick={() => { setPlayback(undefined); clearActiveAutomationExecution(); }}>Dismiss</button> : <button className="secondary danger-text" disabled={playbackView.phase === "stopping"} onClick={() => void stopExecution()}><Icon name="stop.fill" size={12} /> {playbackView.phase === "stopping" ? "Stopping…" : "Stop"}</button>}</div>
+      </div>}
 
       {section === "recorder" && <section className="automation-panel">
         <div className="automation-panel-head"><div><h2>Recordings</h2><p>Perform a task in the browser once, then replay the captured actions.</p></div>
@@ -1367,6 +1407,19 @@ export function AutomationStudio() {
           <div className="recording-review-actions"><button className="secondary" disabled={shareBusy} onClick={() => { setShareTarget(undefined); setShareEmail(""); }}>Cancel</button><button className="primary" disabled={shareBusy || !validShareEmail(shareEmail)} onClick={() => void sendShare()}>{shareBusy && <Spinner size={12} />} Share copy</button></div>
         </section>
       </div>}
+      {pendingExecution && (() => {
+        const trust = automationTrustSummary(pendingExecution.workflow);
+        return <div className="modal-overlay trust-preview-overlay" role="presentation" onMouseDown={(event) => { if (event.target === event.currentTarget) setPendingExecution(undefined); }}>
+          <section className="modal-card trust-preview-dialog" role="dialog" aria-modal="true" aria-labelledby="trust-preview-title">
+            <div className="trust-preview-title"><span><Icon name="checkmark.shield.fill" size={20} /></span><div><h2 id="trust-preview-title">Review this automation</h2><p>NextBrowser will use the selected browser exactly as shown below.</p></div></div>
+            <dl className="trust-preview-grid"><div><dt>Profile</dt><dd>{automationProfile || "Default browser"}</dd></div><div><dt>Website</dt><dd>{trust.domains.length ? trust.domains.join(", ") : "Current workflow target"}</dd></div><div><dt>Storage</dt><dd>{trust.savesLocalArtifact ? "Artifact Center · local only" : "No artifact output requested"}</dd></div><div><dt>Execution</dt><dd>Fast deterministic steps{pendingExecution.workflow.instructions.trim() ? " · AI repair available" : ""}</dd></div></dl>
+            <div className="trust-preview-effects">{trust.effects.map((effect) => <span key={effect} className={["external_upload", "authentication", "publication", "proxy_change"].includes(effect) ? "risk" : ""}><Icon name={["external_upload", "authentication", "publication", "proxy_change"].includes(effect) ? "exclamationmark.triangle.fill" : effect === "local_artifact" ? "tray.full.fill" : "checkmark.circle"} size={12} /> {trustEffectLabel(effect)}</span>)}</div>
+            <ul>{trust.explanation.map((line) => <li key={line}>{line}</li>)}</ul>
+            {trust.needsConfirmation && <p className="trust-preview-warning"><Icon name="exclamationmark.triangle.fill" size={13} /> This workflow may affect an account or send data to a website. Confirm only if every highlighted action is intended.</p>}
+            <div className="recording-review-actions"><button className="secondary" onClick={() => setPendingExecution(undefined)}>Cancel</button><button className="primary" onClick={() => { const pending = pendingExecution; setPendingExecution(undefined); void executeRecipe(pending.workflow, pending.sourceKind, pending.sourceId); }}><Icon name="play.fill" size={12} /> Start safely</button></div>
+          </section>
+        </div>;
+      })()}
     </div>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -47,7 +47,7 @@ import {
   type MultiloginOSType,
 } from "../lib/multiloginProfileCreate";
 import { activeAutomationRecording, AUTOMATION_RECORDING_EVENT, type ActiveAutomationRecording } from "../lib/automationRecording";
-import { activeAutomationExecution, automationAgentAnswer, automationAgentBrowserActionCount, automationExecutionView, AUTOMATION_EXECUTION_EVENT, clearActiveAutomationExecution, executionWithRecipeProgress, setActiveAutomationExecution, type AutomationExecution, type AutomationRecipeProgress } from "../lib/automationExecution";
+import { activeAutomationExecution, automationAgentAnswer, automationAgentBrowserActionCount, automationExecutionView, AUTOMATION_EXECUTION_EVENT, clearActiveAutomationExecution, executionWithRecipeProgress, setActiveAutomationExecution, withAutomationExecutionEvent, type AutomationExecution, type AutomationRecipeProgress } from "../lib/automationExecution";
 import { automationRepairTask, parseAutomationRepairRecipe } from "../lib/automationRepair";
 
 type ManualProxyInputMode = "url" | "fields" | "bulk";
@@ -286,6 +286,7 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
   const recordingWorkspace = activeRecording ? s.workspaces.find((workspace) => workspace.id === activeRecording.workspaceId) : undefined;
   const automationExecutionWorkspace = automationExecution ? s.workspaces.find((workspace) => workspace.id === automationExecution.workspaceId) : undefined;
   const automationExecutionState = automationExecution ? automationExecutionView(automationExecution, s.conversations, automationExecutionClock) : undefined;
+  const automationExecutionLabel = automationExecution?.sourceKind === "recording" ? "Replay" : "Workflow";
   const automationAgentStatus = automationExecution?.engine === "agent" ? automationAgentAnswer(automationExecution, s.conversations)?.status : undefined;
   const recordingDestinationLabel = activeRecording?.destination === "workflow" ? "Workflow Builder" : "Recorder";
   const recordingMiniLabel = activeRecording ? `${recordingDestinationLabel} ${recordingDuration(activeRecording.startedAt, recordingClock)}` : "Recording";
@@ -432,12 +433,19 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
       if (automationExecution.backendRunId) {
         await invoke("automation_run_update", { id: automationExecution.backendRunId, update: { status: "completed", output: { engine: "hybrid", repaired: true, fast_path_saved: persisted, detail } } }).catch(() => undefined);
       }
-      setActiveAutomationExecution({ ...automationExecution, phase: "completed", outputValidated: true, repairPersisted: persisted, repairPersistenceError: persistenceError, progress: 100, detail });
+      setActiveAutomationExecution(withAutomationExecutionEvent({ ...automationExecution, phase: "completed", outputValidated: true, repairPersisted: persisted, repairPersistenceError: persistenceError, progress: 100, detail }, {
+        kind: "repair",
+        title: persisted ? "Repair verified and saved" : "Repair verified, but not saved",
+        detail,
+        state: persisted ? "success" : "failed",
+      }));
     })().catch((error) => {
       if (cancelled) return;
       const detail = error instanceof Error ? error.message : String(error);
       if (automationExecution.backendRunId) void invoke("automation_run_update", { id: automationExecution.backendRunId, update: { status: "failed", output: { engine: "hybrid", repaired: false, detail } } }).catch(() => undefined);
-      setActiveAutomationExecution({ ...automationExecution, phase: "failed", progress: 100, outputValidationError: detail, detail });
+      setActiveAutomationExecution(withAutomationExecutionEvent({ ...automationExecution, phase: "failed", progress: 100, outputValidationError: detail, detail }, {
+        kind: "validation", title: "Repair result did not pass validation", detail, state: "failed",
+      }));
     });
     return () => { cancelled = true; };
   }, [automationExecution?.executionId, automationExecution?.expectedArtifactName, automationExecution?.outputValidated, automationExecution?.outputValidationError, automationExecution?.repairValidationRequired, automationExecution?.startedAt, automationAgentStatus]);
@@ -1110,7 +1118,7 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
       </section>}
 
       {automationExecution && automationExecutionState && <section className={`sidebar-execution-control ${automationExecutionState.phase}`} aria-label="Automation execution status">
-        <div className="sidebar-execution-status"><span className="sidebar-execution-icon"><Icon name={automationExecutionState.phase === "completed" ? "checkmark.circle.fill" : ["failed", "cancelled"].includes(automationExecutionState.phase) ? "xmark.circle.fill" : automationExecutionState.phase === "stopping" ? "stop.fill" : "play.fill"} size={12} /></span><div><strong>{automationExecutionState.phase === "completed" ? "Workflow completed" : automationExecutionState.phase === "cancelled" ? "Workflow stopped" : automationExecutionState.phase === "failed" ? "Workflow failed" : automationExecutionState.phase === "stopping" ? "Stopping workflow" : automationExecutionState.phase === "preparing" ? "Preparing workflow" : "Workflow running"}</strong><small title={automationExecution.workflowTitle}>{automationExecution.workflowTitle} · {automationExecutionWorkspace?.name || "Current workspace"}</small></div><b>{automationExecutionState.progress}%</b></div>
+        <div className="sidebar-execution-status"><span className="sidebar-execution-icon"><Icon name={automationExecutionState.phase === "completed" ? "checkmark.circle.fill" : ["failed", "cancelled"].includes(automationExecutionState.phase) ? "xmark.circle.fill" : automationExecutionState.phase === "stopping" ? "stop.fill" : "play.fill"} size={12} /></span><div><strong>{automationExecutionState.phase === "completed" ? `${automationExecutionLabel} completed` : automationExecutionState.phase === "cancelled" ? `${automationExecutionLabel} stopped` : automationExecutionState.phase === "failed" ? `${automationExecutionLabel} failed` : automationExecutionState.phase === "stopping" ? `Stopping ${automationExecutionLabel.toLowerCase()}` : automationExecutionState.phase === "preparing" ? `Preparing ${automationExecutionLabel.toLowerCase()}` : `${automationExecutionLabel} running`}</strong><small title={automationExecution.workflowTitle}>{automationExecution.workflowTitle} · {automationExecutionWorkspace?.name || "Current workspace"}</small></div><b>{automationExecutionState.progress}%</b></div>
         <div className="sidebar-execution-track"><i style={{ width: `${automationExecutionState.progress}%` }} /></div>
         <small className="sidebar-execution-detail">{automationExecutionState.detail}</small>
         <div className="sidebar-recording-actions"><button onClick={openAutomationExecution}>Open</button>{["completed", "failed", "cancelled"].includes(automationExecutionState.phase) ? <button onClick={clearActiveAutomationExecution}>Dismiss</button> : <button className="stop" disabled={automationExecution.phase === "stopping"} onClick={() => void stopAutomationExecution()}>{automationExecution.phase === "stopping" ? <Spinner size={11} /> : <Icon name="stop.fill" size={11} />} {automationExecution.phase === "stopping" ? "Stopping" : "Stop"}</button>}</div>

--- a/src/components/SkillsView.tsx
+++ b/src/components/SkillsView.tsx
@@ -87,7 +87,7 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
     if (runtime === "cloud-phone") return cloudPhoneRunsIn(cloudPhone);
     const host = selectorTargetHost(e.selector);
     if (host) return `Runs in ${sessionName} → ${host}`;
-    if (e.selector.kind === "captcha") return `Runs in ${sessionName} · current tab`;
+    if (e.selector.kind === "captcha" || e.selector.kind === "current_tab") return `Runs in ${sessionName} · current tab`;
     return `Runs in ${sessionName}`;
   };
 
@@ -226,6 +226,7 @@ export function SkillsView({ onOpenAgentSettings }: { onOpenAgentSettings: () =>
                   </div>
                 )}
                 {repositorySkill && <div className="small ok skill-status"><Icon name="checkmark.seal.fill" size={12} /> Included with NextBrowser</div>}
+                {repositorySkill && <div className="skill-contract small muted"><span>{e.verification === "verified" ? "Verified" : "Test contract included"}</span>{e.permissions?.length ? <span>{e.permissions.map((permission) => permission.replace(/_/g, " ")).join(" · ")}</span> : <span>Legacy permissions</span>}</div>}
                 {e.watchlist && (
                   <button
                     className="skill-watchlist-summary small"

--- a/src/components/UsageView.tsx
+++ b/src/components/UsageView.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useMemo, useState } from "react";
 import { nextctlJson } from "../nextctl";
 import { useStore } from "../store";
+import { invoke } from "../electronBridge";
 import { discordUrl } from "../constants";
 import { trackEvent } from "../lib/analytics";
 import {
   domainPaginationItems,
   domainsPageByTraffic,
+  isProxyTrafficExhausted,
   isProxyTrafficHistoryRangeValid,
+  isTrustedNodeMavenURL,
   mergeProxyTrafficHistories,
   proxyTrafficHistoryCoverage,
   proxyTrafficHistoryMaxDays,
@@ -118,6 +121,8 @@ export function UsageView() {
   const [historyNotice, setHistoryNotice] = useState<string>();
   const [historyReload, setHistoryReload] = useState(0);
   const [domainsPage, setDomainsPage] = useState(1);
+  const [handoffLoading, setHandoffLoading] = useState(false);
+  const [handoffNotice, setHandoffNotice] = useState<string>();
   const gateState = trafficGateState(s.proxy);
   const allowanceBytes = trafficAllowanceBytes(s.proxy);
   const allowanceRemainingBytes = trafficAllowanceRemainingBytes(s.proxy);
@@ -186,9 +191,31 @@ export function UsageView() {
     });
     window.open(discordUrl, "_blank", "noopener,noreferrer");
   };
+  const openNodeMaven = async (kind: "access" | "pricing") => {
+    if (!s.proxy || handoffLoading) return;
+    const url = kind === "access" ? s.proxy.provider_access_url : s.proxy.pricing_url;
+    if (!isTrustedNodeMavenURL(url)) {
+      setHandoffNotice("The NodeMaven link is unavailable. Refresh and try again.");
+      return;
+    }
+    setHandoffLoading(true);
+    setHandoffNotice(undefined);
+    trackEvent(`nodemaven_${kind}_opened`, { proxy_state: s.proxy.state, limited: s.proxy.limited });
+    try {
+      await invoke("open_external", { url });
+      setHandoffNotice(kind === "access"
+        ? "NodeMaven account setup opened in your browser."
+        : "NodeMaven pricing opened. After checkout, return here and refresh your usage.");
+    } catch {
+      setHandoffNotice("We couldn't open NodeMaven. Try again.");
+    } finally {
+      setHandoffLoading(false);
+    }
+  };
   const points = history?.data_points ?? [];
   const topDomains = history?.top_domains ?? [];
   const domainPage = domainsPageByTraffic(topDomains, domainsPage);
+  const proxyExhausted = isProxyTrafficExhausted(s.proxy);
   const peak = peakPoint(points);
   const averageBytes = points.length ? (history?.total_bytes ?? 0) / points.length : 0;
 
@@ -290,6 +317,44 @@ export function UsageView() {
                   <Icon name="bubble.left.and.bubble.right.fill" size={13} />
                   Ask in Discord
                 </button>
+              </div>
+            )}
+            {s.proxy.provider === "nodemaven" && gateState !== "blocked" && (
+              <div className={`nodemaven-handoff ${proxyExhausted ? "exhausted" : "ready"}`}>
+                <div className="nodemaven-handoff-copy">
+                  <Icon name={proxyExhausted ? "exclamationmark.triangle.fill" : "checkmark.circle.fill"} size={18} />
+                  <div>
+                    <strong>{proxyExhausted ? "Your free 1 GB has been used" : "Your NodeMaven account is ready"}</strong>
+                    <p>
+                      {proxyExhausted
+                        ? "Buy more traffic in NodeMaven to continue. Your existing proxy credentials stay the same."
+                        : s.proxy.provider_access_method === "email_sent"
+                          ? "Your free 1 GB is active. NodeMaven sent account access instructions to your email."
+                          : "Your free 1 GB is active. Set a password once so you can buy more traffic when you need it."}
+                    </p>
+                    {s.proxy.provider_account_email && <span>NodeMaven account: {s.proxy.provider_account_email}</span>}
+                  </div>
+                </div>
+                <div className="nodemaven-handoff-actions">
+                  {s.proxy.provider_access_method === "password_reset" && isTrustedNodeMavenURL(s.proxy.provider_access_url) && (
+                    <button className={proxyExhausted ? "btn-bordered" : "btn-bordered-prominent"} disabled={handoffLoading} type="button" onClick={() => void openNodeMaven("access")}>
+                      <Icon name="person.crop.circle" size={13} />
+                      Set up account access
+                    </button>
+                  )}
+                  {proxyExhausted && isTrustedNodeMavenURL(s.proxy.pricing_url) && (
+                    <button className="btn-bordered-prominent" disabled={handoffLoading} type="button" onClick={() => void openNodeMaven("pricing")}>
+                      {handoffLoading ? <Spinner size={13} /> : <Icon name="arrow.up.right" size={13} />}
+                      Buy traffic in NodeMaven
+                    </button>
+                  )}
+                  {proxyExhausted && (
+                    <button className="btn-bordered" disabled={s.isRefreshing} type="button" onClick={() => void refreshUsage()}>
+                      I’ve added traffic — Refresh
+                    </button>
+                  )}
+                </div>
+                {handoffNotice && <p className="nodemaven-handoff-notice" role="status">{handoffNotice}</p>}
               </div>
             )}
           </>

--- a/src/lib/automationExecution.test.ts
+++ b/src/lib/automationExecution.test.ts
@@ -3,6 +3,7 @@ import {
   activeAutomationExecution,
   automationAgentAnswer,
   automationAgentBrowserActionCount,
+  automationExecutionTimeline,
   automationExecutionView,
   canContinueWithoutRemoteRunHistory,
   executionWithRecipeProgress,
@@ -62,6 +63,14 @@ describe("automation execution indicator", () => {
       phase: "running",
       progress: 50,
     });
+    expect(updated.events).toMatchObject([{ kind: "browser", title: "Step 3: extract", state: "info" }]);
+  });
+
+  it("adds safe agent action names to the visible timeline without exposing arguments", () => {
+    const repair = { ...execution, engine: "agent" as const, replyId: "answer", events: [{ id: "repair", at: 100, kind: "repair" as const, title: "AI repair started", state: "info" as const }] };
+    const timeline = automationExecutionTimeline(repair, [conversation("streaming", 1)]);
+    expect(timeline.map((event) => event.title)).toEqual(["AI repair started", "act"]);
+    expect(timeline[1].detail).toBeUndefined();
   });
 
   it("ignores runner events belonging to another execution", () => {

--- a/src/lib/automationExecution.ts
+++ b/src/lib/automationExecution.ts
@@ -38,11 +38,40 @@ export type AutomationExecution = {
   repairPersistenceError?: string;
   repairAttempt?: number;
   workflowSnapshot?: BrowserWorkflowSkill;
+  events?: AutomationExecutionEvent[];
+};
+
+export type AutomationExecutionEvent = {
+  id: string;
+  at: number;
+  kind: "system" | "browser" | "validation" | "repair" | "artifact";
+  title: string;
+  detail?: string;
+  state: "pending" | "success" | "failed" | "info";
 };
 
 export function automationAgentBrowserActionCount(execution: AutomationExecution, conversations: Conversation[]) {
   const answer = automationAgentAnswer(execution, conversations);
   return (answer?.toolEvents || []).filter((event) => /^(?:clawbrowser|nextbrowser)\.(?:open|wait|click|input|press|select|scroll|dismiss|upload|extract|paginate_extract|tabs_extract|form_fill|multi_action|site_recipe_run|act|evaluate|save_artifact)$/.test(event.name)).length;
+}
+
+/** A safe, human-readable merge of runner and agent progress. Tool arguments
+ * are deliberately excluded: they may contain a query or user-entered value. */
+export function automationExecutionTimeline(execution: AutomationExecution, conversations: Conversation[]): AutomationExecutionEvent[] {
+  const stored = execution.events ?? [];
+  if (execution.engine !== "agent") return stored;
+  const answer = automationAgentAnswer(execution, conversations);
+  const browserEvents = (answer?.toolEvents ?? [])
+    .filter((event) => /^(?:clawbrowser|nextbrowser)\.(?:open|wait|click|input|press|select|scroll|dismiss|upload|extract|paginate_extract|tabs_extract|form_fill|multi_action|site_recipe_run|act|evaluate|save_artifact)$/.test(event.name))
+    .map((event): AutomationExecutionEvent => ({
+      id: `tool-${event.id}`,
+      at: event.createdAt,
+      kind: event.name.endsWith("save_artifact") ? "artifact" : "browser",
+      title: event.name.replace(/^(?:clawbrowser|nextbrowser)\./, "").replace(/_/g, " "),
+      state: "info",
+    }));
+  const ids = new Set(stored.map((event) => event.id));
+  return [...stored, ...browserEvents.filter((event) => !ids.has(event.id))].sort((a, b) => a.at - b.at);
 }
 
 export type AutomationExecutionView = {
@@ -103,6 +132,23 @@ export function setActiveAutomationExecution(execution: AutomationExecution) {
   window.dispatchEvent(new CustomEvent(AUTOMATION_EXECUTION_EVENT, { detail: execution }));
 }
 
+export function withAutomationExecutionEvent(execution: AutomationExecution, event: Omit<AutomationExecutionEvent, "id" | "at"> & Partial<Pick<AutomationExecutionEvent, "id" | "at">>): AutomationExecution {
+  const next = {
+    id: event.id ?? `${execution.executionId}-${execution.events?.length || 0}-${event.title}`,
+    at: event.at ?? Date.now(),
+    kind: event.kind,
+    title: event.title,
+    detail: event.detail,
+    state: event.state,
+  } satisfies AutomationExecutionEvent;
+  const events = execution.events ?? [];
+  const previous = events.at(-1);
+  // Progress can be emitted twice by the Electron bridge. Keep the timeline
+  // legible while preserving a changed status or detail.
+  if (previous?.title === next.title && previous.detail === next.detail && previous.state === next.state) return execution;
+  return { ...execution, events: [...events, next].slice(-40) };
+}
+
 export function clearActiveAutomationExecution() {
   localStorage.removeItem(STATE_KEY);
   sessionStorage.removeItem(SESSION_KEY);
@@ -113,7 +159,7 @@ export function executionWithRecipeProgress(execution: AutomationExecution, upda
   if (execution.executionId !== update.executionId || execution.engine !== "deterministic") return execution;
   const browserSessionLost = update.phase === "failed" && /(?:list cdp targets|session .*not found|connection refused|CDP became reachable|browser (?:process )?(?:closed|exited)|target closed)/i.test(update.error || update.detail);
   const completedActions = Math.max(0, Math.min(update.total, update.stepIndex));
-  return {
+  const next = {
     ...execution,
     phase: browserSessionLost ? "preparing" : update.phase,
     expectedActions: update.total,
@@ -125,6 +171,15 @@ export function executionWithRecipeProgress(execution: AutomationExecution, upda
     error: update.error,
     failedStep: update.phase === "failed" && !browserSessionLost ? update.stepIndex : undefined,
   };
+  const kind = update.tool === "save_artifact" ? "artifact" : update.phase === "failed" ? "validation" : "browser";
+  const title = browserSessionLost
+    ? "Browser closed — recovering the selected profile"
+    : update.phase === "failed"
+      ? `Step ${update.stepIndex + 1} could not complete`
+      : update.phase === "completed"
+        ? "Saved browser steps completed"
+        : update.tool ? `Step ${Math.min(update.total, update.stepIndex + 1)}: ${update.tool}` : "Browser progress updated";
+  return withAutomationExecutionEvent(next, { kind, title, detail: next.detail, state: update.phase === "failed" ? "failed" : update.phase === "completed" ? "success" : "info" });
 }
 
 export function automationAgentAnswer(execution: AutomationExecution, conversations: Conversation[]): ChatMessage | undefined {

--- a/src/lib/automationTrust.test.ts
+++ b/src/lib/automationTrust.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { automationTrustSummary } from "./automationTrust";
+
+describe("automation trust preview", () => {
+  it("describes local collection without presenting it as an upload", () => {
+    expect(automationTrustSummary({
+      domain: "example.com",
+      actions: [
+        { tool: "open", arguments: { url: "https://example.com/results" } },
+        { tool: "extract", arguments: { fields: { title: {} } } },
+        { tool: "save_artifact", arguments: { name: "results.json" } },
+      ],
+    })).toMatchObject({
+      domains: ["example.com"],
+      savesLocalArtifact: true,
+      needsConfirmation: false,
+      effects: ["read", "local_artifact"],
+    });
+  });
+
+  it("calls out a file upload as a user confirmation boundary", () => {
+    expect(automationTrustSummary({
+      domain: "example.com",
+      actions: [{ tool: "upload", arguments: { selector: "input[type=file]" } }],
+    })).toMatchObject({ needsConfirmation: true, effects: ["external_upload"] });
+  });
+
+  it("makes account, publication, and proxy effects explicit before a run", () => {
+    expect(automationTrustSummary({
+      domain: "example.com",
+      actions: [
+        { tool: "input", arguments: { selector: "input[type=password]", text: "kept-out-of-preview" } },
+        { tool: "click", arguments: { locator: { role: "button", name: "Publish reply" } } },
+        { tool: "select", arguments: { selector: "[name=proxy]", value: "residential" } },
+      ],
+    })).toMatchObject({
+      needsConfirmation: true,
+      effects: ["authentication", "form_change", "publication", "proxy_change"],
+    });
+  });
+});

--- a/src/lib/automationTrust.ts
+++ b/src/lib/automationTrust.ts
@@ -1,0 +1,77 @@
+import type { BrowserWorkflowAction, BrowserWorkflowSkill } from "../types";
+
+export type TrustEffect = "read" | "local_artifact" | "external_upload" | "form_change" | "download" | "authentication" | "publication" | "proxy_change";
+
+export type AutomationTrustSummary = {
+  domains: string[];
+  effects: TrustEffect[];
+  needsConfirmation: boolean;
+  savesLocalArtifact: boolean;
+  explanation: string[];
+};
+
+function actionDomain(action: BrowserWorkflowAction): string | undefined {
+  if (!['open', 'navigate'].includes(action.tool) || typeof action.arguments.url !== 'string') return undefined;
+  try { return new URL(action.arguments.url).hostname; } catch { return undefined; }
+}
+
+function actionIntent(action: BrowserWorkflowAction) {
+  return `${action.tool} ${JSON.stringify(action.arguments)}`.toLowerCase();
+}
+
+/**
+ * Turn a recipe into the small, user-readable contract shown before execution.
+ * It is intentionally conservative: an interaction that could send data is
+ * called out even when the final page decides not to submit it.
+ */
+export function automationTrustSummary(workflow: Pick<BrowserWorkflowSkill, "actions" | "domain">): AutomationTrustSummary {
+  const domains = [...new Set(workflow.actions.map(actionDomain).filter((value): value is string => !!value))];
+  if (!domains.length && workflow.domain.trim()) domains.push(workflow.domain.trim());
+  const effects = new Set<TrustEffect>();
+  let savesLocalArtifact = false;
+
+  for (const action of workflow.actions) {
+    const tool = action.tool.replace(/^(?:clawbrowser|nextbrowser)\./, "");
+    const intent = actionIntent(action);
+    if (["open", "navigate", "wait", "extract", "paginate_extract", "tabs_extract", "evaluate", "scroll"].includes(tool)) effects.add("read");
+    if (tool === "save_artifact") { effects.add("local_artifact"); savesLocalArtifact = true; }
+    if (tool === "upload") effects.add("external_upload");
+    if (tool === "download" || /\b(download|export|save as)\b/.test(intent)) effects.add("download");
+    if (/\b(log\s?in|sign\s?in|signin|password|one[- ]?time|otp|authenticate)\b/.test(intent)) effects.add("authentication");
+    if (/\b(publish|post|submit|send|reply|comment|share)\b/.test(intent)) effects.add("publication");
+    if (/\b(proxy|residential|datacenter|socks5|http_proxy)\b/.test(intent)) effects.add("proxy_change");
+    if (["input", "select", "form_fill", "click", "press", "act", "multi_action", "dismiss"].includes(tool)) effects.add("form_change");
+  }
+
+  const explanation: string[] = [];
+  if (effects.has("read")) explanation.push("Reads information visible on the selected websites.");
+  if (savesLocalArtifact) explanation.push("Saves requested results only in this computer’s Artifact Center.");
+  if (effects.has("external_upload")) explanation.push("Uploads a file to the selected website.");
+  if (effects.has("download")) explanation.push("Downloads a file to this computer.");
+  if (effects.has("authentication")) explanation.push("May sign in or enter authentication details on the selected website.");
+  if (effects.has("publication")) explanation.push("May publish or submit data to the selected website.");
+  if (effects.has("proxy_change")) explanation.push("May use or change the selected browser proxy.");
+  if (effects.has("form_change")) explanation.push("Interacts with website controls; review the steps before any consequential run.");
+  return {
+    domains,
+    effects: [...effects],
+    // These are data-boundary or account-affecting actions. The preview is
+    // always explicit, and these receive the stronger warning treatment.
+    needsConfirmation: ["external_upload", "authentication", "publication", "proxy_change"].some((effect) => effects.has(effect as TrustEffect)),
+    savesLocalArtifact,
+    explanation,
+  };
+}
+
+export function trustEffectLabel(effect: TrustEffect): string {
+  return ({
+    read: "Read page data",
+    local_artifact: "Save local artifact",
+    external_upload: "Upload file",
+    form_change: "Use page controls",
+    download: "Download file",
+    authentication: "Sign in or authenticate",
+    publication: "Publish or submit",
+    proxy_change: "Use or change proxy",
+  })[effect];
+}

--- a/src/lib/proxyTraffic.test.ts
+++ b/src/lib/proxyTraffic.test.ts
@@ -3,7 +3,9 @@ import type { ProxyTrafficDomainBreakdown } from "../types";
 import {
   domainPaginationItems,
   domainsPageByTraffic,
+  isProxyTrafficExhausted,
   isProxyTrafficHistoryRangeValid,
+  isTrustedNodeMavenURL,
   mergeProxyTrafficHistories,
   proxyTrafficHistoryCoverage,
   proxyTrafficHistoryMaxDays,
@@ -202,5 +204,20 @@ describe("proxy traffic warning", () => {
       percent_used: 100,
       state: "exhausted",
     })).toBe("Proxy traffic limit reached.");
+  });
+});
+
+describe("NodeMaven handoff", () => {
+  it("detects exhausted traffic from remaining bytes or state", () => {
+    expect(isProxyTrafficExhausted({ limited: true, used_bytes: 1_000, limit_bytes: 1_000, state: "ok" })).toBe(true);
+    expect(isProxyTrafficExhausted({ limited: true, used_bytes: 900, limit_bytes: 1_000, state: "exhausted" })).toBe(true);
+    expect(isProxyTrafficExhausted({ limited: true, used_bytes: 900, limit_bytes: 1_000, state: "near_limit" })).toBe(false);
+  });
+
+  it("only accepts HTTPS NodeMaven handoff links", () => {
+    expect(isTrustedNodeMavenURL("https://dashboard.nodemaven.com/pricing")).toBe(true);
+    expect(isTrustedNodeMavenURL("https://nodemaven.com/pricing/")).toBe(true);
+    expect(isTrustedNodeMavenURL("http://dashboard.nodemaven.com/pricing")).toBe(false);
+    expect(isTrustedNodeMavenURL("https://nodemaven.com.evil.example/pricing")).toBe(false);
   });
 });

--- a/src/lib/proxyTraffic.ts
+++ b/src/lib/proxyTraffic.ts
@@ -151,6 +151,24 @@ export function mergeProxyTrafficHistories(
   };
 }
 
+export function isProxyTrafficExhausted(proxyTraffic?: ProxyTraffic | null): boolean {
+  if (!proxyTraffic?.limited) return false;
+  const remaining = proxyTraffic.remaining_bytes
+    ?? (proxyTraffic.limit_bytes == null ? undefined : proxyTraffic.limit_bytes - proxyTraffic.used_bytes);
+  return proxyTraffic.state === "exhausted" || (remaining != null && remaining <= 0);
+}
+
+export function isTrustedNodeMavenURL(value?: string | null): value is string {
+  if (!value) return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:"
+      && (url.hostname === "nodemaven.com" || url.hostname.endsWith(".nodemaven.com"));
+  } catch {
+    return false;
+  }
+}
+
 export function proxyTrafficWarning(proxyTraffic: ProxyTraffic): string | undefined {
   const state = trafficGateState(proxyTraffic);
   if (state === "blocked") return "Free traffic is paused. Ask in Discord to unlock the rest.";

--- a/src/lib/userFacingBrowserError.test.ts
+++ b/src/lib/userFacingBrowserError.test.ts
@@ -22,6 +22,11 @@ describe("userFacingBrowserError", () => {
       .toBe("The browser profile stopped responding. Restart the profile and try again.");
   });
 
+  it("explains a proxy tunnel failure without Chromium error jargon", () => {
+    expect(userFacingBrowserError("navigation failed: net::ERR_TUNNEL_CONNECTION_FAILED"))
+      .toBe("The selected profile’s proxy could not connect. Check or change its proxy, then run the automation again.");
+  });
+
   it("preserves useful ordinary errors while removing local log paths", () => {
     expect(userFacingBrowserError("Could not open page; see log /Users/person/private/child.log"))
       .toBe("Could not open page");

--- a/src/lib/userFacingBrowserError.ts
+++ b/src/lib/userFacingBrowserError.ts
@@ -41,6 +41,10 @@ export function userFacingBrowserError(error: unknown): string {
     return "The browser profile stopped responding. Restart the profile and try again.";
   }
 
+  if (/ERR_TUNNEL_CONNECTION_FAILED/i.test(raw)) {
+    return "The selected profile’s proxy could not connect. Check or change its proxy, then run the automation again.";
+  }
+
   // Never expose private filesystem locations from host-process diagnostics.
   return raw
     .replace(/^Error invoking remote method ['"][^'"]+['"]:\s*(?:Error:\s*)?/i, "")

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -12,3 +12,9 @@ export function getPreviewTab(): string | null {
   if (typeof window === "undefined") return null;
   return new URLSearchParams(window.location.search).get("tab");
 }
+
+export function getPreviewNodeMavenState(): "active" | "exhausted" | null {
+  if (typeof window === "undefined") return null;
+  const value = new URLSearchParams(window.location.search).get("nodemaven");
+  return value === "active" || value === "exhausted" ? value : null;
+}

--- a/src/repositorySkills.test.ts
+++ b/src/repositorySkills.test.ts
@@ -9,6 +9,8 @@ describe("repository skills", () => {
     expect(skill?.source).toBe("repository");
     expect(skill?.selector).toEqual({ kind: "domain", value: "999.md" });
     expect(skill?.instructions).toContain("# 999.md car search");
+    expect(skill?.permissions).toEqual(["read_page", "use_page_controls"]);
+    expect(skill?.verification).toBeUndefined();
   });
 
   it("carries a declared watchlist into the catalog entry", () => {

--- a/src/repositorySkills.ts
+++ b/src/repositorySkills.ts
@@ -1,4 +1,11 @@
-import type { SkillCategory, SkillEntry, SkillRuntime, SkillWatchlist } from "./skillsCatalog";
+import type {
+  SkillCategory,
+  SkillEntry,
+  SkillPermission,
+  SkillRuntime,
+  SkillVerification,
+  SkillWatchlist,
+} from "./skillsCatalog";
 
 interface RepositorySkillManifest {
   id: string;
@@ -10,6 +17,10 @@ interface RepositorySkillManifest {
   category: { id: string; title: string; icon: string; order: number };
   runtime?: SkillRuntime;
   watchlist?: SkillWatchlist;
+  target_mode?: "fixed_domain" | "current_tab";
+  permissions?: SkillPermission[];
+  min_nextctl_version?: string;
+  verification?: SkillVerification;
 }
 
 const manifests = import.meta.glob<RepositorySkillManifest>("../skills/*/manifest.json", {
@@ -49,8 +60,13 @@ export function repositorySkillCategories(): SkillCategory[] {
       categoryTitle: manifest.category.title,
       categoryIcon: manifest.category.icon,
       categoryOrder: manifest.category.order,
-      selector: { kind: "domain", value: manifest.domains[0] },
+      selector: manifest.target_mode === "current_tab"
+        ? { kind: "current_tab", value: "current tab" }
+        : { kind: "domain", value: manifest.domains[0] },
       runtime: manifest.runtime === "cloud-phone" ? "cloud-phone" : undefined,
+      permissions: manifest.permissions ?? [],
+      minNextctlVersion: manifest.min_nextctl_version,
+      verification: manifest.verification,
       source: "repository",
       instructions: skillInstructions,
       author: manifest.author,

--- a/src/skillsCatalog.test.ts
+++ b/src/skillsCatalog.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { withLocalScripts, type SkillCategory, type SkillEntry } from "./skillsCatalog";
+import { selectorFlags, selectorTargetHost, withLocalScripts, type SkillCategory, type SkillEntry } from "./skillsCatalog";
 
 describe("backend-driven skill catalog", () => {
   it("groups only entries returned by the backend", () => {
@@ -18,5 +18,11 @@ describe("backend-driven skill catalog", () => {
     expect(categories.flatMap((category) => category.entries)).not.toContainEqual(
       expect.objectContaining({ subtitle: "amazon.com" }),
     );
+  });
+
+  it("does not turn a current-tab skill into a fixed domain launch", () => {
+    const selector = { kind: "current_tab", value: "current tab" } as const;
+    expect(selectorTargetHost(selector)).toBeUndefined();
+    expect(selectorFlags(selector)).toEqual([]);
   });
 });

--- a/src/skillsCatalog.ts
+++ b/src/skillsCatalog.ts
@@ -1,7 +1,11 @@
 export type Selector =
   | { kind: "domain"; value: string }
   | { kind: "captcha"; value: string }
+  | { kind: "current_tab"; value: "current tab" }
   | { kind: "script"; value: string };
+
+export type SkillPermission = "read_page" | "use_page_controls" | "save_local_artifact" | "upload_file" | "login" | "publish";
+export type SkillVerification = "community" | "verified";
 
 /// A skill that follows accounts over time declares a watchlist, and the app
 /// renders the manager for it. The wording of the runs stays with the skill so
@@ -162,6 +166,9 @@ export interface SkillEntry {
   instructions?: string;
   author?: string;
   watchlist?: SkillWatchlist;
+  permissions?: SkillPermission[];
+  minNextctlVersion?: string;
+  verification?: SkillVerification;
 }
 
 /// fillTemplate substitutes `{name}` placeholders. A placeholder without a
@@ -180,6 +187,7 @@ export interface SkillCategory {
 
 export function selectorFlags(s: Selector): string[] {
   if (s.kind === "captcha") return ["--captcha", s.value];
+  if (s.kind === "current_tab") return [];
   return ["--domain", s.value];
 }
 
@@ -189,6 +197,7 @@ export function selectorTargetHost(s: Selector): string | undefined {
 
 export function selectorIcon(s: Selector): string {
   if (s.kind === "captcha") return "checkmark.shield";
+  if (s.kind === "current_tab") return "rectangle.on.rectangle";
   if (s.kind === "script") return "scroll";
   return "globe";
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -311,8 +311,11 @@ function skillAgentPrompt(
   openedHost?: string,
   directFallback = false,
   task?: string,
+  currentTab = false,
 ): string {
-  const startHint = openedHost
+  const startHint = currentTab
+    ? `${pageReadyNote(undefined, directFallback)} Keep the current browser tab active; do not open a different website unless the user explicitly asks.`
+    : openedHost
     ? pageReadyNote(openedHost, directFallback)
     : ` Start by opening ${target} in the active NextBrowser profile.${pageReadyNote(undefined, directFallback)}`;
   // The task is the app's own instruction for this run, so it precedes the
@@ -4397,8 +4400,7 @@ export const useStore = create<State>((set, get) => {
       background: !!options?.background,
     });
     if (!options?.background) set({ tab: "chat" });
-    const target =
-      entry.selector.kind === "domain" ? entry.selector.value : entry.selector.value;
+    const target = entry.selector.kind === "current_tab" ? "the current tab" : entry.selector.value;
     const requested = options?.conversationId;
     const cid = (requested && get().conversations.some((conversation) => conversation.id === requested) ? requested : undefined)
       ?? get().activeConversation()?.id
@@ -4482,6 +4484,7 @@ export const useStore = create<State>((set, get) => {
       prep.host,
       prep.directFallback,
       task,
+      entry.selector.kind === "current_tab",
     );
     get().enqueue(prompt, chip, cid);
     await get().loadDefaultSession();

--- a/src/styles.css
+++ b/src/styles.css
@@ -938,6 +938,27 @@ body.is-resizing-sidebar {
   margin-top: 15px;
 }
 .proxy-usage-allocation-meta { margin-top: 8px; }
+.nodemaven-handoff {
+  display: grid;
+  gap: 12px;
+  margin-top: 14px;
+  padding: 14px;
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--accent) 7%, var(--surface-2));
+}
+.nodemaven-handoff.exhausted {
+  border-color: color-mix(in srgb, var(--red) 35%, var(--border));
+  background: color-mix(in srgb, var(--red) 7%, var(--surface-2));
+}
+.nodemaven-handoff-copy { display: flex; align-items: flex-start; gap: 10px; }
+.nodemaven-handoff-copy > svg { flex: 0 0 auto; color: var(--accent); margin-top: 1px; }
+.nodemaven-handoff.exhausted .nodemaven-handoff-copy > svg { color: var(--red); }
+.nodemaven-handoff-copy strong { display: block; font-size: 14px; }
+.nodemaven-handoff-copy p { margin: 4px 0; color: var(--muted); font-size: 12px; line-height: 1.45; }
+.nodemaven-handoff-copy span, .nodemaven-handoff-notice { color: var(--muted); font-size: 11px; }
+.nodemaven-handoff-actions { display: flex; flex-wrap: wrap; gap: 8px; }
+.nodemaven-handoff-notice { margin: 0; }
 .proxy-usage-card .warning-banner { margin-top: 12px; }
 .proxy-traffic-gate {
   margin-top: 13px;
@@ -7889,6 +7910,38 @@ pre,
 .recording-progress-card.failed, .recording-progress-card.cancelled { border-color: color-mix(in srgb, var(--red) 35%, var(--line)); background: color-mix(in srgb, var(--red) 8%, var(--panel)); }
 .recording-progress-card.failed .recording-progress-head b, .recording-progress-card.cancelled .recording-progress-head b { color: var(--red); }
 .recording-progress-card.failed .recording-progress-track i, .recording-progress-card.cancelled .recording-progress-track i { background: var(--red); }
+
+/* Explain a run before it starts and make progress useful without exposing
+   transport/CDP diagnostics as the primary UI. */
+.automation-run-timeline { display: grid; gap: 7px; padding-top: 2px; }
+.automation-run-timeline summary { display: flex; cursor: pointer; align-items: center; justify-content: space-between; gap: 10px; color: var(--text); font-size: 11px; font-weight: 600; }
+.automation-run-timeline summary span { overflow: hidden; color: var(--muted); font-size: 10px; font-weight: 400; text-overflow: ellipsis; white-space: nowrap; }
+.automation-run-timeline ol { display: grid; gap: 6px; max-height: 178px; margin: 0; padding: 3px 0 0; overflow: auto; list-style: none; }
+.automation-run-timeline li { display: grid; grid-template-columns: 16px minmax(0, 1fr); align-items: start; gap: 7px; color: var(--muted); font-size: 11px; }
+.automation-run-timeline li.success { color: var(--green); }
+.automation-run-timeline li.failed { color: var(--red); }
+.automation-run-timeline li.repair { color: var(--accent); }
+.automation-run-timeline li span { display: grid; gap: 1px; min-width: 0; }
+.automation-run-timeline li strong { color: var(--text); font-size: 11px; font-weight: 550; }
+.automation-run-timeline li small { overflow: hidden; color: var(--muted); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
+.automation-repair-saved { display: flex; align-items: center; gap: 6px; margin: 0; color: var(--green); font-size: 11px; }
+.trust-preview-dialog { display: grid; width: min(600px, calc(100vw - 32px)); gap: 16px; }
+.trust-preview-title { display: flex; align-items: flex-start; gap: 11px; }
+.trust-preview-title > span { display: grid; width: 38px; height: 38px; place-items: center; border-radius: 12px; background: color-mix(in srgb, var(--accent) 14%, var(--surface-2)); color: var(--accent); }
+.trust-preview-title h2 { margin: 0; font-size: 18px; }
+.trust-preview-title p { margin: 4px 0 0; color: var(--muted); font-size: 12px; }
+.trust-preview-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin: 0; }
+.trust-preview-grid > div { min-width: 0; padding: 10px; border: 1px solid var(--line); border-radius: 10px; background: color-mix(in srgb, var(--surface-1) 85%, transparent); }
+.trust-preview-grid dt { color: var(--muted); font-size: 10px; }
+.trust-preview-grid dd { overflow: hidden; margin: 3px 0 0; color: var(--text); font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
+.trust-preview-effects { display: flex; flex-wrap: wrap; gap: 7px; }
+.trust-preview-effects span { display: inline-flex; align-items: center; gap: 5px; padding: 5px 8px; border: 1px solid color-mix(in srgb, var(--accent) 25%, var(--line)); border-radius: 999px; color: var(--text); font-size: 11px; }
+.trust-preview-effects span.risk, .trust-preview-warning { border-color: color-mix(in srgb, var(--yellow) 45%, var(--line)); color: var(--yellow); }
+.trust-preview-dialog ul { display: grid; gap: 5px; margin: 0; padding-left: 18px; color: var(--muted); font-size: 12px; }
+.trust-preview-warning { display: flex; align-items: flex-start; gap: 7px; margin: 0; padding: 9px 10px; border: 1px solid; border-radius: 9px; background: color-mix(in srgb, var(--yellow) 8%, var(--surface-1)); font-size: 11px; }
+.skill-contract { display: flex; flex-wrap: wrap; gap: 5px 8px; margin-top: -2px; }
+.skill-contract span { padding: 2px 5px; border: 1px solid var(--line); border-radius: 999px; background: color-mix(in srgb, var(--surface-2) 68%, transparent); font-size: 9px; text-transform: capitalize; }
+@media (max-width: 560px) { .trust-preview-grid { grid-template-columns: 1fr; } .trust-preview-dialog { gap: 12px; } }
 .automation-panel { border: 1px solid var(--line); border-radius: 16px; background: var(--panel); overflow: hidden; }
 .automation-panel-head { display: flex; justify-content: space-between; align-items: center; gap: 20px; padding: 18px 20px; border-bottom: 1px solid var(--line); }
 .automation-panel-head h2 { margin: 0 0 4px; font-size: 17px; }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,11 @@ export interface ProxyTraffic {
   state: string;
   top_up_bytes?: number | null;
   dashboard_url?: string | null;
+  provider?: string | null;
+  provider_account_email?: string | null;
+  provider_access_method?: "password_reset" | "email_sent" | null;
+  provider_access_url?: string | null;
+  pricing_url?: string | null;
 }
 
 export interface ProxyTrafficHistoryPoint {


### PR DESCRIPTION
## What changed
- add a pre-run Trust Center, safe action summary, and useful execution timeline for Automation Studio
- preserve verified AI repairs and make proxy failures actionable
- add Marketplace quality contracts: target mode, permissions, acceptance cases, and current-tab skills
- add a secure NodeMaven account handoff: password setup, pricing, refresh after checkout, and trusted URL validation
- bring the Reddit skill up to the new quality contract

## Verification
- `npm test` — 74 files / 558 tests passed
- `npm run validate:skills` — 3 repository skills validated
- `npx tsc --noEmit`
- `npm run build`

Free-tier agent support is already present in the current `main` and is intentionally not duplicated here.