### PR TITLE
feat: collect desktop feedback through Signal Router

### DIFF
--- a/electron/app-build-info.cjs
+++ b/electron/app-build-info.cjs
@@ -1,0 +1,26 @@
+function sourceRevision(appPath, execFileSync) {
+  try {
+    const revision = execFileSync("git", ["rev-parse", "--short=12", "HEAD"], {
+      cwd: appPath,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return /^[0-9a-f]{7,40}$/i.test(revision) ? revision : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function feedbackBuildContext({ app, execFileSync }) {
+  if (app.isPackaged) {
+    return { app_version: app.getVersion(), build: "release" };
+  }
+
+  const revision = sourceRevision(app.getAppPath(), execFileSync);
+  return {
+    app_version: revision ? `development-${revision}` : "development",
+    build: "development",
+  };
+}
+
+module.exports = { feedbackBuildContext, sourceRevision };

--- a/electron/app-build-info.node.cjs
+++ b/electron/app-build-info.node.cjs
@@ -1,0 +1,28 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const { feedbackBuildContext, sourceRevision } = require("./app-build-info.cjs");
+
+test("reports the installed release version without an internal packaged flag", () => {
+  const result = feedbackBuildContext({
+    app: { isPackaged: true, getVersion: () => "0.2.44", getAppPath: () => "/app" },
+    execFileSync: () => { throw new Error("must not read git for releases"); },
+  });
+  assert.deepEqual(result, { app_version: "0.2.44", build: "release" });
+});
+
+test("identifies a development build by its source revision instead of package.json version", () => {
+  const result = feedbackBuildContext({
+    app: { isPackaged: false, getVersion: () => "0.1.13", getAppPath: () => "/repo" },
+    execFileSync: () => "166f50f12345\n",
+  });
+  assert.deepEqual(result, { app_version: "development-166f50f12345", build: "development" });
+});
+
+test("keeps an unresolvable development checkout understandable", () => {
+  assert.equal(sourceRevision("/repo", () => { throw new Error("no git"); }), undefined);
+  const result = feedbackBuildContext({
+    app: { isPackaged: false, getVersion: () => "0.1.13", getAppPath: () => "/repo" },
+    execFileSync: () => { throw new Error("no git"); },
+  });
+  assert.deepEqual(result, { app_version: "development", build: "development" });
+});

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -40,6 +40,7 @@ const {
   putProject,
   putWorkspace,
   resolvePersonalProxy,
+  submitFeedback,
 } = require("./project-sync.cjs");
 const { defaultSSHConfigPath, discoverSSHHosts, isAllowedExplicitConfigPath } = require("./ssh-config.cjs");
 const { createLocalArtifactStore } = require("./local-artifacts.cjs");
@@ -1577,6 +1578,27 @@ async function invokeCommand(command, args = {}, sender) {
     case "workspaces_list": return await listWorkspaces({ env: childEnv() });
     case "workspace_put": return await putWorkspace(String(args.id || ""), args.workspace, { env: childEnv() });
     case "workspace_delete": return await deleteWorkspace(String(args.id || ""), { env: childEnv() });
+    case "feedback_submit": {
+      const rating = Number(args.rating);
+      if (!Number.isInteger(rating) || rating < 1 || rating > 5) throw new Error("Choose a rating from 1 to 5.");
+      const comment = typeof args.comment === "string" ? args.comment.trim() : "";
+      if (comment.length > 2_000) throw new Error("Feedback is limited to 2,000 characters.");
+      try {
+        return await submitFeedback({
+          id: `desktop-feedback:${randomUUID()}`,
+          rating,
+          comment,
+          context: {
+            app_version: app.getVersion(),
+            platform: process.platform,
+            packaged: app.isPackaged,
+          },
+        }, { env: childEnv() });
+      } catch (error) {
+        if (error?.status === 401) throw new Error("Sign in to your NextBrowser account before sending feedback.");
+        throw error;
+      }
+    }
     case "account_logout": {
       await shell.openExternal(authLogoutURL());
       await clearRuntimeCredential({ runtimeRoot: nextbrowserRuntimeRoot() });

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,6 +1,7 @@
 const { app, BrowserWindow, ipcMain, shell, nativeImage, nativeTheme, dialog, Menu, clipboard, safeStorage } = require("electron");
 const { autoUpdater } = require("electron-updater");
 const { execFileSync, spawn } = require("node:child_process");
+const { feedbackBuildContext } = require("./app-build-info.cjs");
 const fs = require("node:fs/promises");
 const fsSync = require("node:fs");
 const os = require("node:os");
@@ -1589,9 +1590,8 @@ async function invokeCommand(command, args = {}, sender) {
           rating,
           comment,
           context: {
-            app_version: app.getVersion(),
+            ...feedbackBuildContext({ app, execFileSync }),
             platform: process.platform,
-            packaged: app.isPackaged,
           },
         }, { env: childEnv() });
       } catch (error) {

--- a/electron/project-sync.cjs
+++ b/electron/project-sync.cjs
@@ -136,6 +136,16 @@ function resolvePersonalProxy(id, deps) {
   return projectRequest(`/v1/personal-proxies/${encodeURIComponent(id)}/credentials`, {}, deps);
 }
 
+// The desktop renderer never receives the account key. The Electron host reads
+// it from the isolated NextBrowser config and sends it only to the authenticated
+// Signal Router endpoint on the same Core domain used for cloud entities.
+function submitFeedback(feedback, deps) {
+  return projectRequest("/signal-router/v1/feedback", {
+    method: "POST",
+    body: JSON.stringify(feedback),
+  }, deps);
+}
+
 module.exports = {
   createPersonalProxy,
   deletePersonalProxy,
@@ -149,4 +159,5 @@ module.exports = {
   putProject,
   putWorkspace,
   resolvePersonalProxy,
+  submitFeedback,
 };

--- a/electron/project-sync.test.cjs
+++ b/electron/project-sync.test.cjs
@@ -12,6 +12,7 @@ const {
   listWorkspaces,
   putProject,
   resolvePersonalProxy,
+  submitFeedback,
 } = require("./project-sync.cjs");
 
 test("syncs projects with the private backend key", async (t) => {
@@ -38,6 +39,25 @@ test("syncs projects with the private backend key", async (t) => {
 
 test("uses the same default backend as cloud skills", () => {
   assert.equal(entityBackendURL({}), "https://core.nextbrowser.com");
+});
+
+test("submits desktop feedback with the saved account key without exposing it to the renderer", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "feedback-sync-"));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  const configDir = path.join(root, "config");
+  await fs.mkdir(configDir, { recursive: true });
+  await fs.writeFile(path.join(configDir, "config.json"), JSON.stringify({ api_key: "nb_live_secret" }));
+  const calls = [];
+  await submitFeedback({ rating: 5, comment: "Useful" }, {
+    env: { NEXTBROWSER_CONFIG_DIR: configDir },
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      return { ok: true, text: async () => JSON.stringify({ ok: true, id: "feedback" }) };
+    },
+  });
+  assert.equal(calls[0].url, "https://core.nextbrowser.com/signal-router/v1/feedback");
+  assert.equal(calls[0].options.headers.authorization, "Bearer nb_live_secret");
+  assert.deepEqual(JSON.parse(calls[0].options.body), { rating: 5, comment: "Useful" });
 });
 
 test("moves entity sync with an app API override", () => {

--- a/electron/project-sync.test.cjs
+++ b/electron/project-sync.test.cjs
@@ -3,6 +3,7 @@ const fs = require("node:fs/promises");
 const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
+require("./app-build-info.node.cjs");
 const {
   createPersonalProxy,
   deletePersonalProxy,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1229,7 +1229,12 @@ export function App() {
     };
   }, [checking, sidebarCollapsed, setSidebarWidth]);
 
-    if (checking && preview !== "login" && preview !== "main" && preview !== "onboarding") {
+  const feedbackModal = feedbackOpen ? <FeedbackModal onClose={() => setFeedbackOpen(false)} onSubmitted={(rating) => {
+    markFeedbackSubmitted(localStorage);
+    trackEvent("feedback_submitted", { rating });
+  }} /> : null;
+
+  if (checking && preview !== "login" && preview !== "main" && preview !== "onboarding") {
     return (
       <>
         <div className="floating-controls">
@@ -1270,6 +1275,7 @@ export function App() {
           <BrowserRuntimeUpdateProgress status={runtimeUpdateInstall} onClose={() => setRuntimeUpdateProgressHidden(true)} onRetry={installBrowserRuntimeUpdates} onOpenManualGuide={openBrowserRuntimeManualGuide} />
         )}
         {unexpectedError && <GlobalErrorNotice error={unexpectedError} onClose={() => setUnexpectedError(undefined)} />}
+        {feedbackModal}
       </>
     );
   }
@@ -1386,10 +1392,7 @@ export function App() {
         <BrowserRuntimeUpdateProgress status={runtimeUpdateInstall} onClose={() => setRuntimeUpdateProgressHidden(true)} onRetry={installBrowserRuntimeUpdates} onOpenManualGuide={openBrowserRuntimeManualGuide} />
       )}
       {unexpectedError && <GlobalErrorNotice error={unexpectedError} onClose={() => setUnexpectedError(undefined)} />}
-      {feedbackOpen && <FeedbackModal onClose={() => setFeedbackOpen(false)} onSubmitted={(rating) => {
-        markFeedbackSubmitted(localStorage);
-        trackEvent("feedback_submitted", { rating });
-      }} />}
+      {feedbackModal}
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -797,14 +797,15 @@ export function App() {
 
   useEffect(() => {
     // Ask only after the app is usable. This keeps the fifth-open request out
-    // of onboarding, recovery, and first-run setup flows.
-    if (feedbackPromptEvaluated.current || checking || showOnboarding || workspaceSetupRequired || !agentReady) return;
+    // of onboarding, recovery, and first-run setup flows, but does not make
+    // feedback depend on which agent the user has selected.
+    if (feedbackPromptEvaluated.current || checking || showOnboarding || workspaceSetupRequired) return;
     feedbackPromptEvaluated.current = true;
     if (shouldPromptForFeedback(localStorage)) {
       setFeedbackOpen(true);
       trackEvent("feedback_prompt_shown", { trigger: "fifth_open" });
     }
-  }, [agentReady, checking, showOnboarding, workspaceSetupRequired]);
+  }, [checking, showOnboarding, workspaceSetupRequired]);
 
   const checkAppUpdate = () => {
     void invoke<AppUpdateStatus>("app_check_for_update").then(setAppUpdate).catch(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -345,7 +345,12 @@ function DiscordButton() {
 
 function FeedbackButton({ onClick }: { onClick: () => void }) {
   return (
-    <button className="social-button feedback-button" onClick={onClick} title="Send feedback" aria-label="Send feedback">
+    <button
+      className="social-button feedback-button"
+      onClick={onClick}
+      title="Send feedback (⌘⇧F on macOS, Ctrl+Shift+F on Windows/Linux)"
+      aria-label="Send feedback. Shortcut: Command or Control, Shift, F"
+    >
       <Icon name="bubble.left.and.bubble.right.fill" size={17} />
       <span>Feedback</span>
     </button>
@@ -806,6 +811,17 @@ export function App() {
       trackEvent("feedback_prompt_shown", { trigger: "fifth_open" });
     }
   }, [checking, showOnboarding, workspaceSetupRequired]);
+
+  useEffect(() => {
+    const openFeedbackWithShortcut = (event: KeyboardEvent) => {
+      if ((!event.metaKey && !event.ctrlKey) || !event.shiftKey || event.altKey || event.key.toLowerCase() !== "f") return;
+      event.preventDefault();
+      setFeedbackOpen(true);
+      trackEvent("feedback_prompt_shown", { trigger: "keyboard_shortcut" });
+    };
+    window.addEventListener("keydown", openFeedbackWithShortcut);
+    return () => window.removeEventListener("keydown", openFeedbackWithShortcut);
+  }, []);
 
   const checkAppUpdate = () => {
     void invoke<AppUpdateStatus>("app_check_for_update").then(setAppUpdate).catch(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import { WorkspaceSetupGate } from "./components/WorkspaceSetupGate";
 import { AgentInstallLink } from "./components/AgentInstallLink";
 import { ConnectorsView } from "./components/ConnectorsView";
 import { AutomationStudio } from "./components/AutomationStudio";
+import { FeedbackModal } from "./components/FeedbackModal";
 
 const TABS: { id: AppTab; label: string; icon?: string }[] = [
   { id: "chat", label: "Project", icon: "folder" },
@@ -337,6 +338,15 @@ function DiscordButton() {
       aria-label="Join NextBrowser on Discord"
     >
       <DiscordMark size={18} />
+    </button>
+  );
+}
+
+function FeedbackButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button className="social-button feedback-button" onClick={onClick} title="Send feedback" aria-label="Send feedback">
+      <Icon name="bubble.left.and.bubble.right.fill" size={17} />
+      <span>Feedback</span>
     </button>
   );
 }
@@ -717,6 +727,7 @@ export function App() {
   const [unexpectedError, setUnexpectedError] = useState<{ reference: string; detail: string }>();
   const [browserRuntimeInstall, setBrowserRuntimeInstall] = useState<BrowserRuntimeInstallStatus>();
   const [agentGateDismissed, setAgentGateDismissed] = useState(false);
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
   const preview = getPreviewMode();
   const checking = useStore((s) => s.checking);
   const tab = useStore((s) => s.tab);
@@ -1272,6 +1283,7 @@ export function App() {
           </div>
           <span className="tabbar-spacer" />
           <div className="tabbar-controls">
+            <FeedbackButton onClick={() => setFeedbackOpen(true)} />
             <SocialButtons />
             <SettingsButton onClick={() => openSettings()} hasUpdate={updateAvailable(appUpdate) || browserRuntimeUpdateAvailable(browserRuntimeUpdates)} />
             <ThemeToggle theme={theme} onToggle={() => setTheme(theme === "dark" ? "light" : "dark")} />
@@ -1344,6 +1356,7 @@ export function App() {
         <BrowserRuntimeUpdateProgress status={runtimeUpdateInstall} onClose={() => setRuntimeUpdateProgressHidden(true)} onRetry={installBrowserRuntimeUpdates} onOpenManualGuide={openBrowserRuntimeManualGuide} />
       )}
       {unexpectedError && <GlobalErrorNotice error={unexpectedError} onClose={() => setUnexpectedError(undefined)} />}
+      {feedbackOpen && <FeedbackModal onClose={() => setFeedbackOpen(false)} />}
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ import { AgentInstallLink } from "./components/AgentInstallLink";
 import { ConnectorsView } from "./components/ConnectorsView";
 import { AutomationStudio } from "./components/AutomationStudio";
 import { FeedbackModal } from "./components/FeedbackModal";
+import { markFeedbackSubmitted, shouldPromptForFeedback } from "./lib/feedbackPrompt";
 
 const TABS: { id: AppTab; label: string; icon?: string }[] = [
   { id: "chat", label: "Project", icon: "folder" },
@@ -728,6 +729,7 @@ export function App() {
   const [browserRuntimeInstall, setBrowserRuntimeInstall] = useState<BrowserRuntimeInstallStatus>();
   const [agentGateDismissed, setAgentGateDismissed] = useState(false);
   const [feedbackOpen, setFeedbackOpen] = useState(false);
+  const feedbackPromptEvaluated = useRef(false);
   const preview = getPreviewMode();
   const checking = useStore((s) => s.checking);
   const tab = useStore((s) => s.tab);
@@ -792,6 +794,17 @@ export function App() {
     const timer = window.setTimeout(() => setUnexpectedError(undefined), 8_000);
     return () => window.clearTimeout(timer);
   }, [unexpectedError]);
+
+  useEffect(() => {
+    // Ask only after the app is usable. This keeps the fifth-open request out
+    // of onboarding, recovery, and first-run setup flows.
+    if (feedbackPromptEvaluated.current || checking || showOnboarding || workspaceSetupRequired || !agentReady) return;
+    feedbackPromptEvaluated.current = true;
+    if (shouldPromptForFeedback(localStorage)) {
+      setFeedbackOpen(true);
+      trackEvent("feedback_prompt_shown", { trigger: "fifth_open" });
+    }
+  }, [agentReady, checking, showOnboarding, workspaceSetupRequired]);
 
   const checkAppUpdate = () => {
     void invoke<AppUpdateStatus>("app_check_for_update").then(setAppUpdate).catch(() => {
@@ -1356,7 +1369,10 @@ export function App() {
         <BrowserRuntimeUpdateProgress status={runtimeUpdateInstall} onClose={() => setRuntimeUpdateProgressHidden(true)} onRetry={installBrowserRuntimeUpdates} onOpenManualGuide={openBrowserRuntimeManualGuide} />
       )}
       {unexpectedError && <GlobalErrorNotice error={unexpectedError} onClose={() => setUnexpectedError(undefined)} />}
-      {feedbackOpen && <FeedbackModal onClose={() => setFeedbackOpen(false)} />}
+      {feedbackOpen && <FeedbackModal onClose={() => setFeedbackOpen(false)} onSubmitted={(rating) => {
+        markFeedbackSubmitted(localStorage);
+        trackEvent("feedback_submitted", { rating });
+      }} />}
     </div>
   );
 }

--- a/src/components/FeedbackModal.tsx
+++ b/src/components/FeedbackModal.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import { invoke } from "../electronBridge";
+import { Icon, Spinner } from "./Icon";
+
+const RATING_LABELS = ["Very poor", "Poor", "Okay", "Good", "Excellent"];
+
+export function FeedbackModal({ onClose }: { onClose: () => void }) {
+  const [rating, setRating] = useState(0);
+  const [comment, setComment] = useState("");
+  const [status, setStatus] = useState<"idle" | "sending" | "sent">("idle");
+  const [error, setError] = useState("");
+
+  const submit = async () => {
+    if (!rating || status === "sending") return;
+    setStatus("sending");
+    setError("");
+    try {
+      await invoke("feedback_submit", { rating, comment });
+      setStatus("sent");
+    } catch (cause) {
+      setStatus("idle");
+      setError(cause instanceof Error ? cause.message : "We couldn't send your feedback. Please try again.");
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onMouseDown={status === "sending" ? undefined : onClose}>
+      <section className="modal-card feedback-modal" role="dialog" aria-modal="true" aria-labelledby="feedback-title" onMouseDown={(event) => event.stopPropagation()}>
+        <div className="modal-title-row">
+          <Icon name="bubble.left.and.bubble.right.fill" size={18} />
+          <div>
+            <strong id="feedback-title">How is NextBrowser?</strong>
+            <div className="muted small">Your rating and note go directly to the product team.</div>
+          </div>
+          <span className="spacer" />
+          {status !== "sending" && <button className="plain-icon-btn" onClick={onClose} aria-label="Close feedback"><Icon name="xmark" size={16} /></button>}
+        </div>
+        {status === "sent" ? (
+          <div className="feedback-success" role="status">
+            <Icon name="checkmark.circle.fill" size={30} className="ok" />
+            <strong>Thank you — your feedback was sent.</strong>
+            <p className="muted small">It helps us decide what to improve next.</p>
+            <button className="primary" onClick={onClose}>Done</button>
+          </div>
+        ) : (
+          <>
+            <div className="feedback-rating" role="radiogroup" aria-label="Rate NextBrowser from one to five">
+              {RATING_LABELS.map((label, index) => {
+                const value = index + 1;
+                return <button key={label} type="button" role="radio" aria-checked={rating === value} className={"feedback-star" + (value <= rating ? " is-selected" : "")} onClick={() => setRating(value)} title={`${value}: ${label}`}><Icon name="star.fill" size={26} fill="currentColor" /></button>;
+              })}
+            </div>
+            <div className="feedback-rating-label">{rating ? `${rating}/5 · ${RATING_LABELS[rating - 1]}` : "Choose a rating"}</div>
+            <label className="feedback-comment">
+              <span>Tell us more <em>(optional)</em></span>
+              <textarea value={comment} maxLength={2_000} rows={4} placeholder="What worked well, or what should we improve?" onChange={(event) => setComment(event.target.value)} />
+              <small>{comment.length} / 2000</small>
+            </label>
+            {error && <p className="error small feedback-error" role="alert">{error}</p>}
+            <div className="modal-actions">
+              <button className="secondary" onClick={onClose} disabled={status === "sending"}>Cancel</button>
+              <span className="spacer" />
+              <button className="primary" onClick={() => void submit()} disabled={!rating || status === "sending"}>{status === "sending" ? <><Spinner size={13} /> Sending…</> : "Send feedback"}</button>
+            </div>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/FeedbackModal.tsx
+++ b/src/components/FeedbackModal.tsx
@@ -6,9 +6,11 @@ const RATING_LABELS = ["Very poor", "Poor", "Okay", "Good", "Excellent"];
 
 export function FeedbackModal({ onClose, onSubmitted }: { onClose: () => void; onSubmitted?: (rating: number) => void }) {
   const [rating, setRating] = useState(0);
+  const [hoverRating, setHoverRating] = useState<number | null>(null);
   const [comment, setComment] = useState("");
   const [status, setStatus] = useState<"idle" | "sending" | "sent">("idle");
   const [error, setError] = useState("");
+  const displayedRating = hoverRating ?? rating;
 
   const submit = async () => {
     if (!rating || status === "sending") return;
@@ -45,13 +47,38 @@ export function FeedbackModal({ onClose, onSubmitted }: { onClose: () => void; o
           </div>
         ) : (
           <>
-            <div className="feedback-rating" role="radiogroup" aria-label="Rate NextBrowser from one to five">
+            <div
+              className="feedback-rating"
+              role="radiogroup"
+              aria-label="Rate NextBrowser from one to five"
+              onMouseLeave={() => setHoverRating(null)}
+            >
               {RATING_LABELS.map((label, index) => {
                 const value = index + 1;
-                return <button key={label} type="button" role="radio" aria-checked={rating === value} className={"feedback-star" + (value <= rating ? " is-selected" : "")} onClick={() => setRating(value)} title={`${value}: ${label}`}><Icon name="star.fill" size={26} fill="currentColor" /></button>;
+                return (
+                  <button
+                    key={label}
+                    type="button"
+                    role="radio"
+                    aria-checked={rating === value}
+                    className={
+                      "feedback-star" +
+                      (value <= displayedRating ? " is-preview" : "") +
+                      (hoverRating === null && value <= rating ? " is-selected" : "") +
+                      (value === hoverRating ? " is-hovered" : "")
+                    }
+                    onMouseEnter={() => setHoverRating(value)}
+                    onFocus={() => setHoverRating(value)}
+                    onBlur={() => setHoverRating(null)}
+                    onClick={() => setRating(value)}
+                    title={`${value}: ${label}`}
+                  >
+                    <Icon name="star.fill" size={26} fill="currentColor" />
+                  </button>
+                );
               })}
             </div>
-            <div className="feedback-rating-label">{rating ? `${rating}/5 · ${RATING_LABELS[rating - 1]}` : "Choose a rating"}</div>
+            <div className="feedback-rating-label">{displayedRating ? `${displayedRating}/5 · ${RATING_LABELS[displayedRating - 1]}` : "Choose a rating"}</div>
             <label className="feedback-comment">
               <span>Tell us more <em>(optional)</em></span>
               <textarea value={comment} maxLength={2_000} rows={4} placeholder="What worked well, or what should we improve?" onChange={(event) => setComment(event.target.value)} />

--- a/src/components/FeedbackModal.tsx
+++ b/src/components/FeedbackModal.tsx
@@ -4,7 +4,7 @@ import { Icon, Spinner } from "./Icon";
 
 const RATING_LABELS = ["Very poor", "Poor", "Okay", "Good", "Excellent"];
 
-export function FeedbackModal({ onClose }: { onClose: () => void }) {
+export function FeedbackModal({ onClose, onSubmitted }: { onClose: () => void; onSubmitted?: (rating: number) => void }) {
   const [rating, setRating] = useState(0);
   const [comment, setComment] = useState("");
   const [status, setStatus] = useState<"idle" | "sending" | "sent">("idle");
@@ -17,6 +17,7 @@ export function FeedbackModal({ onClose }: { onClose: () => void }) {
     try {
       await invoke("feedback_submit", { rating, comment });
       setStatus("sent");
+      onSubmitted?.(rating);
     } catch (cause) {
       setStatus("idle");
       setError(cause instanceof Error ? cause.message : "We couldn't send your feedback. Please try again.");

--- a/src/components/FeedbackModal.tsx
+++ b/src/components/FeedbackModal.tsx
@@ -33,7 +33,7 @@ export function FeedbackModal({ onClose, onSubmitted }: { onClose: () => void; o
           <Icon name="bubble.left.and.bubble.right.fill" size={18} />
           <div>
             <strong id="feedback-title">How is NextBrowser?</strong>
-            <div className="muted small">Your rating and note go directly to the product team.</div>
+            <div className="muted small">Your signed-in email, rating, and note go directly to the product team.</div>
           </div>
           <span className="spacer" />
           {status !== "sending" && <button className="plain-icon-btn" onClick={onClose} aria-label="Close feedback"><Icon name="xmark" size={16} /></button>}

--- a/src/lib/feedbackPrompt.test.ts
+++ b/src/lib/feedbackPrompt.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { feedbackPromptConfig, markFeedbackSubmitted, shouldPromptForFeedback } from "./feedbackPrompt";
+
+function storage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => void values.set(key, value),
+    removeItem: (key) => void values.delete(key),
+    clear: () => values.clear(),
+    key: (index) => [...values.keys()][index] ?? null,
+    get length() { return values.size; },
+  };
+}
+
+describe("feedback prompt cadence", () => {
+  it("asks on every fifth usable opening until the user submits feedback", () => {
+    const local = storage();
+    expect(Array.from({ length: 10 }, () => shouldPromptForFeedback(local))).toEqual([
+      false, false, false, false, true,
+      false, false, false, false, true,
+    ]);
+  });
+
+  it("suppresses prompts for three months after a successful submission then starts a new five-open cycle", () => {
+    const local = storage();
+    const submittedAt = 1_000_000;
+    markFeedbackSubmitted(local, submittedAt);
+    expect(shouldPromptForFeedback(local, submittedAt + feedbackPromptConfig.cooldownMs - 1)).toBe(false);
+    expect(Array.from({ length: 5 }, (_, index) => shouldPromptForFeedback(local, submittedAt + feedbackPromptConfig.cooldownMs + index))).toEqual([
+      false, false, false, false, true,
+    ]);
+  });
+});

--- a/src/lib/feedbackPrompt.ts
+++ b/src/lib/feedbackPrompt.ts
@@ -1,0 +1,54 @@
+const STATE_KEY = "nextbrowser.feedbackPrompt.v1";
+const PROMPT_EVERY_OPENS = 5;
+// A feedback request is intentionally rare after a successful submission.
+const FEEDBACK_COOLDOWN_MS = 90 * 24 * 60 * 60 * 1_000;
+
+interface FeedbackPromptState {
+  opens: number;
+  submittedAt?: number;
+}
+
+function load(storage: Storage): FeedbackPromptState {
+  try {
+    const parsed: unknown = JSON.parse(storage.getItem(STATE_KEY) ?? "{}");
+    if (!parsed || typeof parsed !== "object") return { opens: 0 };
+    const value = parsed as Partial<FeedbackPromptState>;
+    return {
+      opens: Number.isInteger(value.opens) && value.opens! >= 0 ? value.opens! : 0,
+      ...(Number.isFinite(value.submittedAt) && value.submittedAt! > 0 ? { submittedAt: value.submittedAt } : {}),
+    };
+  } catch {
+    return { opens: 0 };
+  }
+}
+
+function save(storage: Storage, state: FeedbackPromptState): void {
+  try {
+    storage.setItem(STATE_KEY, JSON.stringify(state));
+  } catch {
+    // Feedback is optional. Private browsing or a full storage quota must not
+    // interfere with opening the application.
+  }
+}
+
+/** Records one usable app opening and returns true on every fifth opening. */
+export function shouldPromptForFeedback(storage: Storage, now = Date.now()): boolean {
+  let state = load(storage);
+  if (state.submittedAt && now - state.submittedAt < FEEDBACK_COOLDOWN_MS) return false;
+
+  // After three months, forget the previous response and start a fresh cycle.
+  if (state.submittedAt) state = { opens: 0 };
+  const opens = state.opens + 1;
+  save(storage, { opens });
+  return opens % PROMPT_EVERY_OPENS === 0;
+}
+
+/** Stops automatic prompts for three months after an actual successful send. */
+export function markFeedbackSubmitted(storage: Storage, now = Date.now()): void {
+  save(storage, { opens: 0, submittedAt: now });
+}
+
+export const feedbackPromptConfig = {
+  everyOpens: PROMPT_EVERY_OPENS,
+  cooldownMs: FEEDBACK_COOLDOWN_MS,
+};

--- a/src/styles.css
+++ b/src/styles.css
@@ -2298,9 +2298,10 @@ body.is-resizing-sidebar {
 .feedback-button { gap: 6px; padding-inline: 10px; }
 .feedback-modal { width: min(460px, calc(100vw - 32px)); }
 .feedback-rating { display: flex; justify-content: space-between; gap: 7px; margin: 22px 0 5px; }
-.feedback-star { appearance: none; border: 0; background: transparent; color: var(--border); padding: 7px; border-radius: 10px; cursor: pointer; transition: color .14s ease, transform .14s ease, background .14s ease; }
-.feedback-star:hover { color: #d8c8ff; background: color-mix(in srgb, var(--accent) 13%, transparent); transform: translateY(-2px); }
-.feedback-star.is-selected { color: #ffd36d; }
+.feedback-star { appearance: none; border: 0; background: transparent; color: var(--border); padding: 7px; border-radius: 10px; cursor: pointer; transition: color .14s ease, transform .14s ease, background .14s ease, box-shadow .14s ease, opacity .14s ease; }
+.feedback-star.is-preview { color: #ffd36d; opacity: .72; }
+.feedback-star.is-selected { color: #ffd36d; opacity: 1; }
+.feedback-star.is-hovered { color: #ffe4a0; opacity: 1; background: color-mix(in srgb, var(--accent) 16%, transparent); box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 48%, transparent), 0 5px 16px color-mix(in srgb, var(--accent) 18%, transparent); transform: translateY(-2px) scale(1.07); }
 .feedback-star:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .feedback-rating-label { color: var(--muted); font-size: 12px; text-align: center; min-height: 18px; }
 .feedback-comment { display: grid; gap: 7px; margin-top: 18px; color: var(--text); font-size: 12px; font-weight: 600; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -2294,6 +2294,22 @@ body.is-resizing-sidebar {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
+
+.feedback-button { gap: 6px; padding-inline: 10px; }
+.feedback-modal { width: min(460px, calc(100vw - 32px)); }
+.feedback-rating { display: flex; justify-content: space-between; gap: 7px; margin: 22px 0 5px; }
+.feedback-star { appearance: none; border: 0; background: transparent; color: var(--border); padding: 7px; border-radius: 10px; cursor: pointer; transition: color .14s ease, transform .14s ease, background .14s ease; }
+.feedback-star:hover { color: #d8c8ff; background: color-mix(in srgb, var(--accent) 13%, transparent); transform: translateY(-2px); }
+.feedback-star.is-selected { color: #ffd36d; }
+.feedback-star:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.feedback-rating-label { color: var(--muted); font-size: 12px; text-align: center; min-height: 18px; }
+.feedback-comment { display: grid; gap: 7px; margin-top: 18px; color: var(--text); font-size: 12px; font-weight: 600; }
+.feedback-comment em { color: var(--muted); font-style: normal; font-weight: 400; }
+.feedback-comment textarea { width: 100%; min-height: 96px; resize: vertical; }
+.feedback-comment small { color: var(--muted); font-weight: 400; justify-self: end; margin-top: -3px; }
+.feedback-error { margin: 10px 0 -3px; }
+.feedback-success { min-height: 210px; display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; gap: 10px; }
+.feedback-success p { margin: 0 0 8px; }
 .github-star-count {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## What
- adds a compact 1–5 rating and optional feedback note in the app header
- keeps the account credential in Electron main process; the renderer never reads it
- delivers authenticated feedback to Signal Router at core.nextbrowser.com
- handles success, sign-in, validation and retryable error states

## Verification
- `npm test`
- `npm run build`
- exercised the real Electron main-process request against production Signal Router; confirmed Slack delivery