### PR TITLE
Fix personal proxy picker overlay

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -7097,7 +7097,7 @@ code { background: var(--surface-4); padding: 1px 5px; border-radius: 4px; }
 .personal-proxy-select-copy small, .personal-proxy-select-option small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-size: 10px; }
 .personal-proxy-select-chevron { color: var(--muted); transition: transform 140ms ease; }
 .personal-proxy-select-trigger.is-open .personal-proxy-select-chevron { transform: rotate(180deg); }
-.personal-proxy-select-menu { position: fixed; z-index: 10020; display: flex; flex-direction: column; min-height: 0; overflow: hidden; border: 1px solid var(--line-strong); border-radius: 10px; background: var(--surface-2); box-shadow: 0 14px 36px var(--shadow); }
+.personal-proxy-select-menu { position: fixed; z-index: 10020; isolation: isolate; display: flex; flex-direction: column; min-height: 0; overflow: hidden; border: 1px solid var(--line-strong); border-radius: 10px; background: var(--bg-elevated); box-shadow: 0 14px 36px var(--shadow); }
 .personal-proxy-select-options { min-height: 0; overflow: auto; padding: 4px; }
 .personal-proxy-select-option { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 8px; width: 100%; padding: 8px; border: 0; border-radius: 7px; background: transparent; color: var(--text); text-align: left; }
 .personal-proxy-select-option > span { display: grid; gap: 2px; min-width: 0; }


### PR DESCRIPTION
Makes the personal proxy picker use an opaque elevated surface, so profile form controls never show through the open menu. Keeps the existing portal and stacking isolation.\n\nVerified with the picker component test and production build.