### PR TITLE
Fix Codex MCP startup and browser toolset update confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Nextbrowser is the desktop control surface. Profiles define browser identities, 
 - [Browser control reference](docs/cli-reference.md) — browser operations and diagnostics used with Nextbrowser.
 - [Configuration and development](docs/configuration.md) — application settings, local state, analytics notes, and development scripts.
 - [Troubleshooting](docs/troubleshooting.md) — account-to-page diagnostics and common recovery paths.
+- [Codex MCP recovery](docs/troubleshooting.md#codex-reports-a-clawbrowser-mcp-startup-or-handshake-error) — recover from legacy ClawBrowser MCP configuration errors.
 - [Language index](docs/i18n/README.md) — all 20 README editions.
 
 ## Roadmap

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,6 +18,17 @@ Start at the account layer and move inward toward the page. Stop at the first fa
 
 Confirm that the agent is installed and runs outside Nextbrowser. If discovery still fails, use the path setting supported by the installed release, restart the app, and verify the agent's own authentication.
 
+## Codex reports a ClawBrowser MCP startup or handshake error
+
+Nextbrowser starts Codex with its managed `nextbrowser` MCP server. It does not require a separately configured `clawbrowser` MCP server in Codex.
+
+1. Update Nextbrowser and restart the affected Terminal chat.
+2. If Codex prints `invalid transport in mcp_servers.clawbrowser`, open `~/.codex/config.toml` and remove the obsolete `[mcp_servers.clawbrowser]` block, or replace it with a complete configuration supported by your installed Codex version.
+3. Run `codex --version` in a system terminal to confirm the Codex CLI is available, then reconnect Codex from Nextbrowser Settings if needed.
+4. If the terminal still exits, include the first terminal error and the Nextbrowser version in a support report. Do not include `auth.json`, tokens, cookies, or the complete Codex configuration.
+
+The underlying browser server is named `nextbrowser` in a Nextbrowser-managed Codex session. Old warnings naming `clawbrowser` identify a separate legacy MCP entry rather than the managed server.
+
 ## The API key is rejected
 
 Use the product setup flow to store the key again and verify account identity. Do not paste the key into an issue, screenshot, prompt, or chat transcript.

--- a/electron/agent-workspace.test.cjs
+++ b/electron/agent-workspace.test.cjs
@@ -49,7 +49,8 @@ test("terminal Codex keeps workspace isolation while allowing Clawbrowser networ
   assert.match(main, /mcp_servers\.nextbrowser\.env_vars=.*MULTILOGIN_TOKEN/);
   assert.match(main, /mcp_servers\.nextbrowser\.env_vars=.*NEXTBROWSER_AUTOMATION_TRACE_FILE/);
   assert.match(main, /mcp_servers\.nextbrowser\.env_vars=.*NEXTBROWSER_CONTROL_URL/);
-  assert.match(main, /mcp_servers\.clawbrowser\.enabled=false/);
+  assert.doesNotMatch(main, /\n\[mcp_servers\.clawbrowser\]/);
+  assert.doesNotMatch(main, /"-c", "mcp_servers\.clawbrowser\.enabled=false"/);
   assert.match(main, /mcp_servers\.nextbrowser\.env_vars=.*NEXTBROWSER_CONTROL_TOKEN/);
   assert.match(main, /nextctlHasAutomationTrace\(nextctlBin\)/);
   assert.match(main, /codexClawbrowserMCPArgs\(nextctlBin, supportedTraceFile\)/);

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -157,9 +157,6 @@ default_tools_approval_mode = "approve"
 
 [plugins."clawbrowser@nbc-local"]
 enabled = false
-
-[mcp_servers.clawbrowser]
-enabled = false
 `;
 
 function codexClawbrowserMCPArgs(nextctlBin, automationTraceFile = "") {
@@ -180,7 +177,6 @@ function codexClawbrowserMCPArgs(nextctlBin, automationTraceFile = "") {
     "-c", 'plugins."clawbrowser@clawctl-local".enabled=false',
     "-c", 'plugins."clawbrowser@clawctl-local".mcp_servers.clawbrowser.enabled=false',
     "-c", 'plugins."clawbrowser@nbc-local".enabled=false',
-    "-c", "mcp_servers.clawbrowser.enabled=false",
     "-c", `mcp_servers.nextbrowser.command=${JSON.stringify(nextctlBin)}`,
     "-c", `mcp_servers.nextbrowser.args=${JSON.stringify(["mcp", ...(automationTraceFile ? ["--automation-trace-file", automationTraceFile] : [])])}`,
     "-c", `mcp_servers.nextbrowser.env=${mcpEnv}`,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import { trafficAllowanceBytes, trafficAllowanceFraction } from "./lib/trafficGa
 import { getPreviewMode, getPreviewNodeMavenState, getPreviewTab } from "./preview";
 import { humanBytes, type AppTab, type Conversation } from "./types";
 import { resolveTheme, type Theme } from "./theme";
-import { pendingBrowserRuntimeUpdate } from "./lib/browserRuntimeUpdate";
+import { confirmedBrowserRuntimeUpdates, pendingBrowserRuntimeUpdate } from "./lib/browserRuntimeUpdate";
 import { flushAnalyticsEngagement, initAnalytics, trackEvent, trackScreenView } from "./lib/analytics";
 import {
   appTabLabel,
@@ -827,8 +827,11 @@ export function App() {
     if (runtimeUpdatePrompt) setRuntimeUpdatePromptDismissed(browserRuntimeUpdateSignature(runtimeUpdatePrompt));
     setRuntimeUpdatePrompt(undefined);
   };
-  const installBrowserRuntimeUpdates = (requestedRuntimes?: BrowserRuntimeUpdateEntry["runtime"][]) => {
-    const runtimes = requestedRuntimes ?? runtimeUpdatePrompt?.map((runtime) => runtime.runtime) ?? [];
+  const installBrowserRuntimeUpdates = (requestedRuntimes?: unknown) => {
+    const runtimes = confirmedBrowserRuntimeUpdates(
+      requestedRuntimes,
+      runtimeUpdatePrompt?.map((runtime) => runtime.runtime) ?? [],
+    );
     if (!runtimes.length) return;
     setRuntimeUpdatePromptDismissed(browserRuntimeUpdateSignature(browserRuntimeUpdates.runtimes));
     setRuntimeUpdatePrompt(undefined);
@@ -1215,7 +1218,7 @@ export function App() {
           <BrowserRuntimeUpdatePrompt
             runtimes={runtimeUpdatePrompt}
             onLater={dismissBrowserRuntimeUpdatePrompt}
-            onConfirm={installBrowserRuntimeUpdates}
+            onConfirm={() => installBrowserRuntimeUpdates()}
           />
         )}
         {runtimeUpdateInstall.status !== "idle" && !runtimeUpdateProgressHidden && (
@@ -1320,7 +1323,7 @@ export function App() {
         <BrowserRuntimeUpdatePrompt
           runtimes={runtimeUpdatePrompt}
           onLater={dismissBrowserRuntimeUpdatePrompt}
-          onConfirm={installBrowserRuntimeUpdates}
+          onConfirm={() => installBrowserRuntimeUpdates()}
         />
       )}
       <DashboardKeyModal />

--- a/src/components/AgentTerminal.tsx
+++ b/src/components/AgentTerminal.tsx
@@ -9,6 +9,7 @@ import type { ChatAttachment } from "../types";
 import { terminalAttachmentContext } from "../lib/chatAttachments";
 import { terminalBrowserScopeContext, terminalInputWithDeferredContext, terminalLineBufferAfter } from "../lib/contextHandoff";
 import { terminalActivityPreview, terminalAgentReady, terminalInputShouldQueueBeforeReady } from "../lib/terminalReadiness";
+import { codexMcpRecovery } from "../lib/codexMcpRecovery";
 import { terminalBrowserSession } from "../lib/terminalBrowserSession";
 import { activeAutomationRecording, AUTOMATION_RECORDING_EVENT } from "../lib/automationRecording";
 import { openTerminalWebLink } from "../lib/terminalWebLinks";
@@ -184,6 +185,7 @@ export function AgentTerminal({ agentId, agentName, conversationId, workspaceId,
     let lastObservedBrowserSession = "";
     let lastEscapeAt = 0;
     let startupOutput = "";
+    let lastMcpRecovery = "";
     let readinessTimer: ReturnType<typeof setTimeout> | undefined;
     let previewTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -334,6 +336,11 @@ export function AgentTerminal({ agentId, agentName, conversationId, workspaceId,
         if (id !== terminalIdRef.current) return;
         terminal.write(data);
         startupOutput = (startupOutput + data).slice(-64_000);
+        const recovery = codexMcpRecovery(agentId, startupOutput);
+        if (recovery && recovery !== lastMcpRecovery) {
+          lastMcpRecovery = recovery;
+          terminal.write(`\r\n\x1b[33m${recovery}\x1b[0m\r\n`);
+        }
         // MCP browser starts happen inside the terminal process, outside the
         // Electron command bridge that normally emits profile lifecycle events.
         // Observe the successful session payload and reconcile the sidebar with

--- a/src/lib/browserRuntimeUpdate.test.ts
+++ b/src/lib/browserRuntimeUpdate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { pendingBrowserRuntimeUpdate } from "./browserRuntimeUpdate";
+import { confirmedBrowserRuntimeUpdates, pendingBrowserRuntimeUpdate } from "./browserRuntimeUpdate";
 
 describe("pendingBrowserRuntimeUpdate", () => {
   it("shows immediate visible progress for the confirmed toolset", () => {
@@ -13,5 +13,10 @@ describe("pendingBrowserRuntimeUpdate", () => {
       currentVersion: "0.5.7",
       progress: 0,
     });
+  });
+
+  it("uses the confirmed dialog runtimes when React supplies a click event", () => {
+    expect(confirmedBrowserRuntimeUpdates({ type: "click" }, ["dasbrowser"])).toEqual(["dasbrowser"]);
+    expect(confirmedBrowserRuntimeUpdates(["camoufox"], ["dasbrowser"])).toEqual(["camoufox"]);
   });
 });

--- a/src/lib/browserRuntimeUpdate.ts
+++ b/src/lib/browserRuntimeUpdate.ts
@@ -26,3 +26,14 @@ export function pendingBrowserRuntimeUpdate<T extends string>(
     message: "Checking the selected browser toolset updates…",
   };
 }
+
+/**
+ * A dialog button supplies a MouseEvent to its onClick handler. Only explicit
+ * runtime arrays are valid here; any other value means “use the runtimes the
+ * user just confirmed in the dialog”. This keeps the update action from
+ * silently returning before the IPC call is made.
+ */
+export function confirmedBrowserRuntimeUpdates<T extends string>(requested: unknown, fallback: T[]): T[] {
+  if (!Array.isArray(requested)) return fallback;
+  return requested.filter((runtime): runtime is T => typeof runtime === "string");
+}

--- a/src/lib/codexMcpRecovery.test.ts
+++ b/src/lib/codexMcpRecovery.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { codexMcpRecovery } from "./codexMcpRecovery";
+
+describe("codexMcpRecovery", () => {
+  it("explains the malformed legacy MCP config", () => {
+    expect(codexMcpRecovery("codex", "Error loading config.toml: invalid transport\nin mcp_servers.clawbrowser"))
+      .toContain("remove or repair");
+  });
+
+  it("does not attach Codex recovery guidance to another terminal", () => {
+    expect(codexMcpRecovery("claude", "MCP startup incomplete (failed: clawbrowser)")).toBeUndefined();
+  });
+});

--- a/src/lib/codexMcpRecovery.ts
+++ b/src/lib/codexMcpRecovery.ts
@@ -1,0 +1,10 @@
+export function codexMcpRecovery(agentId: string, output: string): string | undefined {
+  if (agentId !== "codex") return undefined;
+  if (/invalid transport\s*(?:\r?\n|\s)+in\s+mcp_servers\.clawbrowser/i.test(output)) {
+    return "Codex rejected a legacy ClawBrowser MCP entry before startup. Update NextBrowser; if it still occurs, remove or repair [mcp_servers.clawbrowser] in ~/.codex/config.toml, then restart Terminal.";
+  }
+  if (/MCP client for [`']?clawbrowser[`']? failed to start|MCP startup incomplete \(failed: clawbrowser\)/i.test(output)) {
+    return "The legacy standalone ClawBrowser MCP did not start. Restart Terminal; NextBrowser uses its managed nextbrowser MCP. If it repeats, see the Codex MCP troubleshooting steps in the NextBrowser README.";
+  }
+  return undefined;
+}


### PR DESCRIPTION
## What changed
- removes the malformed standalone `[mcp_servers.clawbrowser]` entry and CLI override that recent Codex rejects as `invalid transport` before MCP initialization
- retains plugin-level legacy MCP disabling while configuring the managed `nextbrowser` server
- adds contextual terminal recovery guidance and documented remediation for stale local Codex configuration
- fixes Update now: React supplied a click event to the install handler, which caused it to return before starting IPC; confirmation now starts the selected runtime updates reliably

## Verified
- real dev-app test with DasBrowser deliberately downgraded from 144.32 to 144.31: modal appeared, Update now showed background progress, and it installed 144.32 successfully
- confirmed resulting runtime metadata is 144.32 and `codesign --verify --deep --strict` passes
- real dev-app Codex terminal reaches its interactive prompt without `invalid transport` or the ClawBrowser MCP startup warning
- `npx vitest run src/lib/browserRuntimeUpdate.test.ts src/lib/codexMcpRecovery.test.ts`
- `node --test electron/agent-workspace.test.cjs electron/browser-runtime-updates.test.cjs`
- `npm run build`