### PR TITLE
Show immediate browser toolset update progress

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1247,9 +1247,25 @@ async function installedBrowserRuntimeVersion(runtime) {
 }
 async function installBrowserRuntimeUpdates(requestedRuntimes = []) {
   if (browserRuntimeUpdateInstallPromise) return browserRuntimeUpdateInstallPromise;
+  const requested = [...new Set((Array.isArray(requestedRuntimes) ? requestedRuntimes : []).filter((runtime) => (
+    runtime === "clawbrowser" || runtime === "camoufox" || runtime === "dasbrowser"
+  )))];
+  // `installSelectedRuntimeUpdates` begins with a fresh network check. Publish
+  // a status before that check so an IPC subscriber never leaves the user with
+  // a closed confirmation dialog and no visible acknowledgement.
+  setBrowserRuntimeUpdateInstallStatus("installing", {
+    runtimes: requested,
+    completed: [],
+    errors: [],
+    currentRuntime: requested[0],
+    currentName: "browser toolsets",
+    total: requested.length,
+    progress: 0,
+    message: "Checking the selected browser toolset updates…",
+  });
   browserRuntimeUpdateInstallPromise = (async () => {
     return installSelectedRuntimeUpdates({
-      requestedRuntimes,
+      requestedRuntimes: requested,
       checkForUpdates: checkForBrowserRuntimeUpdates,
       installRuntime: async (update) => {
         if (update.runtime === "clawbrowser") await updateClawbrowserRuntime(update.latestVersion);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { trafficAllowanceBytes, trafficAllowanceFraction } from "./lib/trafficGa
 import { getPreviewMode, getPreviewNodeMavenState, getPreviewTab } from "./preview";
 import { humanBytes, type AppTab, type Conversation } from "./types";
 import { resolveTheme, type Theme } from "./theme";
+import { pendingBrowserRuntimeUpdate } from "./lib/browserRuntimeUpdate";
 import { flushAnalyticsEngagement, initAnalytics, trackEvent, trackScreenView } from "./lib/analytics";
 import {
   appTabLabel,
@@ -832,6 +833,9 @@ export function App() {
     setRuntimeUpdatePromptDismissed(browserRuntimeUpdateSignature(browserRuntimeUpdates.runtimes));
     setRuntimeUpdatePrompt(undefined);
     setRuntimeUpdateProgressHidden(false);
+    // Do not wait for an Electron event before showing feedback. The host first
+    // refreshes release availability, which can take several seconds.
+    setRuntimeUpdateInstall(pendingBrowserRuntimeUpdate(runtimes, browserRuntimeUpdates.runtimes));
     void invoke<BrowserRuntimeUpdateInstallStatus>("browser_runtime_install_updates", { runtimes })
       .then(setRuntimeUpdateInstall)
       .catch((error) => setRuntimeUpdateInstall({

--- a/src/lib/browserRuntimeUpdate.test.ts
+++ b/src/lib/browserRuntimeUpdate.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { pendingBrowserRuntimeUpdate } from "./browserRuntimeUpdate";
+
+describe("pendingBrowserRuntimeUpdate", () => {
+  it("shows immediate visible progress for the confirmed toolset", () => {
+    expect(pendingBrowserRuntimeUpdate(["camoufox"], [
+      { runtime: "camoufox", name: "Camoufox", latestVersion: "0.5.7" },
+    ])).toMatchObject({
+      status: "installing",
+      runtimes: ["camoufox"],
+      currentRuntime: "camoufox",
+      currentName: "Camoufox",
+      currentVersion: "0.5.7",
+      progress: 0,
+    });
+  });
+});

--- a/src/lib/browserRuntimeUpdate.ts
+++ b/src/lib/browserRuntimeUpdate.ts
@@ -1,0 +1,28 @@
+export type BrowserRuntimeUpdateCandidate<T extends string = string> = {
+  runtime: T;
+  name: string;
+  latestVersion?: string;
+};
+
+// The renderer must show progress before the Electron process has finished its
+// fresh update check. Relying only on an asynchronous IPC event leaves a silent
+// gap after the user confirms an update (and the event can be missed during
+// startup).
+export function pendingBrowserRuntimeUpdate<T extends string>(
+  runtimes: readonly T[],
+  candidates: readonly BrowserRuntimeUpdateCandidate<T>[],
+) {
+  const first = candidates.find((candidate) => candidate.runtime === runtimes[0]);
+  return {
+    status: "installing" as const,
+    runtimes: [...runtimes],
+    completed: [] as T[],
+    errors: [],
+    currentRuntime: first?.runtime ?? runtimes[0],
+    currentName: first?.name ?? "browser toolsets",
+    currentVersion: first?.latestVersion,
+    total: runtimes.length,
+    progress: 0,
+    message: "Checking the selected browser toolset updates…",
+  };
+}


### PR DESCRIPTION
## Fix
The toolset update confirmation used to close before the renderer received an asynchronous Electron progress event. On a slow release check this looked like the button had done nothing.

The renderer and host now publish an immediate `installing` state before the fresh availability check begins. The progress card shows which toolset is being checked, then transitions to download, success, partial failure, or actionable recovery.

## Verification
- `npx vitest run src/lib/browserRuntimeUpdate.test.ts`
- `node --test electron/browser-runtime-updates.test.cjs`
- `npm run build`