### PR TITLE
fix: isolate Terminal Codex from legacy MCP servers

### DIFF
--- a/electron/agent-workspace.test.cjs
+++ b/electron/agent-workspace.test.cjs
@@ -43,6 +43,7 @@ test("terminal Codex keeps workspace isolation while allowing Clawbrowser networ
   assert.match(main, /ensureCodexTerminalProfile\(\)/);
   assert.match(main, /const nextctlBin = await resolveOrInstallNextctl\(\)/);
   assert.match(main, /plugins\."clawbrowser@clawctl-local"\.enabled=false/);
+  assert.match(main, /"-c", "mcp_servers=\{\}"/);
   assert.match(main, /mcp_servers\.nextbrowser\.command=/);
   assert.match(main, /mcp_servers\.nextbrowser\.args=/);
   assert.match(main, /mcp_servers\.nextbrowser\.env=/);

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -175,6 +175,12 @@ function codexClawbrowserMCPArgs(nextctlBin, automationTraceFile = "") {
   const mcpEnv = `{${mcpEnvKeys.map((key) => `${key}=${JSON.stringify(runtimeEnv[key])}`).join(",")}}`;
   return [
     "--profile", CODEX_TERMINAL_PROFILE,
+    // Codex profiles layer on top of the user's base config. A legacy manual
+    // `mcp_servers.clawbrowser` entry would otherwise still start alongside
+    // the app-owned server and can close during initialize. Restrict this
+    // NextBrowser-launched process to the MCP server configured below without
+    // reading, editing, or deleting the user's persistent Codex config.
+    "-c", "mcp_servers={}",
     "-c", 'plugins."clawbrowser@clawctl-local".enabled=false',
     "-c", 'plugins."clawbrowser@clawctl-local".mcp_servers.clawbrowser.enabled=false',
     "-c", 'plugins."clawbrowser@nbc-local".enabled=false',


### PR DESCRIPTION
## Summary
Terminal Codex now clears inherited MCP server entries for its own process, then configures only the app-owned NextBrowser MCP server. This prevents an old manual clawbrowser MCP entry from failing during the Codex initialize handshake.

The user config is never edited or deleted.

## Verification
- Reproduced that a legacy global clawbrowser MCP entry is inherited without the process-level reset
- Verified the reset removes that legacy entry before NextBrowser configures its server
- Started the visible NextBrowser Terminal Codex journey to an interactive prompt with no MCP startup warning
- node --test electron/agent-workspace.test.cjs
- npm run build