### PR TITLE
Fix Multilogin setup and terminal reliability

### DIFF
--- a/electron/agent-workspace.test.cjs
+++ b/electron/agent-workspace.test.cjs
@@ -49,6 +49,7 @@ test("terminal Codex keeps workspace isolation while allowing Clawbrowser networ
   assert.match(main, /mcp_servers\.nextbrowser\.env_vars=.*MULTILOGIN_TOKEN/);
   assert.match(main, /mcp_servers\.nextbrowser\.env_vars=.*NEXTBROWSER_AUTOMATION_TRACE_FILE/);
   assert.match(main, /mcp_servers\.nextbrowser\.env_vars=.*NEXTBROWSER_CONTROL_URL/);
+  assert.match(main, /mcp_servers\.clawbrowser\.enabled=false/);
   assert.match(main, /mcp_servers\.nextbrowser\.env_vars=.*NEXTBROWSER_CONTROL_TOKEN/);
   assert.match(main, /nextctlHasAutomationTrace\(nextctlBin\)/);
   assert.match(main, /codexClawbrowserMCPArgs\(nextctlBin, supportedTraceFile\)/);

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -78,7 +78,7 @@ const {
   installRuntimeUpdateWithVerification,
 } = require("./browser-runtime-updates.cjs");
 const { createMultiloginCredentialStore, exchangeAutomationToken } = require("./multilogin-credential.cjs");
-const { parseMultiloginProfiles, parseMultiloginCreatedProfile, parseMultiloginFolders } = require("./multilogin-profiles.cjs");
+const { parseMultiloginProfiles, parseMultiloginCreatedMobileProfile, parseMultiloginCreatedProfile, parseMultiloginFolders } = require("./multilogin-profiles.cjs");
 const { multiloginAccountFromTokens } = require("./multilogin-account.cjs");
 const { MULTILOGIN_DOWNLOAD_URL, resolveMultiloginApp } = require("./multilogin-app.cjs");
 const { runAgentProcess } = require("./agent-process.cjs");
@@ -157,6 +157,9 @@ default_tools_approval_mode = "approve"
 
 [plugins."clawbrowser@nbc-local"]
 enabled = false
+
+[mcp_servers.clawbrowser]
+enabled = false
 `;
 
 function codexClawbrowserMCPArgs(nextctlBin, automationTraceFile = "") {
@@ -177,6 +180,7 @@ function codexClawbrowserMCPArgs(nextctlBin, automationTraceFile = "") {
     "-c", 'plugins."clawbrowser@clawctl-local".enabled=false',
     "-c", 'plugins."clawbrowser@clawctl-local".mcp_servers.clawbrowser.enabled=false',
     "-c", 'plugins."clawbrowser@nbc-local".enabled=false',
+    "-c", "mcp_servers.clawbrowser.enabled=false",
     "-c", `mcp_servers.nextbrowser.command=${JSON.stringify(nextctlBin)}`,
     "-c", `mcp_servers.nextbrowser.args=${JSON.stringify(["mcp", ...(automationTraceFile ? ["--automation-trace-file", automationTraceFile] : [])])}`,
     "-c", `mcp_servers.nextbrowser.env=${mcpEnv}`,
@@ -932,6 +936,31 @@ async function createMultiloginProfile(args = {}) {
   return parseMultiloginCreatedProfile(result.stdout);
 }
 
+async function createMultiloginMobileProfile(args = {}) {
+  await initializeMultiloginCredential();
+  if (!multiloginAutomationToken) throw new Error("Connect Multilogin before creating a cloud phone.");
+  const name = String(args.name || "").trim();
+  if (!name) throw new Error("Cloud phone name is required.");
+  const country = String(args.country || "").trim().toUpperCase();
+  const bin = await resolveOrInstallNextctl();
+  if (!bin) throw new Error("nextctl is required to create Multilogin cloud phones.");
+  const result = await run(
+    bin,
+    [
+      "--runtime", "multilogin",
+      ...(multiloginFolders?.mobile ? ["--multilogin-folder-id", multiloginFolders.mobile] : []),
+      "mobile", "profiles", "create", name,
+      ...(/^[A-Z]{2}$/.test(country) ? ["--country", country] : []),
+      "--android-version", "14",
+      "--json",
+    ],
+    { MULTILOGIN_TOKEN: multiloginAutomationToken },
+    { requestId: args.requestId, timeoutMs: Number(args.timeoutMs) || 120_000 },
+  );
+  if (result.code !== 0) throw multiloginCommandError(result);
+  return parseMultiloginCreatedMobileProfile(result.stdout);
+}
+
 async function disconnectMultilogin() {
   await initializeMultiloginCredential();
   await multiloginCredentialStore?.clear();
@@ -1342,6 +1371,7 @@ async function invokeCommand(command, args = {}, sender) {
     case "multilogin_connect": return await connectMultilogin(args.bearerToken);
     case "multilogin_disconnect": return await disconnectMultilogin();
     case "multilogin_profile_create": return await createMultiloginProfile(args);
+    case "multilogin_mobile_profile_create": return await createMultiloginMobileProfile(args);
     case "multilogin_folders_list": {
       await initializeMultiloginCredential();
       if (!multiloginAutomationToken) throw new Error("Connect Multilogin before choosing a folder.");

--- a/electron/multilogin-profiles.cjs
+++ b/electron/multilogin-profiles.cjs
@@ -80,6 +80,25 @@ function parseMultiloginCreatedProfile(stdout) {
   };
 }
 
+function parseMultiloginCreatedMobileProfile(stdout) {
+  let payload;
+  try {
+    payload = JSON.parse(String(stdout || ""));
+  } catch {
+    throw new Error("nextctl returned an invalid Multilogin cloud phone response.");
+  }
+  const mobile = payload?.data?.mobile ?? payload?.mobile ?? payload?.data;
+  const profile = Array.isArray(mobile?.profiles) ? mobile.profiles[0] : undefined;
+  const id = boundedString(profile?.id ?? profile?.profile_id);
+  if (!id) throw new Error("Multilogin did not return the created cloud phone.");
+  return {
+    id,
+    name: boundedString(profile?.name ?? profile?.profile_name ?? profile?.serial_name) || id,
+    folderId: boundedString(mobile?.folder_id ?? profile?.folder_id) || undefined,
+    country: boundedString(mobile?.country, 8).toUpperCase() || undefined,
+  };
+}
+
 const MULTILOGIN_FOLDER_KINDS = { browser: "browser", mobile: "mobile" };
 
 /** Reads `nbc profiles folders --json` into the folder choices the UI offers. */
@@ -104,4 +123,4 @@ function parseMultiloginFolders(stdout) {
 }
 
 module.exports = {
-  parseMultiloginFolders, parseMultiloginProfiles, parseMultiloginCreatedProfile };
+  parseMultiloginFolders, parseMultiloginProfiles, parseMultiloginCreatedProfile, parseMultiloginCreatedMobileProfile };

--- a/electron/multilogin-profiles.test.cjs
+++ b/electron/multilogin-profiles.test.cjs
@@ -1,7 +1,7 @@
 const assert = require("node:assert/strict");
 const test = require("node:test");
 
-const { parseMultiloginProfiles, parseMultiloginCreatedProfile } = require("./multilogin-profiles.cjs");
+const { parseMultiloginProfiles, parseMultiloginCreatedProfile, parseMultiloginCreatedMobileProfile } = require("./multilogin-profiles.cjs");
 
 test("normalizes Multilogin Mimic browser profiles", () => {
   assert.deepEqual(
@@ -58,5 +58,14 @@ test("rejects a Multilogin create response without an ID", () => {
   assert.throws(
     () => parseMultiloginCreatedProfile(JSON.stringify({ data: { profile: { profile: { name: "Shop US" } } } })),
     /did not return the created profile/,
+  );
+});
+
+test("reads a created Multilogin cloud phone", () => {
+  assert.deepEqual(
+    parseMultiloginCreatedMobileProfile(JSON.stringify({
+      data: { mobile: { folder_id: "mobile-folder", country: "us", profiles: [{ id: "phone-1", name: "Research phone" }] } },
+    })),
+    { id: "phone-1", name: "Research phone", folderId: "mobile-folder", country: "US" },
   );
 });

--- a/src/agents.test.ts
+++ b/src/agents.test.ts
@@ -17,7 +17,9 @@ describe("agent invocation parity", () => {
     expect(agentById("claude").installUrl).toBe("https://code.claude.com/docs/en/installation");
     expect(agentById("codex").installUrl).toBe("https://chatgpt.com/download/");
     expect(agentById("antigravity").installUrl).toBe("https://www.antigravity.google/docs/cli/install/");
+    expect(agentById("kilo").installUrl).toBe("https://kilo.ai/docs/getting-started/using-kilo-for-free");
     expect(agentById("copilot").installUrl).toBe("https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli");
+    expect(agentById("amazonq").installUrl).toBe("https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/q-tiers.html");
     expect(agentInstallName(agentById("claude"))).toBe("Claude Code CLI");
     expect(agentInstallName(agentById("codex"))).toBe("ChatGPT desktop app with Codex");
   });

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -64,7 +64,7 @@ export const AGENTS: AgentSpec[] = [
   spec("claude", "Claude Code", "claude", "claudePrint", { primary: true, loginArgs: ["auth", "login"], logoutArgs: ["auth", "logout"], statusArgs: ["auth", "status"], installUrl: "https://code.claude.com/docs/en/installation" }),
   spec("codex", "Codex", "codex", "codexExec", { primary: true, loginArgs: ["login"], logoutArgs: ["logout"], statusArgs: ["login", "status"], installUrl: "https://chatgpt.com/download/", installKind: "app" }),
   spec("hermes", "Hermes Agent", "hermes", "hermesOneshot", { loginArgs: ["setup"] }),
-  spec("kilo", "Kilo Code", "kilo", "runSubcommand"),
+  spec("kilo", "Kilo Code", "kilo", "runSubcommand", { installUrl: "https://kilo.ai/docs/getting-started/using-kilo-for-free" }),
   spec("openclaw", "OpenClaw", "openclaw", "openclawAgent", { loginArgs: ["onboard"] }),
   spec("cline", "Cline", "cline", "promptArg", { loginArgs: ["auth"] }),
   spec("pi", "pi", "pi", "promptFlag"),
@@ -73,8 +73,8 @@ export const AGENTS: AgentSpec[] = [
   // Authentication happens when its interactive terminal opens (keyring first,
   // then Google Sign-In), so it intentionally has no status or logout command.
   spec("antigravity", "Antigravity CLI", "agy", "promptFlag", { installUrl: "https://www.antigravity.google/docs/cli/install/" }),
-  // Copilot Free includes a monthly AI-credit allowance. Its documented
-  // programmatic mode is `copilot -p <prompt>`.
+  // Copilot Free includes a small monthly allowance. The CLI's programmatic
+  // mode is `copilot -p <prompt>`, the same shape used by Gemini/Antigravity.
   spec("copilot", "GitHub Copilot CLI", "copilot", "promptFlag", { loginArgs: ["login"], installUrl: "https://docs.github.com/en/copilot/how-tos/copilot-cli/set-up-copilot-cli/install-copilot-cli" }),
   spec("qwen", "Qwen Code", "qwen", "promptFlag"),
   spec("opencode", "OpenCode", "opencode", "runSubcommand"),
@@ -92,7 +92,7 @@ export const AGENTS: AgentSpec[] = [
   spec("plandex", "Plandex", "plandex", "promptArg"),
   spec("codebuff", "Codebuff", "codebuff", "promptArg"),
   spec("interpreter", "Open Interpreter", "interpreter", "promptArg"),
-  spec("amazonq", "Amazon Q", "q", "promptArg"),
+  spec("amazonq", "Amazon Q", "q", "promptArg", { installUrl: "https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/q-tiers.html" }),
   spec("continue", "Continue", "cn", "promptArg"),
   spec("droid", "Factory Droid", "droid", "promptArg"),
 ];

--- a/src/components/PersonalProxySelect.test.tsx
+++ b/src/components/PersonalProxySelect.test.tsx
@@ -1,0 +1,20 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { PersonalProxySelect } from "./PersonalProxySelect";
+
+describe("PersonalProxySelect", () => {
+  it("uses the app-styled picker instead of the native select menu", () => {
+    const html = renderToStaticMarkup(
+      <PersonalProxySelect
+        value="proxy-1"
+        proxies={[{ id: "proxy-1", name: "US residential", scheme: "http", host: "proxy.example", port: 8080 }]}
+        onChange={vi.fn()}
+        onAdd={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain("US residential");
+    expect(html).toContain("personal-proxy-select-trigger");
+    expect(html).not.toContain("<select");
+  });
+});

--- a/src/components/PersonalProxySelect.tsx
+++ b/src/components/PersonalProxySelect.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useId, useRef, useState, type CSSProperties, type KeyboardEvent } from "react";
+import { createPortal } from "react-dom";
+import { Icon } from "./Icon";
+
+export interface PersonalProxyOption {
+  id: string;
+  name: string;
+  scheme: string;
+  host: string;
+  port: number;
+}
+
+interface PersonalProxySelectProps {
+  value: string;
+  proxies: PersonalProxyOption[];
+  disabled?: boolean;
+  ariaLabel?: string;
+  onChange: (id: string) => void;
+  onAdd: () => void;
+}
+
+export function PersonalProxySelect({ value, proxies, disabled = false, ariaLabel = "Personal proxy", onChange, onAdd }: PersonalProxySelectProps) {
+  const id = useId();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const [style, setStyle] = useState<CSSProperties>();
+  const selected = proxies.find((proxy) => proxy.id === value);
+
+  const close = (restoreFocus = false) => {
+    setOpen(false);
+    if (restoreFocus) window.requestAnimationFrame(() => triggerRef.current?.focus());
+  };
+  const position = () => {
+    const rect = triggerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const padding = 8;
+    const gap = 6;
+    const availableBelow = window.innerHeight - rect.bottom - padding - gap;
+    const availableAbove = rect.top - padding - gap;
+    const above = availableBelow < 200 && availableAbove > availableBelow;
+    const height = Math.max(132, Math.min(280, above ? availableAbove : availableBelow));
+    setStyle({
+      left: Math.max(padding, Math.min(rect.left, window.innerWidth - rect.width - padding)),
+      top: above ? Math.max(padding, rect.top - height - gap) : rect.bottom + gap,
+      width: rect.width,
+      maxHeight: height,
+    });
+  };
+  const show = () => {
+    if (disabled) return;
+    position();
+    setOpen(true);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const outside = (event: PointerEvent) => {
+      const target = event.target as Node;
+      if (!rootRef.current?.contains(target) && !dropdownRef.current?.contains(target)) close();
+    };
+    const reposition = () => position();
+    document.addEventListener("pointerdown", outside);
+    window.addEventListener("resize", reposition);
+    window.addEventListener("scroll", reposition, true);
+    return () => {
+      document.removeEventListener("pointerdown", outside);
+      window.removeEventListener("resize", reposition);
+      window.removeEventListener("scroll", reposition, true);
+    };
+  }, [open]);
+
+  const onKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (["Enter", " ", "ArrowDown", "ArrowUp"].includes(event.key)) {
+      event.preventDefault();
+      show();
+    }
+    if (event.key === "Escape") close(true);
+  };
+
+  return (
+    <div className="personal-proxy-select" ref={rootRef}>
+      <button ref={triggerRef} type="button" className={`personal-proxy-select-trigger${open ? " is-open" : ""}`} disabled={disabled} aria-label={ariaLabel} aria-haspopup="listbox" aria-expanded={open} aria-controls={`${id}-listbox`} onClick={() => open ? close() : show()} onKeyDown={onKeyDown}>
+        <span className="personal-proxy-select-copy">{selected ? <><strong>{selected.name}</strong><small>{selected.scheme.toUpperCase()} · {selected.host}:{selected.port}</small></> : <span>Choose a proxy</span>}</span>
+        <Icon name="chevron.down" size={14} className="personal-proxy-select-chevron" />
+      </button>
+      {open && createPortal(
+        <div ref={dropdownRef} className="personal-proxy-select-menu" style={style} onMouseDown={(event) => event.stopPropagation()}>
+          <div id={`${id}-listbox`} className="personal-proxy-select-options" role="listbox" aria-label={ariaLabel}>
+            {proxies.map((proxy) => {
+              const isSelected = proxy.id === value;
+              return <button key={proxy.id} type="button" role="option" aria-selected={isSelected} className={`personal-proxy-select-option${isSelected ? " is-selected" : ""}`} onClick={() => { onChange(proxy.id); close(true); }}>
+                <span><strong>{proxy.name}</strong><small>{proxy.scheme.toUpperCase()} · {proxy.host}:{proxy.port}</small></span>
+                {isSelected && <Icon name="checkmark" size={14} />}
+              </button>;
+            })}
+          </div>
+          <button type="button" className="personal-proxy-select-add" onClick={() => { close(); onAdd(); }}><Icon name="plus" size={13} /> Add proxy</button>
+        </div>,
+        document.body,
+      )}
+    </div>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -11,11 +11,11 @@ import { guideProfileTarget } from "../lib/guideQuickStart";
 import { manualProxyDefaultName, manualProxyLimits, parseManualProxyBatch, parseManualProxyClipboard, validateManualProxyFields, type ManualProxyScheme } from "../lib/manualProxy";
 import { internalError, needsSupportLink } from "../lib/userFacingError";
 import { userFacingMultiloginError } from "../lib/userFacingMultiloginError";
-import { openMultiloginApp } from "../lib/multiloginApp";
 import { entityNameLimits, validateEntityName } from "../lib/entityValidation";
 import { cancelNextctlRun } from "../nextctl";
 import { conversationPreview, type AppTab, type BrowserWorkflowAction, type BrowserWorkflowSkill } from "../types";
 import { CountrySelect } from "./CountrySelect";
+import { PersonalProxySelect } from "./PersonalProxySelect";
 import { UserFacingError } from "./UserFacingError";
 import { VPSSetupModal } from "./VPSSetupModal";
 import { CONNECTOR_PROMPT_RESUMED_EVENT, CONNECTORS } from "../connectorsCatalog";
@@ -64,6 +64,17 @@ function recordingDuration(startedAt: number, now = Date.now()) {
 
 function repairedRecipeEvidence(actions: BrowserWorkflowAction[]) {
   return actions.map((action) => `Called clawbrowser.${action.tool}(${JSON.stringify(action.arguments)})\n{"ok":true}`).join("\n");
+}
+
+function multiloginCreationError(error: unknown, kind: MultiloginProfileKind): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/workspace has no .*Default folder|workspace has multiple .*Default folder/i.test(message)) {
+    const item = kind === "mobile" ? "cloud-phone" : "browser";
+    return `This Multilogin workspace needs one ${item} folder named “Default” before NextBrowser can create a new ${kind === "mobile" ? "cloud phone" : "browser profile"}. Create or rename that folder in Multilogin, then refresh here. You can still choose an existing shared profile.`;
+  }
+  return /timed out/i.test(message)
+    ? "Multilogin profile creation took too long and was stopped. Check your connection, then try again."
+    : userFacingMultiloginError(error, kind);
 }
 
 interface SidebarProps {
@@ -926,7 +937,7 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
       setProfileError("Create a workspace before adding a Multilogin profile.");
       return;
     }
-    const invalid = multiloginSubmitError(multiloginMode, profileConnection, profileCountry, multiloginDraft);
+    const invalid = multiloginSubmitError(multiloginMode, profileConnection, profileCountry, multiloginDraft, multiloginKind);
     if (invalid) {
       setProfileError(invalid);
       return;
@@ -946,19 +957,20 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
     const requestId = `profile-create-${crypto.randomUUID()}`;
     profileCreateRequestRef.current = requestId;
     setProfileSaving(true);
-    setProfileCreationStage("Creating Multilogin profile");
+    const creatingPhone = multiloginKind === "mobile";
+    setProfileCreationStage(creatingPhone ? "Creating Multilogin cloud phone" : "Creating Multilogin profile");
     setProfileError(null);
     const proxyStageTimer = window.setTimeout(() => setProfileCreationStage("Attaching Multilogin proxy"), 4_000);
     try {
-      const created = await invoke<MultiloginCreatedProfile>("multilogin_profile_create", {
+      const created = await invoke<MultiloginCreatedProfile>(creatingPhone ? "multilogin_mobile_profile_create" : "multilogin_profile_create", {
         name: createdName,
-        country: multiloginCreateCountry(profileConnection, profileCountry),
+        country: multiloginCreateCountry(creatingPhone ? "managed" : profileConnection, profileCountry),
         osType: multiloginOS,
         requestId,
         timeoutMs: PROFILE_CREATE_TIMEOUT_MS,
       });
       if (profileCreateRequestRef.current !== requestId) return;
-      applyMultiloginSelection(multiloginProfileSelection("browser", created));
+      applyMultiloginSelection(multiloginProfileSelection(creatingPhone ? "mobile" : "browser", created));
       void refreshMultiloginStatus();
       setProfileCreationStage("Ready");
       await new Promise((resolve) => window.setTimeout(resolve, 450));
@@ -966,12 +978,7 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
       finishMultiloginProfile();
     } catch (error) {
       if (profileCreateRequestRef.current !== requestId) return;
-      const message = error instanceof Error ? error.message : String(error);
-      setProfileError(
-        /timed out/i.test(message)
-          ? "Multilogin profile creation took too long and was stopped. Check your connection, then try again."
-          : userFacingMultiloginError(error, "browser"),
-      );
+      setProfileError(multiloginCreationError(error, multiloginKind));
     } finally {
       window.clearTimeout(proxyStageTimer);
       if (profileCreateRequestRef.current === requestId) {
@@ -1570,19 +1577,14 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
                   </button>
                 </span>
                 {s.personalProxies.length ? (
-                  <select
+                  <PersonalProxySelect
                     value={profilePersonalProxyId}
+                    proxies={s.personalProxies}
                     disabled={profileSaving}
-                    onChange={(event) => setProfilePersonalProxyId(event.target.value)}
-                    aria-label="Personal proxy"
-                  >
-                    <option value="" disabled>Choose a proxy</option>
-                    {s.personalProxies.map((proxy) => (
-                      <option key={proxy.id} value={proxy.id}>
-                        {proxy.name} · {proxy.scheme.toUpperCase()} · {proxy.host}:{proxy.port}
-                      </option>
-                    ))}
-                  </select>
+                    ariaLabel="Personal proxy"
+                    onChange={setProfilePersonalProxyId}
+                    onAdd={() => { resetManualProxyForm(); setManualProxyEditing(true); setManualProxyOpen(true); }}
+                  />
                 ) : (
                   <button
                     type="button"
@@ -1654,6 +1656,11 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
                       <span>{multiloginAccountLabel(multiloginStatus?.account) || "Multilogin workspace"}</span>
                       <button type="button" className="link" onClick={routeToMultiloginConnector}>Change</button>
                     </div>
+                    <div className="profile-multilogin-proxy-note">
+                      <Icon name="network" size={13} />
+                      <span><strong>Proxy is managed by Multilogin</strong><small>For a custom proxy, configure it in Multilogin, then choose that existing profile here.</small></span>
+                      <button type="button" className="link" onClick={() => void invoke("open_external", { url: "https://app.multilogin.com" })}>Open Multilogin</button>
+                    </div>
                     <div className="connector-profile-tabs profile-multilogin-modes" role="tablist" aria-label="Multilogin profile source">
                       <button
                         type="button"
@@ -1675,21 +1682,33 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
                       </button>
                     </div>
                     {multiloginMode === "new" ? (
-                      <label className="modal-field profile-multilogin-os">
-                        <span>Fingerprint OS</span>
-                        <select
-                          value={multiloginOS}
-                          disabled={profileSaving}
-                          aria-label="Multilogin fingerprint OS"
-                          onChange={(event) => setMultiloginOS(event.target.value as MultiloginOSType)}
-                        >
-                          {MULTILOGIN_OS_TYPES.map((osType) => (
-                            <option key={osType} value={osType}>
-                              {osType === "macos" ? "macOS" : osType === "windows" ? "Windows" : "Linux"}
-                            </option>
-                          ))}
-                        </select>
-                      </label>
+                      <>
+                        <div className="connector-profile-tabs profile-multilogin-kind-tabs" role="tablist" aria-label="Multilogin profile type to create">
+                          <button type="button" role="tab" aria-selected={multiloginKind === "browser"} className={multiloginKind === "browser" ? "active" : ""} onClick={() => { setMultiloginKind("browser"); setProfileError(null); }}>
+                            <span>Browser</span>
+                          </button>
+                          <button type="button" role="tab" aria-selected={multiloginKind === "mobile"} className={multiloginKind === "mobile" ? "active" : ""} onClick={() => { setMultiloginKind("mobile"); setProfileConnection("managed"); setProfileError(null); }}>
+                            <span>Cloud phone</span>
+                          </button>
+                        </div>
+                        {multiloginKind === "browser" ? (
+                          <label className="modal-field profile-multilogin-os">
+                            <span>Fingerprint OS</span>
+                            <select
+                              value={multiloginOS}
+                              disabled={profileSaving}
+                              aria-label="Multilogin fingerprint OS"
+                              onChange={(event) => setMultiloginOS(event.target.value as MultiloginOSType)}
+                            >
+                              {MULTILOGIN_OS_TYPES.map((osType) => (
+                                <option key={osType} value={osType}>
+                                  {osType === "macos" ? "macOS" : osType === "windows" ? "Windows" : "Linux"}
+                                </option>
+                              ))}
+                            </select>
+                          </label>
+                        ) : <p className="profile-multilogin-phone-note">Creates one Android 14 cloud phone with a Multilogin-managed proxy in the selected country.</p>}
+                      </>
                     ) : (
                       <div className="profile-multilogin-picker" role="tabpanel">
                         <div className="profile-multilogin-picker-head">
@@ -1764,15 +1783,9 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
                               {multiloginQuery.trim() ? "No matching profiles" : (
                                 <>
                                   <span>No {multiloginKind === "browser" ? "browser profiles" : "cloud phones"} in this Multilogin workspace yet.</span>
-                                  {multiloginKind === "browser" ? (
-                                    <button type="button" className="link" onClick={() => { setMultiloginMode("new"); setProfileError(null); }}>
-                                      Create profile
-                                    </button>
-                                  ) : (
-                                    <button type="button" className="link" onClick={() => void openMultiloginApp()}>
-                                      Create one in Multilogin
-                                    </button>
-                                  )}
+                                  <button type="button" className="connector-empty-create" onClick={() => { setMultiloginMode("new"); setProfileConnection("managed"); setProfileError(null); }}>
+                                    Create {multiloginKind === "browser" ? "a browser profile" : "a cloud phone"}
+                                  </button>
                                 </>
                               )}
                             </div>
@@ -2015,17 +2028,33 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
               {!isDefaultProfile && (
                 <>
                   <div className="profile-menu-divider" />
-                  <button
-                    className="profile-delete-btn"
-                    onClick={() => {
-                      setProfileDeleteError(null);
-                      setConfirmDelete(menuProfile);
-                      setMenuProfile(null);
-                    }}
-                  >
-                    <Icon name="trash" size={14} />
-                    Delete profile
-                  </button>
+                  <div className="profile-menu-danger-actions">
+                    {profileBusy && (
+                      <button
+                        type="button"
+                        className="profile-stop-btn"
+                        disabled={status === "stopping"}
+                        onClick={() => {
+                          void runProfileAction(`We couldn't stop “${menuProfile}”.`, "PROFILE_STOP_FAILED", () => s.stopProfile(menuProfile));
+                          setMenuProfile(null);
+                        }}
+                      >
+                        <Icon name="stop.fill" size={13} />
+                        {status === "stopping" ? "Stopping profile…" : "Stop profile"}
+                      </button>
+                    )}
+                    <button
+                      className="profile-delete-btn"
+                      onClick={() => {
+                        setProfileDeleteError(null);
+                        setConfirmDelete(menuProfile);
+                        setMenuProfile(null);
+                      }}
+                    >
+                      <Icon name="trash" size={14} />
+                      Delete profile
+                    </button>
+                  </div>
                 </>
               )}
             </div>
@@ -2075,7 +2104,7 @@ export function Sidebar({ onOpenAgentSettings, onHome }: SidebarProps) {
             {profileConnectionEditor.connection === "managed" && <div className="modal-field profile-proxy-country-field"><span>Proxy country</span><CountrySelect countries={proxyCountries} value={profileConnectionEditor.country} disabled={profileConnectionSaving} ariaLabel="Proxy country" onChange={(country) => setProfileConnectionEditor({ ...profileConnectionEditor, country })} /></div>}
             {profileConnectionEditor.connection === "personal" && <div className="modal-field profile-personal-proxy-field">
               <span className="profile-field-heading"><span>Personal proxy</span><button type="button" className="link" onClick={() => { resetManualProxyForm(); setManualProxyEditing(s.personalProxies.length === 0); setManualProxyOpen(true); }}>Manage</button></span>
-              {s.personalProxies.length ? <select value={profileConnectionEditor.proxyId} disabled={profileConnectionSaving} onChange={(event) => setProfileConnectionEditor({ ...profileConnectionEditor, proxyId: event.target.value })}><option value="" disabled>Choose a proxy</option>{s.personalProxies.map((proxy) => <option key={proxy.id} value={proxy.id}>{proxy.name} · {proxy.scheme.toUpperCase()} · {proxy.host}:{proxy.port}</option>)}</select> : <button type="button" className="personal-proxy-empty-action" onClick={() => { resetManualProxyForm(); setManualProxyEditing(true); setManualProxyOpen(true); }}><Icon name="plus" size={13} /> Create your first proxy</button>}
+              {s.personalProxies.length ? <PersonalProxySelect value={profileConnectionEditor.proxyId} proxies={s.personalProxies} disabled={profileConnectionSaving} onChange={(proxyId) => setProfileConnectionEditor({ ...profileConnectionEditor, proxyId })} onAdd={() => { resetManualProxyForm(); setManualProxyEditing(true); setManualProxyOpen(true); }} /> : <button type="button" className="personal-proxy-empty-action" onClick={() => { resetManualProxyForm(); setManualProxyEditing(true); setManualProxyOpen(true); }}><Icon name="plus" size={13} /> Create your first proxy</button>}
             </div>}
             {profileConnectionError && <div className="error small" role="alert">{profileConnectionError}</div>}
             <div className="modal-actions"><button type="button" className="secondary" disabled={profileConnectionSaving} onClick={() => setProfileConnectionEditor(null)}>Cancel</button><button type="submit" className="primary" disabled={profileConnectionSaving || (profileConnectionEditor.connection === "personal" && !profileConnectionEditor.proxyId)}>{profileConnectionSaving ? <Spinner size={13} /> : <Icon name="checkmark" size={13} />}{profileConnectionSaving ? "Saving…" : "Save connection"}</button></div>

--- a/src/lib/agentRunResult.test.ts
+++ b/src/lib/agentRunResult.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { agentEmptyReplyMessage } from "./agentRunResult";
+
+describe("agentEmptyReplyMessage", () => {
+  it("gives Antigravity users a recoverable, actionable error", () => {
+    expect(agentEmptyReplyMessage("antigravity", "Antigravity CLI")).toMatch(
+      /^Antigravity CLI finished without a reply\. Check that Antigravity is signed in and that its free quota is available, then retry\. Ref: NB-/,
+    );
+  });
+
+  it("does not present an empty successful agent result as a reply", () => {
+    expect(agentEmptyReplyMessage("codex", "Codex")).toMatch(
+      /^Codex finished without a reply\. Check its connection and retry\. Ref: NB-/,
+    );
+  });
+});

--- a/src/lib/agentRunResult.ts
+++ b/src/lib/agentRunResult.ts
@@ -1,0 +1,14 @@
+import { internalError } from "./userFacingError";
+
+export function agentEmptyReplyMessage(agentId: string, agentName: string): string {
+  if (agentId === "antigravity") {
+    return internalError(
+      "Antigravity CLI finished without a reply. Check that Antigravity is signed in and that its free quota is available, then retry.",
+      "ANTIGRAVITY_EMPTY_REPLY",
+    );
+  }
+  return internalError(
+    `${agentName} finished without a reply. Check its connection and retry.`,
+    "AGENT_EMPTY_REPLY",
+  );
+}

--- a/src/lib/multiloginProfileCreate.ts
+++ b/src/lib/multiloginProfileCreate.ts
@@ -38,11 +38,12 @@ export function multiloginSubmitError(
   connection: "managed" | "direct" | "personal",
   country: string,
   selection?: MultiloginProfileSelection,
+  kind: MultiloginProfileKind = "browser",
 ): string | undefined {
   if (mode === "existing") {
     return selection ? undefined : "Choose a Multilogin profile.";
   }
-  return connection === "managed" && !multiloginCreateCountry(connection, country)
+  return (kind === "mobile" || connection === "managed") && !multiloginCreateCountry("managed", country)
     ? "Choose a valid proxy country."
     : undefined;
 }

--- a/src/lib/multiloginProfiles.ts
+++ b/src/lib/multiloginProfiles.ts
@@ -42,6 +42,11 @@ export interface MultiloginConnectionStatus {
   folders?: { browser?: string; mobile?: string };
   valid: boolean;
   secureStorageAvailable: boolean;
+  /**
+   * A local recognition label decoded from the short-lived sign-in token.
+   * Multilogin automation tokens themselves only grant workspace access.
+   */
+  accountEmail?: string;
   browserProfiles?: MultiloginProfileSummary[];
   cloudPhones?: MultiloginProfileSummary[];
   browserProfilesError?: string;

--- a/src/store.ts
+++ b/src/store.ts
@@ -44,6 +44,7 @@ import { proxyTrafficWarning } from "./lib/proxyTraffic";
 import { activeAutomationRecording } from "./lib/automationRecording";
 import { setAnalyticsUserId, trackEvent, trackScreenView, trackTiming } from "./lib/analytics";
 import { internalError } from "./lib/userFacingError";
+import { agentEmptyReplyMessage } from "./lib/agentRunResult";
 import { userFacingBrowserError } from "./lib/userFacingBrowserError";
 import {
   hasCompletedCurrentOnboarding,
@@ -1369,7 +1370,8 @@ export const useStore = create<State>((set, get) => {
             const error = internalError(`${agentById(agentId).name} stopped unexpectedly.`, "AGENT_STOPPED_UNEXPECTEDLY");
             text = text ? `${text}\n${error}` : error;
           } else if (!text) {
-            text = "(no output)";
+            status = "failed";
+            text = agentEmptyReplyMessage(agentId, agentById(agentId).name);
           }
           return { ...message, status, text, stalled: false };
         }),

--- a/src/styles.css
+++ b/src/styles.css
@@ -5407,6 +5407,11 @@ code { background: var(--surface-4); padding: 1px 5px; border-radius: 4px; }
 }
 .profile-delete-btn:active { background: color-mix(in srgb, var(--red) 16%, transparent); }
 .profile-delete-btn:focus-visible { outline: 2px solid color-mix(in srgb, var(--red) 60%, transparent); outline-offset: 2px; }
+.profile-menu-danger-actions { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 7px; }
+.profile-menu-danger-actions .profile-delete-btn { width: auto; }
+.profile-stop-btn { display: inline-flex; align-items: center; justify-content: center; gap: 7px; min-height: var(--hit); padding: 8px 10px; border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--line)); border-radius: var(--button-radius); background: var(--accent-soft); color: var(--accent-text); font: inherit; font-size: 12px; font-weight: 650; }
+.profile-stop-btn:hover:not(:disabled) { background: color-mix(in srgb, var(--accent) 22%, var(--surface-3)); border-color: var(--accent); }
+.profile-stop-btn:disabled { opacity: .62; cursor: default; }
 
 /* Onboarding */
 .onboarding-overlay {
@@ -7045,6 +7050,42 @@ code { background: var(--surface-4); padding: 1px 5px; border-radius: 4px; }
   border: 1px solid var(--line);
   border-radius: var(--radius-md);
 }
+.profile-multilogin-proxy-note {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 9px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--surface-1);
+  color: var(--accent-text);
+}
+.profile-multilogin-proxy-note > span { display: grid; gap: 2px; min-width: 0; }
+.profile-multilogin-proxy-note strong { font-size: 11px; color: var(--text); }
+.profile-multilogin-proxy-note small, .profile-multilogin-phone-note { color: var(--muted); font-size: 10px; line-height: 1.4; }
+.profile-multilogin-proxy-note .link { font-size: 10px; white-space: nowrap; }
+.profile-multilogin-phone-note { margin: 0; padding: 2px 1px; }
+.connector-profile-empty { display: grid; gap: 8px; }
+.connector-empty-create { justify-self: center; min-height: 30px; padding: 5px 9px; border: 1px solid var(--line-strong); border-radius: 7px; background: var(--surface-3); color: var(--accent-text); font: inherit; font-size: 11px; font-weight: 600; }
+.connector-empty-create:hover { border-color: var(--accent); background: var(--accent-soft); }
+.connector-account-context { margin: 0; color: var(--muted); font-size: 11px; line-height: 1.45; }
+
+.personal-proxy-select { min-width: 0; }
+.personal-proxy-select-trigger { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 8px; width: 100%; min-height: 42px; padding: 7px 10px; border: 1px solid var(--line-strong); border-radius: 8px; background: var(--surface-2); color: var(--text); text-align: left; }
+.personal-proxy-select-trigger:hover, .personal-proxy-select-trigger.is-open { border-color: color-mix(in srgb, var(--accent) 58%, var(--line-strong)); background: var(--surface-3); }
+.personal-proxy-select-copy { display: grid; gap: 2px; min-width: 0; }
+.personal-proxy-select-copy strong, .personal-proxy-select-option strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; }
+.personal-proxy-select-copy small, .personal-proxy-select-option small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-size: 10px; }
+.personal-proxy-select-chevron { color: var(--muted); transition: transform 140ms ease; }
+.personal-proxy-select-trigger.is-open .personal-proxy-select-chevron { transform: rotate(180deg); }
+.personal-proxy-select-menu { position: fixed; z-index: 10020; display: flex; flex-direction: column; min-height: 0; overflow: hidden; border: 1px solid var(--line-strong); border-radius: 10px; background: var(--surface-2); box-shadow: 0 14px 36px var(--shadow); }
+.personal-proxy-select-options { min-height: 0; overflow: auto; padding: 4px; }
+.personal-proxy-select-option { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 8px; width: 100%; padding: 8px; border: 0; border-radius: 7px; background: transparent; color: var(--text); text-align: left; }
+.personal-proxy-select-option > span { display: grid; gap: 2px; min-width: 0; }
+.personal-proxy-select-option:hover, .personal-proxy-select-option.is-selected { background: var(--accent-soft); color: var(--accent-text); }
+.personal-proxy-select-add { display: inline-flex; align-items: center; justify-content: center; gap: 6px; min-height: 34px; margin: 4px; padding: 7px; border: 1px solid var(--line-strong); border-radius: 7px; background: var(--surface-3); color: var(--accent-text); font: inherit; font-size: 11px; font-weight: 600; }
+.personal-proxy-select-add:hover { border-color: var(--accent); background: var(--accent-soft); }
 .create-profile-modal .modal-actions {
   padding-top: 14px;
   border-top: 1px solid var(--line);


### PR DESCRIPTION
## What changed
- make the Multilogin desktop-app step clickable and make the web token guide work with both Application and Storage DevTools labels
- show a local token-email hint and clearly explain that Multilogin shared folders/profiles belong to the connected Multilogin workspace, not to NextBrowser workspaces
- offer token replacement, browser/cloud-phone creation, clear Default-folder remediation, and an in-context custom-proxy explanation
- replace native personal-proxy selectors with the app-styled picker and inline Add proxy action
- place Stop profile beside Delete and keep the connection editor escapable
- disable the legacy standalone `clawbrowser` MCP config so Terminal Chat only uses the managed `nextbrowser` config
- replace agent `(no output)` with a useful Antigravity-aware failure message and surface free-capable CLIs in the agent catalog

## Verification
- `npx vitest run src/components/MultiloginConnector.test.tsx src/components/PersonalProxySelect.test.tsx src/lib/multiloginProfileCreate.test.ts src/lib/multiloginProfiles.test.ts src/lib/agentRunResult.test.ts src/agents.test.ts`
- `node --test electron/multilogin-credential.test.cjs electron/multilogin-profiles.test.cjs electron/agent-workspace.test.cjs`
- `npm run build`
- exercised the Multilogin desktop/web token guides in the dev Electron UI