### PR TITLE
fix: restore cross-platform CI validation

### DIFF
--- a/skills/bitwarden-autofill-login/manifest.json
+++ b/skills/bitwarden-autofill-login/manifest.json
@@ -5,6 +5,9 @@
   "author": "Yas1nY1lmaz",
   "domains": ["github.com", "accounts.google.com", "login.microsoftonline.com"],
   "operations": ["form"],
+  "target_mode": "current_tab",
+  "permissions": ["read_page", "use_page_controls", "login"],
+  "verification": "community",
   "category": {
     "id": "utilities",
     "title": "Utilities",

--- a/src/remoteControl.test.ts
+++ b/src/remoteControl.test.ts
@@ -116,10 +116,9 @@ describe("RemoteControlClient", () => {
   // clients must survive a signalling message they were never taught. This one
   // arrives before the answer, so ignoring it has to leave the rest working.
   it("ignores a signalling message it does not know and still takes the answer", async () => {
-    let deliver: ((event: { payload: { id: string; type: string; data?: string } }) => void) | null =
-      null;
+    const listener: { deliver?: (event: { payload: { id: string; type: string; data?: string } }) => void } = {};
     bridge.listen.mockImplementation(async (_event: string, handler: unknown) => {
-      deliver = handler as typeof deliver;
+      listener.deliver = handler as NonNullable<typeof listener.deliver>;
       return () => undefined;
     });
 
@@ -130,9 +129,9 @@ describe("RemoteControlClient", () => {
     );
 
     await client.start();
-    expect(deliver).not.toBeNull();
+    expect(listener.deliver).toBeTypeOf("function");
 
-    deliver?.({
+    listener.deliver?.({
       payload: {
         id: "signal-1",
         type: "message",
@@ -147,7 +146,7 @@ describe("RemoteControlClient", () => {
     expect(onError).not.toHaveBeenCalled();
 
     const peer = FakePeerConnection.instances[0];
-    deliver?.({
+    listener.deliver?.({
       payload: {
         id: "signal-1",
         type: "message",


### PR DESCRIPTION
Restores CI after the Bitwarden skill merge by declaring its target mode and permissions required by the repository skill contract. Also makes the RemoteControl signalling test type-safe under the TypeScript configuration used by both macOS and Windows CI.\n\nValidated locally: npm test, npm run build, and npm run pack on macOS.