### PR TITLE
Avoid unavailable Linux browser toolset updates

### DIFF
--- a/electron/browser-runtime-updates.cjs
+++ b/electron/browser-runtime-updates.cjs
@@ -306,6 +306,64 @@ async function latestClawbrowserVersion(fetchImpl) {
   return version;
 }
 
+function clawbrowserPlatformAsset(platform, arch, version) {
+  try {
+    return clawbrowserReleaseAsset(platform, arch, version).assetName;
+  } catch {
+    return "";
+  }
+}
+
+function missingClawbrowserAssetMessage(version, platform, arch) {
+  return `ClawBrowser ${version} does not include a download for ${platform}/${arch} yet.`;
+}
+
+async function latestClawbrowserRelease(fetchImpl, platform, arch) {
+  let release;
+  let version = "";
+  try {
+    release = await fetchJSON(fetchImpl, "https://api.github.com/repos/clawbrowser/clawbrowser/releases/latest");
+    version = normalizeVersion(release?.tag_name);
+    if (!version) throw new Error("Latest ClawBrowser release did not include a version");
+  } catch {
+    const response = await fetchImpl("https://github.com/clawbrowser/clawbrowser/releases/latest", {
+      headers: { Accept: "text/html", "User-Agent": "NextBrowser-runtime-update-checker" },
+      redirect: "follow",
+      signal: AbortSignal.timeout(8_000),
+    });
+    if (!response.ok) throw new Error(`Update source returned ${response.status}`);
+    const finalTag = String(response.url || "").match(/\/releases\/tag\/([^/?#]+)/i)?.[1];
+    const html = finalTag ? "" : await response.text();
+    const htmlTag = html.match(/\/clawbrowser\/clawbrowser\/releases\/tag\/([^"'/?#]+)/i)?.[1];
+    version = normalizeVersion(decodeURIComponent(finalTag || htmlTag || ""));
+    if (!version) throw new Error("Latest ClawBrowser release did not include a version");
+  }
+
+  const assetName = clawbrowserPlatformAsset(platform, arch, version);
+  if (!assetName) {
+    return { version, availability: "unavailable", message: `Automatic ClawBrowser updates are not available for ${platform}/${arch}.` };
+  }
+  if (Array.isArray(release?.assets)) {
+    return release.assets.some((asset) => asset?.name === assetName)
+      ? { version, availability: "available" }
+      : { version, availability: "unavailable", message: missingClawbrowserAssetMessage(version, platform, arch) };
+  }
+
+  // GitHub's release redirect does not expose assets. Confirm the exact archive
+  // before offering an update so a rate-limited API cannot create a false Update
+  // button for a platform omitted from this release.
+  const archiveRelease = clawbrowserReleaseAsset(platform, arch, version);
+  const response = await fetchImpl(archiveRelease.url, {
+    method: "HEAD",
+    headers: { Accept: "application/octet-stream", "User-Agent": "NextBrowser-runtime-update-checker" },
+    redirect: "follow",
+    signal: AbortSignal.timeout(8_000),
+  });
+  if (response.ok) return { version, availability: "available" };
+  if (response.status === 404) return { version, availability: "unavailable", message: missingClawbrowserAssetMessage(version, platform, arch) };
+  throw new Error(`Update source could not verify the ${assetName} download (${response.status}).`);
+}
+
 async function latestCamoufoxVersion(fetchImpl) {
   const release = await fetchJSON(fetchImpl, "https://pypi.org/pypi/camoufox/json");
   const version = normalizeVersion(release?.info?.version);
@@ -336,21 +394,28 @@ function runtimeResult(source, currentVersion, latestVersion, error = "", instal
   };
 }
 
-async function checkBrowserRuntimeUpdates({ fetchImpl = fetch, runtimeRoot, readDasbrowserVersion = async () => "", isRuntimeInstalled = {} }) {
+async function checkBrowserRuntimeUpdates({ fetchImpl = fetch, runtimeRoot, readDasbrowserVersion = async () => "", isRuntimeInstalled = {}, platform = process.platform, arch = process.arch }) {
   const installed = {
     clawbrowser: await installedClawbrowserVersion(runtimeRoot),
     camoufox: await installedCamoufoxVersion(runtimeRoot),
     dasbrowser: normalizeVersion(await readDasbrowserVersion()),
   };
   const latestReaders = {
-    clawbrowser: latestClawbrowserVersion,
-    camoufox: latestCamoufoxVersion,
-    dasbrowser: latestDasbrowserVersion,
+    clawbrowser: () => latestClawbrowserRelease(fetchImpl, platform, arch),
+    camoufox: () => latestCamoufoxVersion(fetchImpl),
+    dasbrowser: () => latestDasbrowserVersion(fetchImpl),
   };
   const runtimes = await Promise.all(RUNTIME_UPDATE_SOURCES.map(async (source) => {
     try {
-      const latest = await latestReaders[source.runtime](fetchImpl);
-      return runtimeResult(source, installed[source.runtime], latest, "", isRuntimeInstalled[source.runtime] ?? !!installed[source.runtime]);
+      const latest = await latestReaders[source.runtime]();
+      if (source.runtime === "clawbrowser" && latest.availability === "unavailable") {
+        return {
+          ...runtimeResult(source, installed[source.runtime], latest.version, "", isRuntimeInstalled[source.runtime] ?? !!installed[source.runtime]),
+          status: "unavailable",
+          error: latest.message,
+        };
+      }
+      return runtimeResult(source, installed[source.runtime], source.runtime === "clawbrowser" ? latest.version : latest, "", isRuntimeInstalled[source.runtime] ?? !!installed[source.runtime]);
     } catch (error) {
       return runtimeResult(source, installed[source.runtime], "", error?.message || String(error), isRuntimeInstalled[source.runtime] ?? !!installed[source.runtime]);
     }

--- a/electron/browser-runtime-updates.test.cjs
+++ b/electron/browser-runtime-updates.test.cjs
@@ -150,17 +150,38 @@ test("checks every runtime independently and preserves partial results", async (
   fs.mkdirSync(path.join(root, "data"), { recursive: true });
   fs.writeFileSync(path.join(root, "data", ".clawbrowser-browser-release.json"), JSON.stringify({ version: "1.0.3" }));
   const fetchImpl = async (url) => {
-    if (url.includes("api.github.com")) return { ok: true, json: async () => ({ tag_name: "1.0.4" }) };
+    if (url.includes("api.github.com")) return { ok: true, json: async () => ({ tag_name: "1.0.4", assets: [{ name: "clawbrowser-linux-x64.tar.gz" }] }) };
     if (url.includes("pypi.org")) return { ok: false, status: 503 };
     return { ok: true, text: async () => '<a href="https://cdn.dasbrowser.com/144.32/DasbrowserSetup.exe">Download</a>' };
   };
-  const result = await checkBrowserRuntimeUpdates({ fetchImpl, runtimeRoot: root, readDasbrowserVersion: async () => "144.31" });
+  const result = await checkBrowserRuntimeUpdates({ fetchImpl, runtimeRoot: root, platform: "linux", arch: "x64", readDasbrowserVersion: async () => "144.31" });
   assert.equal(result.status, "partial");
   assert.deepEqual(result.runtimes.map(({ runtime, status }) => [runtime, status]), [
     ["clawbrowser", "available"],
     ["camoufox", "error"],
     ["dasbrowser", "available"],
   ]);
+});
+
+test("does not offer a Linux update when the latest ClawBrowser release has only macOS and Windows assets", async (t) => {
+  const root = fixture(t);
+  fs.mkdirSync(path.join(root, "data"), { recursive: true });
+  fs.writeFileSync(path.join(root, "data", ".clawbrowser-browser-release.json"), JSON.stringify({ version: "1.0.3" }));
+  const fetchImpl = async (url) => {
+    if (url.includes("api.github.com")) return { ok: true, json: async () => ({ tag_name: "1.0.4", assets: [{ name: "clawbrowser-macos-arm64.tar.gz" }, { name: "clawbrowser-win-amd64.zip" }] }) };
+    if (url.includes("pypi.org")) return { ok: true, json: async () => ({ info: { version: "0.5.5" } }) };
+    return { ok: true, text: async () => '<a href="https://cdn.dasbrowser.com/144.32/DasbrowserSetup.exe">Download</a>' };
+  };
+  const result = await checkBrowserRuntimeUpdates({ fetchImpl, runtimeRoot: root, platform: "linux", arch: "x64", readDasbrowserVersion: async () => "144.32" });
+  assert.deepEqual(result.runtimes[0], {
+    runtime: "clawbrowser",
+    name: "ClawBrowser",
+    releasePage: "https://github.com/clawbrowser/clawbrowser/releases/latest",
+    status: "unavailable",
+    currentVersion: "1.0.3",
+    latestVersion: "1.0.4",
+    error: "ClawBrowser 1.0.4 does not include a download for linux/x64 yet.",
+  });
 });
 
 test("falls back to the official latest-release redirect when GitHub API is rate limited", async (t) => {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1111,6 +1111,8 @@ async function checkForBrowserRuntimeUpdates() {
   browserRuntimeUpdateCheckPromise = checkBrowserRuntimeUpdates({
     fetchImpl: fetch,
     runtimeRoot: nextbrowserRuntimeRoot(),
+    platform: process.platform,
+    arch: process.arch,
     readDasbrowserVersion: installedDasbrowserVersion,
     isRuntimeInstalled: {
       clawbrowser: !!resolveBrowserRuntime({ platform: process.platform, homeDir: home(), env: process.env, runtimeRoot: nextbrowserRuntimeRoot() }),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,7 +64,7 @@ interface BrowserRuntimeInstallStatus {
 interface BrowserRuntimeUpdateEntry {
   runtime: "clawbrowser" | "dasbrowser" | "camoufox";
   name: string;
-  status: "available" | "up-to-date" | "not-installed" | "unknown" | "error";
+  status: "available" | "up-to-date" | "not-installed" | "unavailable" | "unknown" | "error";
   currentVersion?: string;
   latestVersion?: string;
   releasePage: string;
@@ -234,6 +234,7 @@ function browserRuntimeUpdateLabel(runtime: BrowserRuntimeUpdateEntry): string {
   if (runtime.status === "available") return `${runtime.currentVersion ?? "Installed"} → ${runtime.latestVersion ?? "new version"}`;
   if (runtime.status === "up-to-date") return `${runtime.currentVersion ?? runtime.latestVersion ?? "Installed"} · Up to date`;
   if (runtime.status === "not-installed") return runtime.latestVersion ? `Not installed · Latest ${runtime.latestVersion}` : "Not installed";
+  if (runtime.status === "unavailable") return runtime.latestVersion ? `Latest ${runtime.latestVersion} · Not available for this system yet` : "Not available for this system yet";
   if (runtime.status === "error") return "Couldn't check";
   return runtime.currentVersion
     ? `${runtime.currentVersion} · Latest unknown`


### PR DESCRIPTION
Checks the exact ClawBrowser release assets before offering an update. Linux users see an unavailable status instead of a broken update modal when a release contains only macOS and Windows downloads.