### PR TITLE
fix: install missing browser toolsets

### DIFF
--- a/electron/browser-runtime-updates.cjs
+++ b/electron/browser-runtime-updates.cjs
@@ -33,7 +33,10 @@ function assertRuntimeReleaseVersion(value) {
 
 function selectAvailableRuntimeUpdates(status, requestedRuntimes) {
   const requested = new Set(Array.isArray(requestedRuntimes) ? requestedRuntimes.map(String) : []);
-  return (status?.runtimes || []).filter((runtime) => runtime.status === "available" && requested.has(runtime.runtime));
+  return (status?.runtimes || []).filter((runtime) => (
+    (runtime.status === "available" || runtime.status === "not-installed")
+    && requested.has(runtime.runtime)
+  ));
 }
 
 function conciseFailureMessage(error) {
@@ -86,7 +89,7 @@ async function installSelectedRuntimeUpdates({ requestedRuntimes, checkForUpdate
       completed: [],
       errors: [],
       progress: 100,
-      message: "The selected browser toolsets are already up to date.",
+      message: "The selected browser toolsets are already installed or up to date.",
     };
     onStatus(result);
     return result;

--- a/electron/browser-runtime-updates.test.cjs
+++ b/electron/browser-runtime-updates.test.cjs
@@ -49,7 +49,7 @@ test("builds official platform release URLs without using the GitHub API", () =>
   assert.throws(() => clawbrowserReleaseAsset("darwin", "x64", "1.0.4"), /not available/);
 });
 
-test("installs only explicitly confirmed updates that are still available", () => {
+test("installs only explicitly confirmed updates or missing toolsets", () => {
   const status = {
     runtimes: [
       { runtime: "clawbrowser", status: "available" },
@@ -57,7 +57,7 @@ test("installs only explicitly confirmed updates that are still available", () =
       { runtime: "dasbrowser", status: "up-to-date" },
     ],
   };
-  assert.deepEqual(selectAvailableRuntimeUpdates(status, ["clawbrowser", "camoufox", "invented"]), [status.runtimes[0]]);
+  assert.deepEqual(selectAvailableRuntimeUpdates(status, ["clawbrowser", "camoufox", "invented"]), [status.runtimes[0], status.runtimes[1]]);
   assert.deepEqual(selectAvailableRuntimeUpdates(status, []), []);
 });
 

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -5,7 +5,7 @@ const fs = require("node:fs/promises");
 const fsSync = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
-const { randomUUID } = require("node:crypto");
+const { createHash, randomUUID } = require("node:crypto");
 const http = require("node:http");
 const { Readable } = require("node:stream");
 const { pipeline } = require("node:stream/promises");
@@ -1228,7 +1228,7 @@ async function updateClawbrowserRuntime(latestVersion) {
 async function updateCamoufoxRuntime(latestVersion) {
   const python = camoufoxVenvPython();
   const version = assertRuntimeReleaseVersion(latestVersion);
-  if (!launchable(python)) return installCamoufoxRuntime(version);
+  if (!launchable(python) || !(await camoufoxPythonSupported(python))) return installCamoufoxRuntime(version);
   const install = await run(python, [
     "-m", "pip", "install", "--disable-pip-version-check", "--upgrade", `camoufox[geoip]==${version}`,
   ], {}, { timeoutMs: 30 * 60 * 1000 });
@@ -1242,15 +1242,20 @@ async function installCamoufoxRuntime(latestVersion) {
   const python = camoufoxVenvPython();
   const venv = path.dirname(path.dirname(python));
   camoufoxInstallPromise = (async () => {
-    const baseCandidates = process.platform === "win32" ? ["py", "python"] : ["python3", "python"];
+    const baseCandidates = process.platform === "win32" ? ["py", "python"] : ["python3.13", "python3.12", "python3.11", "python3"];
     let created = null;
     for (const candidate of baseCandidates) {
-      const available = await run(candidate, ["--version"], {}, { timeoutMs: 10_000 }).catch(() => null);
-      if (!available || available.code !== 0) continue;
+      if (!(await camoufoxPythonSupported(candidate))) continue;
       created = await run(candidate, ["-m", "venv", venv], {}, { timeoutMs: 120_000 });
       break;
     }
-    if (!created) throw new Error("Python 3 is required to install Camoufox. Install Python 3, then retry.");
+    if (!created) {
+      // A previous attempt may have created a venv with an unsupported system
+      // Python. Replace only this managed, incomplete runtime before asking uv
+      // for its compatible Python 3.13.
+      await fs.rm(venv, { recursive: true, force: true });
+      created = await createCamoufoxManagedPython(venv);
+    }
     if (created.code !== 0) throw new Error((created.stderr || created.stdout || "Could not create the Camoufox Python environment.").trim());
     const packageInstall = await run(python, [
       "-m", "pip", "install", "--disable-pip-version-check", `camoufox[geoip]==${version}`,
@@ -1262,6 +1267,47 @@ async function installCamoufoxRuntime(latestVersion) {
     camoufoxInstallPromise = null;
   });
   return camoufoxInstallPromise;
+}
+async function camoufoxPythonSupported(python) {
+  const result = await run(python, ["-c", "import sys; raise SystemExit(0 if (3, 11) <= sys.version_info[:2] < (3, 14) else 1)"], {}, { timeoutMs: 10_000 }).catch(() => null);
+  return !!result && result.code === 0;
+}
+function camoufoxUVRelease() {
+  const releases = {
+    "darwin/arm64": { asset: "uv-aarch64-apple-darwin.tar.gz", digest: "281ea18a5778099f7edeee0a7b20671d14918782de153604c939486f2b8a2791" },
+    "darwin/x64": { asset: "uv-x86_64-apple-darwin.tar.gz", digest: "567d98b0c541a68df8aaa2c3214242c4070068b2edaea1be376a4c0fa348bdf1" },
+    "linux/arm64": { asset: "uv-aarch64-unknown-linux-gnu.tar.gz", digest: "69616218470b2ad053617efb9e7027b1518ea38918d933c2791e113d99cec507" },
+    "linux/x64": { asset: "uv-x86_64-unknown-linux-gnu.tar.gz", digest: "954add045f29f93191523175e4aea066996840e86c1b6339dee25f48b15b5ddb" },
+    "win32/x64": { asset: "uv-x86_64-pc-windows-msvc.zip", digest: "3f68ab95d2856e6b238e0e3f4255a723ccdc2cf1d4b8e53f5a4f5a47b645dc72" },
+  };
+  const release = releases[`${process.platform}/${process.arch}`];
+  if (!release) throw new Error(`Camoufox automatic installation is not available for ${process.platform}/${process.arch}.`);
+  return release;
+}
+async function createCamoufoxManagedPython(venv) {
+  const release = camoufoxUVRelease();
+  const runtimeDir = path.dirname(venv);
+  const executable = process.platform === "win32" ? "uv.exe" : "uv";
+  const uv = path.join(runtimeDir, "uv", executable);
+  if (!launchable(uv)) {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "nextbrowser-camoufox-uv-"));
+    try {
+      const archive = path.join(tempDir, release.asset);
+      const extracted = path.join(tempDir, "extract");
+      await downloadFile(`https://github.com/astral-sh/uv/releases/download/0.8.14/${release.asset}`, archive);
+      const digest = createHash("sha256").update(await fs.readFile(archive)).digest("hex");
+      if (digest !== release.digest) throw new Error("Camoufox Python installer checksum verification failed.");
+      await extractArchive(archive, release.asset.endsWith(".zip") ? "zip" : "tar", extracted);
+      const source = findBinaryUnderRoots(executable, [extracted]);
+      if (!source) throw new Error("Camoufox Python installer did not contain uv.");
+      await fs.mkdir(path.dirname(uv), { recursive: true });
+      await fs.copyFile(source, uv);
+      if (process.platform !== "win32") await fs.chmod(uv, 0o700);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  }
+  return run(uv, ["venv", "--seed", "--python", "3.13", "--python-preference", "managed", venv], {}, { timeoutMs: 15 * 60 * 1000 });
 }
 async function installedBrowserRuntimeVersion(runtime) {
   if (runtime === "clawbrowser") return installedClawbrowserVersion(nextbrowserRuntimeRoot());

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -128,6 +128,7 @@ let browserRuntimeUpdateInstallStatus = { status: "idle", runtimes: [] };
 let browserRuntimeUpdateInstallPromise = null;
 let nextctlInstallPromise = null;
 let browserInstallPromise = null;
+let camoufoxInstallPromise = null;
 let dasbrowserInstallPromise = null;
 const browserRuntimeInstallAbortControllers = new Map();
 let agentControlServer = null;
@@ -1226,14 +1227,41 @@ async function updateClawbrowserRuntime(latestVersion) {
 }
 async function updateCamoufoxRuntime(latestVersion) {
   const python = camoufoxVenvPython();
-  if (!launchable(python)) throw new Error("Camoufox is not installed on this device.");
   const version = assertRuntimeReleaseVersion(latestVersion);
+  if (!launchable(python)) return installCamoufoxRuntime(version);
   const install = await run(python, [
     "-m", "pip", "install", "--disable-pip-version-check", "--upgrade", `camoufox[geoip]==${version}`,
   ], {}, { timeoutMs: 30 * 60 * 1000 });
   if (install.code !== 0) throw new Error((install.stderr || install.stdout || "Camoufox package update failed.").trim());
   const browser = await run(python, ["-m", "camoufox", "fetch"], {}, { timeoutMs: 30 * 60 * 1000 });
   if (browser.code !== 0) throw new Error((browser.stderr || browser.stdout || "Camoufox browser download failed.").trim());
+}
+async function installCamoufoxRuntime(latestVersion) {
+  if (camoufoxInstallPromise) return camoufoxInstallPromise;
+  const version = assertRuntimeReleaseVersion(latestVersion);
+  const python = camoufoxVenvPython();
+  const venv = path.dirname(path.dirname(python));
+  camoufoxInstallPromise = (async () => {
+    const baseCandidates = process.platform === "win32" ? ["py", "python"] : ["python3", "python"];
+    let created = null;
+    for (const candidate of baseCandidates) {
+      const available = await run(candidate, ["--version"], {}, { timeoutMs: 10_000 }).catch(() => null);
+      if (!available || available.code !== 0) continue;
+      created = await run(candidate, ["-m", "venv", venv], {}, { timeoutMs: 120_000 });
+      break;
+    }
+    if (!created) throw new Error("Python 3 is required to install Camoufox. Install Python 3, then retry.");
+    if (created.code !== 0) throw new Error((created.stderr || created.stdout || "Could not create the Camoufox Python environment.").trim());
+    const packageInstall = await run(python, [
+      "-m", "pip", "install", "--disable-pip-version-check", `camoufox[geoip]==${version}`,
+    ], {}, { timeoutMs: 30 * 60 * 1000 });
+    if (packageInstall.code !== 0) throw new Error((packageInstall.stderr || packageInstall.stdout || "Camoufox package installation failed.").trim());
+    const browser = await run(python, ["-m", "camoufox", "fetch"], {}, { timeoutMs: 30 * 60 * 1000 });
+    if (browser.code !== 0) throw new Error((browser.stderr || browser.stdout || "Camoufox browser download failed.").trim());
+  })().finally(() => {
+    camoufoxInstallPromise = null;
+  });
+  return camoufoxInstallPromise;
 }
 async function installedBrowserRuntimeVersion(runtime) {
   if (runtime === "clawbrowser") return installedClawbrowserVersion(nextbrowserRuntimeRoot());

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -128,21 +128,22 @@ function BrowserRuntimeUpdatePrompt({ runtimes, onLater, onConfirm }: {
   onLater: () => void;
   onConfirm: () => void;
 }) {
+  const isFirstInstall = runtimes.every((runtime) => runtime.status === "not-installed");
   return (
     <div className="modal-overlay">
       <div className="modal-card runtime-update-prompt" role="dialog" aria-modal="true" aria-labelledby="runtime-update-title">
         <div className="modal-title-row">
           <Icon name="arrow.down.circle" size={19} className="warn" />
           <div>
-            <strong id="runtime-update-title">Browser toolset update available</strong>
-            <div className="muted small">Choose when NextBrowser may install it.</div>
+            <strong id="runtime-update-title">{isFirstInstall ? "Install browser toolset" : "Browser toolset update available"}</strong>
+            <div className="muted small">{isFirstInstall ? "NextBrowser will download and prepare it for a new profile." : "Choose when NextBrowser may install it."}</div>
           </div>
         </div>
         <div className="runtime-update-prompt-list">
           {runtimes.map((runtime) => (
             <div className="runtime-update-prompt-row" key={runtime.runtime}>
               <strong>{runtime.name}</strong>
-              <span className="muted small">{runtime.currentVersion ?? "Installed"} → {runtime.latestVersion}</span>
+              <span className="muted small">{runtime.currentVersion ?? (runtime.status === "not-installed" ? "Not installed" : "Installed")} → {runtime.latestVersion}</span>
             </div>
           ))}
         </div>
@@ -150,7 +151,7 @@ function BrowserRuntimeUpdatePrompt({ runtimes, onLater, onConfirm }: {
         <div className="row settings-actions">
           <button className="secondary" onClick={onLater}>Later</button>
           <span className="spacer" />
-          <button className="primary" onClick={onConfirm}>Update {runtimes.length > 1 ? `${runtimes.length} toolsets` : "now"}</button>
+          <button className="primary" onClick={onConfirm}>{isFirstInstall ? `Install ${runtimes.length > 1 ? `${runtimes.length} toolsets` : "now"}` : `Update ${runtimes.length > 1 ? `${runtimes.length} toolsets` : "now"}`}</button>
         </div>
       </div>
     </div>
@@ -221,7 +222,7 @@ function browserRuntimeUpdateAvailable(status?: BrowserRuntimeUpdateStatus | nul
 
 function browserRuntimeUpdateSignature(runtimes: BrowserRuntimeUpdateEntry[]): string {
   return runtimes
-    .filter((runtime) => runtime.status === "available")
+    .filter((runtime) => runtime.status === "available" || runtime.status === "not-installed")
     .map((runtime) => `${runtime.runtime}:${runtime.latestVersion ?? "unknown"}`)
     .sort()
     .join("|");
@@ -549,9 +550,9 @@ function SettingsModal({
                     {browserRuntimeUpdateLabel(runtime)}
                   </span>
                 </div>
-                {runtime.status === "available" && (
+                {(runtime.status === "available" || runtime.status === "not-installed") && (
                   <button className="mini primary-mini" onClick={() => onRequestBrowserRuntimeUpdate(runtime)}>
-                    Update
+                    {runtime.status === "not-installed" ? "Install" : "Update"}
                   </button>
                 )}
               </div>
@@ -959,9 +960,12 @@ export function App() {
 
   useEffect(() => {
     const available = browserRuntimeUpdates.runtimes.filter((runtime) => runtime.status === "available");
-    const signature = browserRuntimeUpdateSignature(available);
+    const actionable = browserRuntimeUpdates.runtimes.filter((runtime) => (
+      runtime.status === "available" || runtime.status === "not-installed"
+    ));
+    const signature = browserRuntimeUpdateSignature(actionable);
     if (runtimeUpdatePrompt) {
-      const promptStillCurrent = runtimeUpdatePrompt.every((prompted) => available.some((runtime) => (
+      const promptStillCurrent = runtimeUpdatePrompt.every((prompted) => actionable.some((runtime) => (
         runtime.runtime === prompted.runtime && runtime.latestVersion === prompted.latestVersion
       )));
       if (!promptStillCurrent) {

--- a/src/lib/browserRuntimeUpdate.ts
+++ b/src/lib/browserRuntimeUpdate.ts
@@ -23,7 +23,7 @@ export function pendingBrowserRuntimeUpdate<T extends string>(
     currentVersion: first?.latestVersion,
     total: runtimes.length,
     progress: 0,
-    message: "Checking the selected browser toolset updates…",
+    message: "Checking the selected browser toolsets…",
   };
 }
 


### PR DESCRIPTION
## Summary
- show an explicit Install action for browser toolsets that are not yet installed
- install Camoufox with a managed compatible Python when the system Python cannot support the current release
- replace the deprecated Discord invite in the app and documentation
- start Terminal Codex with only the app-owned NextBrowser MCP server, so legacy clawbrowser entries cannot fail its initialize handshake
- preserve the existing confirmation and background progress UX

## Verification
- Installed Camoufox 0.5.6 through the live dev UI on macOS
- Confirmed the UI transitions from Not installed to Up to date
- Started a fresh visible Terminal Codex session after adding a legacy global clawbrowser MCP config; it reaches the interactive prompt with no MCP startup warning
- node --test electron/agent-workspace.test.cjs
- npm run build